### PR TITLE
Handle login failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty</artifactId>
-			<version>3.6.2.Final</version>
+			<version>3.6.3.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/src/main/java/com/impossibl/postgres/protocol/v30/StartupCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/StartupCommandImpl.java
@@ -41,6 +41,7 @@ public class StartupCommandImpl extends CommandImpl implements StartupCommand {
 			@Override
 			public synchronized void error(Notice error) {
 				setError(error);
+				notify();
 			}
 
 			@Override

--- a/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -7,6 +7,7 @@ import static java.util.Arrays.asList;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.charset.Charset;
+import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -105,12 +106,11 @@ public class BasicContext implements Context {
 	public void refreshType(int typeId) {
 	}
 	
-	public void init() throws IOException {
+	public void init() throws IOException, SQLException {
 		
-		if(start()) {
+		start();
 			
-			loadTypes();
-		}
+		loadTypes();
 	}
 
 	private void loadTypes() throws IOException {
@@ -137,7 +137,7 @@ public class BasicContext implements Context {
 		logger.info("load time: " + timer.getLap() + "ms");
 	}
 	
-	private boolean start() throws IOException {
+	private void start() throws IOException, SQLException {
 		
 		Map<String, Object> params = new HashMap<String, Object>();
 
@@ -150,7 +150,10 @@ public class BasicContext implements Context {
 
 		protocol.execute(startup);
 		
-		return startup.getError() == null;
+		Notice error = startup.getError();
+		if (error != null) {
+			throw new SQLException("Could not open connection: " + error.code + ": " + error.message);
+		}
 	}
 	
 	public <T> List<T> execQuery(String queryTxt, Class<T> rowType, Object... params) throws IOException {


### PR DESCRIPTION
The code was missing notify() when server returned login failure. The returned error was also ignored resulting in a non-working connection returned to user application.
