### PR TITLE
Combine protocol messages to one ChannelBuffer and only write to socket once.

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
@@ -245,29 +245,32 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
 		
 		protocol.setListener(listener);
 
+		ChannelBuffer msg = null;
+
 		if(status != Status.Suspended) {
 
-			protocol.sendBind(portalName, statementName, parameterTypes, parameterValues);
+			msg = protocol.appendBindExecToBuffer(msg, portalName, statementName, parameterTypes, parameterValues);
 
 		}
 
 		if(resultFields == null || !parameterTypes.isEmpty()) {
 
-			protocol.sendDescribe(Portal, portalName);
+			msg = protocol.appendDescribeToBuffer(msg, Portal, portalName);
 
 		}
 
-		protocol.sendExecute(portalName, maxRows);
+		msg = protocol.appendExecuteToBuffer(msg, portalName, maxRows);
 
 		if(maxRows > 0 && protocol.getTransactionStatus() == TransactionStatus.Idle) {
-			protocol.sendFlush();			
+			protocol.appendFlushToBuffer(msg);
 		}
 		else {
-			protocol.sendSync();			
+			protocol.appendSyncToBuffer(msg);
 		}
 
+		protocol.channel.write(msg);
+
 		waitFor(listener);
-		
 	}
 
 }


### PR DESCRIPTION
This patch is for the prepared statement execute.

In a my benchmark it speeds up a simple query with two result rows in a loop to localhost postgresql server by upto 15x by avoiding multiple system calls per round-trip.
