### PR TITLE
Change statementName and portalName from String to long

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnection.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnection.java
@@ -146,21 +146,21 @@ class PGConnection extends BasicContext implements Connection {
 	}
 
 	/**
-	 * Generates and returns the next unique statement name for this connection
+	 * Generates and returns the next unique statement id for this connection
 	 * 
-	 * @return New unique statement name
+	 * @return New unique statement id
 	 */
-	String getNextStatementName() {
-		return String.format("%016X", ++statementId);
+	long getNextStatementId() {
+		return ++statementId;
 	}
 
 	/**
-	 * Generates and returns the next unique portal name for this connection
+	 * Generates and returns the next unique portal id for this connection
 	 * 
-	 * @return New unique portal name
+	 * @return New unique portal id
 	 */
-	String getNextPortalName() {
-		return String.format("%016X", ++portalId);
+	long getNextPortalId() {
+		return ++portalId;
 	}
 
 	/**
@@ -637,15 +637,15 @@ class PGConnection extends BasicContext implements Connection {
 		
 		SQLTextEscapes.processEscapes(sqlText, this);
 		
-		String statementName = getNextStatementName();
+		long statementId = getNextStatementId();
 
-		PrepareCommand prepare = protocol.createPrepare(statementName, sqlText.toString(), Collections.<Type> emptyList());
+		PrepareCommand prepare = protocol.createPrepare(statementId, sqlText.toString(), Collections.<Type> emptyList());
 
 		warningChain = execute(prepare);
 
 		PGPreparedStatement statement =
 				new PGPreparedStatement(this, resultSetType, resultSetConcurrency, resultSetHoldability,
-						statementName, prepare.getDescribedParameterTypes(), prepare.getDescribedResultFields());
+						statementId, prepare.getDescribedParameterTypes(), prepare.getDescribedResultFields());
 		
 		activeStatements.add(new WeakReference<PGStatement>(statement));
 		

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -51,8 +51,8 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 	
 	
 	
-	PGPreparedStatement(PGConnection connection, int type, int concurrency, int holdability, String name, List<Type> parameterTypes, List<ResultField> resultFields) {
-		super(connection, type, concurrency, holdability, name, resultFields);
+	PGPreparedStatement(PGConnection connection, int type, int concurrency, int holdability, long id, List<Type> parameterTypes, List<ResultField> resultFields) {
+		super(connection, type, concurrency, holdability, id, resultFields);
 		this.parameterTypes = parameterTypes;
 		this.parameterValues = Arrays.asList(new Object[parameterTypes.size()]);
 	}
@@ -99,7 +99,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 	@Override
 	public boolean execute() throws SQLException {
 		
-		boolean res = super.executeStatement(name, parameterTypes, parameterValues);
+		boolean res = super.executeStatement(id, parameterTypes, parameterValues);
 		
 		if(wantsGeneratedKeys) {
 			generatedKeysResultSet = getResultSet();

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -413,7 +413,7 @@ class PGResultSet implements ResultSet {
 		
 		if(command != null) {
 			
-			statement.dispose(Portal, command.getPortalName());
+			statement.dispose(Portal, command.getPortalId());
 		}
 		
 		//Release resources

--- a/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
@@ -18,7 +18,7 @@ import com.impossibl.postgres.types.Type;
 class PGSimpleStatement extends PGStatement {
 
 	public PGSimpleStatement(PGConnection connection, int type, int concurrency, int holdability) {
-		super(connection, type, concurrency, holdability, null, Collections.<ResultField>emptyList());
+		super(connection, type, concurrency, holdability, 0, Collections.<ResultField>emptyList());
 	}
 
 	SQLWarning prepare(SQLText sqlText) throws SQLException {
@@ -27,7 +27,7 @@ class PGSimpleStatement extends PGStatement {
 			SQLTextEscapes.processEscapes(sqlText, connection);
 		}
 		
-		PrepareCommand prep = connection.getProtocol().createPrepare(null, sqlText.toString(), Collections.<Type>emptyList());
+		PrepareCommand prep = connection.getProtocol().createPrepare(0, sqlText.toString(), Collections.<Type>emptyList());
 		
 		SQLWarning warningChain = connection.execute(prep);
 		
@@ -40,7 +40,7 @@ class PGSimpleStatement extends PGStatement {
 		
 		SQLWarning prepWarningChain = prepare(sqlText);
 				
-		boolean res = super.executeStatement(null, Collections.<Type>emptyList(), Collections.<Object>emptyList());
+		boolean res = super.executeStatement(0, Collections.<Type>emptyList(), Collections.<Object>emptyList());
 		
 		warningChain = chainWarnings(prepWarningChain, warningChain);
 		

--- a/src/main/java/com/impossibl/postgres/protocol/BindExecCommand.java
+++ b/src/main/java/com/impossibl/postgres/protocol/BindExecCommand.java
@@ -15,8 +15,8 @@ public interface BindExecCommand extends QueryCommand {
 	int getMaxFieldLength();
 	public void setMaxFieldLength(int maxFieldLength);
 	
-	String getStatementName();
-	String getPortalName();
+	long getStatementId();
+	long getPortalId();
 	
 	List<Type> getParameterTypes();
 	List<Object> getParameterValues();

--- a/src/main/java/com/impossibl/postgres/protocol/CloseCommand.java
+++ b/src/main/java/com/impossibl/postgres/protocol/CloseCommand.java
@@ -4,6 +4,6 @@ public interface CloseCommand extends Command {
 	
 	ServerObjectType getObjectType();
 
-	String getObjectName();
+	long getObjectId();
 
 }

--- a/src/main/java/com/impossibl/postgres/protocol/PrepareCommand.java
+++ b/src/main/java/com/impossibl/postgres/protocol/PrepareCommand.java
@@ -6,7 +6,7 @@ import com.impossibl.postgres.types.Type;
 
 public interface PrepareCommand extends Command {
 
-	String getStatementName();
+	long getStatementId();
 	List<Type> getParseParameterTypes();
 	List<Type> getDescribedParameterTypes();
 	List<ResultField> getDescribedResultFields();

--- a/src/main/java/com/impossibl/postgres/protocol/Protocol.java
+++ b/src/main/java/com/impossibl/postgres/protocol/Protocol.java
@@ -12,12 +12,12 @@ public interface Protocol {
 	TransactionStatus getTransactionStatus();
 
 	StartupCommand createStartup(Map<String,Object> parameters);
-	PrepareCommand createPrepare(String statementName, String sqlText, List<Type> parameterTypes);
-	BindExecCommand createBindExec(String portalName, String statementName, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields, Class<?> rowType);
+	PrepareCommand createPrepare(long statementId, String sqlText, List<Type> parameterTypes);
+	BindExecCommand createBindExec(long portalId, long statementUd, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields, Class<?> rowType);
 	QueryCommand createQuery(String sqlText);
 	FunctionCallCommand createFunctionCall(String functionName, List<Type> parameterTypes, List<Object> parameterValues);
 	
-	CloseCommand createClose(ServerObjectType objectType, String objectName);
+	CloseCommand createClose(ServerObjectType objectType, long objectId);
 	
 	void execute(Command cmd) throws IOException;
 	

--- a/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
@@ -126,8 +126,8 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
 	};
 
 
-	private String statementName;
-	private String portalName;
+	private long statementId;
+	private long portalId;
 	private List<Type> parameterTypes;
 	private List<Object> parameterValues;
 	private List<ResultField> resultFields;
@@ -143,10 +143,10 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
 	private SettingsContext parsingContext; 
 
 	
-	public BindExecCommandImpl(String portalName, String statementName, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields, Class<?> rowType) {
+	public BindExecCommandImpl(long portalId, long statementId, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields, Class<?> rowType) {
 
-		this.statementName = statementName;
-		this.portalName = portalName;
+		this.statementId = statementId;
+		this.portalId = portalId;
 		this.parameterTypes = parameterTypes;
 		this.parameterValues = parameterValues;
 		this.resultFields = resultFields;
@@ -165,13 +165,13 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
 	}
 
 	@Override
-	public String getStatementName() {
-		return statementName;
+	public long getStatementId() {
+		return statementId;
 	}
 
 	@Override
-	public String getPortalName() {
-		return portalName;
+	public long getPortalId() {
+		return portalId;
 	}
 
 	public Status getStatus() {
@@ -241,17 +241,17 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
 
 		if(status != Status.Suspended) {
 
-			protocol.sendBind(portalName, statementName, parameterTypes, parameterValues);
+			protocol.sendBind(portalId, statementId, parameterTypes, parameterValues);
 
 		}
 
 		if(resultFields == null || !parameterTypes.isEmpty()) {
 
-			protocol.sendDescribe(Portal, portalName);
+			protocol.sendDescribe(Portal, portalId);
 
 		}
 
-		protocol.sendExecute(portalName, maxRows);
+		protocol.sendExecute(portalId, maxRows);
 
 		if(maxRows > 0 && protocol.getTransactionStatus() == TransactionStatus.Idle) {
 			protocol.sendFlush();			

--- a/src/main/java/com/impossibl/postgres/protocol/v30/CloseCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/CloseCommandImpl.java
@@ -12,7 +12,7 @@ import com.impossibl.postgres.protocol.TransactionStatus;
 public class CloseCommandImpl extends CommandImpl implements CloseCommand {
 	
 	ServerObjectType objectType;
-	String objectName;
+	long objectId;
 	boolean complete;
 
 	private ProtocolListener listener = new BaseProtocolListener() {
@@ -44,9 +44,9 @@ public class CloseCommandImpl extends CommandImpl implements CloseCommand {
 
 	};
 
-	public CloseCommandImpl(ServerObjectType objectType, String objectName) {
+	public CloseCommandImpl(ServerObjectType objectType, long objectId) {
 		this.objectType = objectType;
-		this.objectName = objectName;
+		this.objectId = objectId;
 	}
 
 	@Override
@@ -55,8 +55,8 @@ public class CloseCommandImpl extends CommandImpl implements CloseCommand {
 	}
 	
 	@Override
-	public String getObjectName() {
-		return objectName;
+	public long getObjectId() {
+		return objectId;
 	}
 
 	@Override
@@ -64,7 +64,7 @@ public class CloseCommandImpl extends CommandImpl implements CloseCommand {
 
 		protocol.setListener(listener);
 		
-		protocol.sendClose(objectType, objectName);
+		protocol.sendClose(objectType, objectId);
 		
 		protocol.sendSync();
 

--- a/src/main/java/com/impossibl/postgres/protocol/v30/PrepareCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/PrepareCommandImpl.java
@@ -16,7 +16,7 @@ import com.impossibl.postgres.types.Type;
 
 public class PrepareCommandImpl extends CommandImpl implements PrepareCommand {
 
-	private String statementName;
+	private long statementId;
 	private String query;
 	private List<Type> parseParameterTypes;
 	private List<Type> describedParameterTypes;
@@ -68,8 +68,8 @@ public class PrepareCommandImpl extends CommandImpl implements PrepareCommand {
 
 	};
 
-	public PrepareCommandImpl(String statementName, String query, List<Type> parseParameterTypes) {
-		this.statementName = statementName;
+	public PrepareCommandImpl(long statementId, String query, List<Type> parseParameterTypes) {
+		this.statementId = statementId;
 		this.query = query;
 		this.parseParameterTypes = parseParameterTypes;
 	}
@@ -79,8 +79,8 @@ public class PrepareCommandImpl extends CommandImpl implements PrepareCommand {
 	}
 
 	@Override
-	public String getStatementName() {
-		return statementName;
+	public long getStatementId() {
+		return statementId;
 	}
 
 	@Override
@@ -103,9 +103,9 @@ public class PrepareCommandImpl extends CommandImpl implements PrepareCommand {
 
 		protocol.setListener(listener);
 
-		protocol.sendParse(statementName, query, parseParameterTypes);
+		protocol.sendParse(statementId, query, parseParameterTypes);
 
-		protocol.sendDescribe(Statement, statementName);
+		protocol.sendDescribe(Statement, statementId);
 
 		protocol.sendFlush();
 

--- a/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -218,7 +218,7 @@ public class BasicContext implements Context {
 	
 	protected <T> List<T> execQuery(String queryTxt, Class<T> rowType, Object... params) throws IOException, NoticeException {
 
-		PrepareCommand prepare = protocol.createPrepare(null, queryTxt, Collections.<Type>emptyList());
+		PrepareCommand prepare = protocol.createPrepare(0, queryTxt, Collections.<Type>emptyList());
 		
 		protocol.execute(prepare);
 		
@@ -226,7 +226,7 @@ public class BasicContext implements Context {
 			throw new NoticeException("Error preparing query", prepare.getError());
 		}
 		
-		BindExecCommand query = protocol.createBindExec(null, null, prepare.getDescribedParameterTypes(), asList(params), prepare.getDescribedResultFields(), rowType);
+		BindExecCommand query = protocol.createBindExec(0, 0, prepare.getDescribedParameterTypes(), asList(params), prepare.getDescribedResultFields(), rowType);
 		
 		protocol.execute(query);
 		

--- a/src/main/java/com/impossibl/postgres/utils/ChannelBuffers.java
+++ b/src/main/java/com/impossibl/postgres/utils/ChannelBuffers.java
@@ -1,7 +1,6 @@
 package com.impossibl.postgres.utils;
 
 import java.nio.charset.Charset;
-
 import org.jboss.netty.buffer.ChannelBuffer;
 
 public class ChannelBuffers {
@@ -22,4 +21,20 @@ public class ChannelBuffers {
 		buffer.writeByte(0);
 	}
 
+  private final static byte[] hex = {'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
+  public static void writeLongAsCString(ChannelBuffer buffer, long val) {
+		if (val == 0) {
+			buffer.writeByte(0);
+			return;
+		}
+
+		byte[] buf = new byte[16 + 1];
+		int pos = 16;
+		while (val != 0) {
+			buf[--pos] = hex[(int) (val & 15)];
+			val >>>= 4;
+	  }
+
+		buffer.writeBytes(buf, pos, 17-pos);
+	}
 }


### PR DESCRIPTION
The statementName and portalName are generated unique numbers. Instead of converting first from long->String and then every time when they are written to protocol messages from String->byte[]->ByteBuffer.

This patch just pass the statementId and portalId as numbers around. When writing to ByteBuffer just create a temporary byte[] and serialize the number directly to it before writing it out.
