### PR TITLE
Simplify version parsing & Change the user used for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,19 @@ packaged inside and another without.
 
 The unit tests need a PostgreSQL database to execute against. The tests assume theses defaults:
 
-	DATABASE: test
 	SERVER: 	localhost
-	USERNAME:	postgres
+	PORT: 	        5432
+	DATABASE:       test
+	USERNAME:	pgjdbc
 	PASSWORD:	test
+
+The following system properties are supported in order to customize the setup
+
+	pgjdbc.test.server
+	pgjdbc.test.port
+	pgjdbc.test.db
+	pgjdbc.test.user
+	pgjdbc.test.password
 
 If you'd like to build the driver without running the unit tests use the command:
 

--- a/src/main/java/com/impossibl/postgres/system/Version.java
+++ b/src/main/java/com/impossibl/postgres/system/Version.java
@@ -29,30 +29,23 @@
 package com.impossibl.postgres.system;
 
 import java.util.HashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Version {
 	
-	//private static final Pattern VERSION_PATTERN = compile("(\\d+)(?:\\.(\\d+)(?:\\.(\\d+))?)?");
-	private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?");
 	private static final HashMap<Version,Version> all = new HashMap<Version,Version>();
 	
-	int major;
-	Integer minor;
-	Integer revision;
+	private int major;
+	private Integer minor;
+	private Integer revision;
 	
 	public static Version parse(String versionString) {
+                String[] version = versionString.split("\\.");
 		
-		Matcher matcher = VERSION_PATTERN.matcher(versionString);
-		if(!matcher.find())
-			return null;
-		
-		int major = Integer.parseInt(matcher.group(1));
-		Integer minor = matcher.group(2) != null ? Integer.parseInt(matcher.group(2)) : null;
-		Integer revision = matcher.group(3) != null ? Integer.parseInt(matcher.group(3)) : null;
-		
-		return get(major, minor, revision);
+		int major = Integer.parseInt(version[0]);
+		Integer minor = version.length > 1 ? Integer.valueOf(version[1]) : null;
+		Integer revision = version.length > 2 ? Integer.valueOf(version[2]) : null;
+
+                return get(major, minor, revision);
 	}
 
 	public static synchronized Version get(int major, Integer minor, Integer revision) {

--- a/src/test/java/com/impossibl/postgres/jdbc/TestUtil.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/TestUtil.java
@@ -53,11 +53,15 @@ public class TestUtil {
 			query = "?" + Joiner.on("&").withKeyValueSeparator("=").join(params(urlParams));
 		}
 
-		return "jdbc:postgresql://" + getServer() + "/" + getDatabase() + query;
+		if(!"5432".equals(getPort())) {
+                	return "jdbc:postgresql://" + getServer() + ":" + getPort() + "/" + getDatabase() + query;
+                } else {
+                	return "jdbc:postgresql://" + getServer() + "/" + getDatabase() + query;
+                }
 	}
 
 	public static String getServer() {
-		return System.getProperty("pgjdbc.test.server", "test");
+		return System.getProperty("pgjdbc.test.server", "localhost");
 	}
 
 	public static String getPort() {
@@ -79,7 +83,7 @@ public class TestUtil {
 	}
 
 	public static String getUser() {
-		return System.getProperty("pgjdbc.test.user", "postgres");
+		return System.getProperty("pgjdbc.test.user", "pgjdbc");
 	}
 
 	public static String getPassword() {


### PR DESCRIPTION
The user 'postgres' runs the server instance, so it is better to have a dedicated user for the test suite 'pgjdbc'.

This PR also simplifies the version parsing.
