### PR TITLE
Support unicode table and field names

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
@@ -4,7 +4,9 @@ import static com.impossibl.postgres.protocol.TransactionStatus.Active;
 import static com.impossibl.postgres.protocol.TransactionStatus.Failed;
 import static com.impossibl.postgres.protocol.TransactionStatus.Idle;
 import static com.impossibl.postgres.utils.ChannelBuffers.readCString;
+import static com.impossibl.postgres.utils.ChannelBuffers.readCStringUtf8;
 import static com.impossibl.postgres.utils.ChannelBuffers.writeCString;
+import static com.impossibl.postgres.utils.ChannelBuffers.writeCStringUtf8;
 import static java.util.Arrays.asList;
 import static java.util.logging.Level.FINEST;
 
@@ -206,7 +208,7 @@ public class ProtocolImpl implements Protocol {
 		ChannelBuffer msg = newMessage(PARSE_MSG_ID);
 
 		writeCString(msg, stmtName != null ? stmtName : "");
-		writeCString(msg, query);
+		writeCStringUtf8(msg, query);
 
 		msg.writeShort(paramTypes.size());
 		for (Type paramType : paramTypes) {
@@ -587,7 +589,7 @@ public class ProtocolImpl implements Protocol {
 		for (int c = 0; c < fieldCount; ++c) {
 
 			ResultField field = new ResultField();
-			field.name = readCString(buffer);
+			field.name = readCStringUtf8(buffer);
 			field.relationId = buffer.readInt();
 			field.relationAttributeNumber = buffer.readShort();
 			field.type = registry.loadType(buffer.readInt());

--- a/src/main/java/com/impossibl/postgres/utils/ChannelBuffers.java
+++ b/src/main/java/com/impossibl/postgres/utils/ChannelBuffers.java
@@ -1,6 +1,7 @@
 package com.impossibl.postgres.utils;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 
@@ -16,9 +17,23 @@ public class ChannelBuffers {
 		return res;
 	}
 
+	public static String readCStringUtf8(ChannelBuffer buffer) {
+		byte[] bytes = new byte[buffer.bytesBefore((byte) 0) + 1];
+		buffer.readBytes(bytes);
+
+		String res = new String(bytes, 0, bytes.length-1, UTF_8);
+
+		return res;
+	}
+
 	public static void writeCString(ChannelBuffer buffer, String val) {
 		
 		buffer.writeBytes(val.getBytes(US_ASCII));
+		buffer.writeByte(0);
+	}
+
+	public static void writeCStringUtf8(ChannelBuffer buffer, String val) {
+		buffer.writeBytes(val.getBytes(UTF_8));
 		buffer.writeByte(0);
 	}
 


### PR DESCRIPTION
Example DDL that works after the patch:

``` sql
create table a€ (val€ int);
```
