### PR TITLE
Show allocation trace in threaded housekeeper

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/Housekeeper.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/Housekeeper.java
@@ -54,24 +54,4 @@ public interface Housekeeper {
    * Ensures the cleanup queue is emptied immediately
    */
   void emptyQueue();
-
-  /**
-   * ** Only used for unit testing **
-   *
-   * Checks if a referent has been queued and then processed and removed from
-   * the lists
-   *
-   * @param referent
-   *          Referent to check
-   * @return
-   */
-  boolean testCheckCleaned(int referentId);
-
-  /**
-   * ** Only used for unit testing **
-   *
-   * Clears list of references
-   */
-  void testClear();
-
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnection.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnection.java
@@ -91,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.lang.Boolean.parseBoolean;
@@ -118,16 +119,18 @@ class PGConnection extends BasicContext implements Connection {
 
     Protocol protocol;
     List<WeakReference<PGStatement>> statements;
+    Exception allocationTrace;
 
     public Cleanup(Protocol protocol, List<WeakReference<PGStatement>> statements) {
       this.protocol = protocol;
       this.statements = statements;
+      this.allocationTrace = new Exception();
     }
 
     @Override
     public void run() {
 
-      logger.warning("cleaning up leaked connection");
+      logger.log(Level.WARNING, "cleaning up leaked connection", allocationTrace);
 
       protocol.shutdown();
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -89,6 +89,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.lang.Math.max;
@@ -111,16 +112,18 @@ class PGResultSet implements ResultSet {
 
     PGStatement statement;
     QueryCommand command;
+    Exception allocationTrace;
 
     public Cleanup(PGStatement statement, QueryCommand command) {
       this.statement = statement;
       this.command = command;
+      this.allocationTrace = new Exception();
     }
 
     @Override
     public void run() {
 
-      logger.warning("cleaning up leaked result-set");
+      logger.log(Level.WARNING, "cleaning up leaked result-set", allocationTrace);
 
       try {
         statement.dispose(command);

--- a/src/main/java/com/impossibl/postgres/jdbc/PGStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGStatement.java
@@ -53,6 +53,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.sql.ResultSet.CONCUR_READ_ONLY;
@@ -74,17 +75,19 @@ abstract class PGStatement implements Statement {
     PGConnection connection;
     String name;
     List<WeakReference<PGResultSet>> resultSets;
+    Exception allocationTrace;
 
     public Cleanup(PGConnection connection, String name, List<WeakReference<PGResultSet>> resultSets) {
       this.connection = connection;
       this.name = name;
       this.resultSets = resultSets;
+      this.allocationTrace = new Exception();
     }
 
     @Override
     public void run() {
 
-      logger.warning("cleaning up leaked statement");
+      logger.log(Level.WARNING, "cleaning up leaked statement", allocationTrace);
 
       closeResultSets(resultSets);
 

--- a/src/main/java/com/impossibl/postgres/jdbc/ThreadedHousekeeper.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/ThreadedHousekeeper.java
@@ -148,7 +148,9 @@ public class ThreadedHousekeeper implements Housekeeper {
 
   }
 
-  @Override
+  /**
+   * Test only
+   */
   public boolean testCheckCleaned(int referentId) {
 
     System.gc();
@@ -165,9 +167,10 @@ public class ThreadedHousekeeper implements Housekeeper {
     return true;
   }
 
-  @Override
+  /**
+   * Test only
+   */
   public void testClear() {
     cleanupReferences.clear();
   }
-
 }

--- a/src/test/java/com/impossibl/postgres/jdbc/CodecTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/CodecTest.java
@@ -109,6 +109,7 @@ public class CodecTest {
   @After
   public void tearDown() throws SQLException {
     TestUtil.dropType(conn, "teststruct");
+    TestUtil.closeDB(conn);
   }
 
   @Test

--- a/src/test/java/com/impossibl/postgres/jdbc/ExceptionTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/ExceptionTest.java
@@ -52,6 +52,7 @@ public class ExceptionTest {
   @After
   public void tearDown() throws SQLException {
     TestUtil.dropTable(conn, "checktest");
+    TestUtil.closeDB(conn);
   }
 
   @Test(expected = SQLIntegrityConstraintViolationException.class)

--- a/src/test/java/com/impossibl/postgres/jdbc/LeakTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/LeakTest.java
@@ -63,19 +63,21 @@ public class LeakTest {
 
   @After
   public void after() throws Exception {
-
-    if (conn != null)
+    if (conn != null && getHousekeeper() != null)
       getHousekeeper().testClear();
   }
 
-  Housekeeper getHousekeeper() {
-    return ((PGConnection) conn).housekeeper;
+  ThreadedHousekeeper getHousekeeper() {
+    if (((PGConnection) conn).housekeeper != null)
+      return (ThreadedHousekeeper)((PGConnection) conn).housekeeper;
+    else
+      return null;
   }
 
   @Test
   public void testResultSetLeak() throws SQLException {
 
-    Housekeeper housekeeper = getHousekeeper();
+    ThreadedHousekeeper housekeeper = getHousekeeper();
 
     int connId = System.identityHashCode(conn);
 
@@ -99,7 +101,7 @@ public class LeakTest {
   @Test
   public void testResultSetNoLeak() throws SQLException {
 
-    Housekeeper housekeeper = getHousekeeper();
+    ThreadedHousekeeper housekeeper = getHousekeeper();
 
     int connId = System.identityHashCode(conn);
 
@@ -122,7 +124,7 @@ public class LeakTest {
   @Test
   public void testStatementLeak() throws SQLException {
 
-    Housekeeper housekeeper = getHousekeeper();
+    ThreadedHousekeeper housekeeper = getHousekeeper();
 
     int connId = System.identityHashCode(conn);
 
@@ -146,7 +148,7 @@ public class LeakTest {
   @Test
   public void testStatementNoLeak() throws SQLException {
 
-    Housekeeper housekeeper = getHousekeeper();
+    ThreadedHousekeeper housekeeper = getHousekeeper();
 
     int connId = System.identityHashCode(conn);
 
@@ -170,7 +172,7 @@ public class LeakTest {
   @Test
   public void testConnectionLeak() throws SQLException {
 
-    Housekeeper housekeeper = getHousekeeper();
+    ThreadedHousekeeper housekeeper = getHousekeeper();
 
     int connId = System.identityHashCode(conn);
 
@@ -207,7 +209,7 @@ public class LeakTest {
     stmt.close();
     conn.close();
 
-    Housekeeper housekeeper = getHousekeeper();
+    ThreadedHousekeeper housekeeper = getHousekeeper();
 
     sleep();
     assertTrue(housekeeper.testCheckCleaned(rsId));


### PR DESCRIPTION
- Only have housekeeper methods in the interface
- Show allocation trace in case of a leak
- Fixed two test case leaks
