### PR TITLE
Initial public API for PGConnection

### DIFF
--- a/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
+++ b/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
@@ -26,29 +26,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.impossibl.postgres.jdbc;
+package com.impossibl.postgres.api.jdbc;
 
-import java.sql.SQLException;
+import java.sql.Connection;
 
-class LargeObject64 extends LargeObject {
-
-  LargeObject64(PGConnectionImpl connection, int oid, int fd) {
-    super(connection, oid, fd);
-  }
-
-  @Override
-  long lseek(long offset, int whence) throws SQLException {
-    return connection.executeForFirstResultValue("select lo_lseek64($1,$2,$3)", true, Long.class, fd, offset, whence);
-  }
-
-  @Override
-  long tell() throws SQLException {
-    return connection.executeForFirstResultValue("select lo_tell64($1)", true, Long.class, fd);
-  }
-
-  @Override
-  int truncate(long len) throws SQLException {
-    return connection.executeForFirstResultValue("select lo_truncate64($1,$2)", true, Integer.class, fd, len);
-  }
-
+/**
+ * Public API for PGConnection
+ */
+public interface PGConnection extends Connection {
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/LargeObject.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/LargeObject.java
@@ -46,9 +46,9 @@ class LargeObject {
 
   int oid;
   int fd;
-  PGConnection connection;
+  PGConnectionImpl connection;
 
-  static LargeObject open(PGConnection connection, int oid) throws SQLException {
+  static LargeObject open(PGConnectionImpl connection, int oid) throws SQLException {
     int fd = open(connection, oid, INV_READ | INV_WRITE);
     if (fd == -1) {
       throw new SQLException("Unable to open large object");
@@ -60,7 +60,7 @@ class LargeObject {
       return new LargeObject(connection, oid, fd);
   }
 
-  LargeObject(PGConnection connection, int oid, int fd) {
+  LargeObject(PGConnectionImpl connection, int oid, int fd) {
     super();
     this.oid = oid;
     this.fd = fd;
@@ -71,15 +71,15 @@ class LargeObject {
     return open(connection, oid);
   }
 
-  static int creat(PGConnection conn, int mode) throws SQLException {
+  static int creat(PGConnectionImpl conn, int mode) throws SQLException {
     return conn.executeForFirstResultValue("select lo_creat($1)", true, Integer.class, mode);
   }
 
-  static int open(PGConnection conn, int oid, int access) throws SQLException {
+  static int open(PGConnectionImpl conn, int oid, int access) throws SQLException {
     return conn.executeForFirstResultValue("select lo_open($1,$2)", true, Integer.class, oid, access);
   }
 
-  static int unlink(PGConnection conn, int oid) throws SQLException {
+  static int unlink(PGConnectionImpl conn, int oid) throws SQLException {
     return conn.executeForFirstResultValue("select lo_unlink($1)", true, Integer.class, oid);
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGArray.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGArray.java
@@ -46,11 +46,11 @@ import java.util.Map;
 
 public class PGArray implements Array {
 
-  PGConnection connection;
+  PGConnectionImpl connection;
   ArrayType type;
   Object[] value;
 
-  public PGArray(PGConnection connection, ArrayType type, Object[] value) {
+  public PGArray(PGConnectionImpl connection, ArrayType type, Object[] value) {
     super();
     this.connection = connection;
     this.type = type;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGBlob.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGBlob.java
@@ -72,7 +72,7 @@ public class PGBlob implements Blob {
   LargeObject lo;
   List<LargeObject> streamLos;
 
-  PGBlob(PGConnection connection, int oid) throws SQLException {
+  PGBlob(PGConnectionImpl connection, int oid) throws SQLException {
 
     if (connection.getAutoCommit()) {
       throw new SQLException("Blobs require connection to be in manual-commit mode... setAutoCommit(false)");

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -28,6 +28,7 @@
  */
 package com.impossibl.postgres.jdbc;
 
+import com.impossibl.postgres.api.jdbc.PGConnection;
 import com.impossibl.postgres.jdbc.SQLTextTree.Node;
 import com.impossibl.postgres.jdbc.SQLTextTree.ParameterPiece;
 import com.impossibl.postgres.jdbc.SQLTextTree.Processor;
@@ -107,7 +108,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import org.jboss.netty.handler.queue.BlockingReadTimeoutException;
 
-class PGConnection extends BasicContext implements Connection {
+class PGConnectionImpl extends BasicContext implements PGConnection {
 
   private static final Logger logger = Logger.getLogger(PGConnection.class.getName());
 
@@ -154,7 +155,7 @@ class PGConnection extends BasicContext implements Connection {
   final Object cleanupKey;
 
 
-  PGConnection(SocketAddress address, Properties settings, Housekeeper housekeeper) throws IOException {
+  PGConnectionImpl(SocketAddress address, Properties settings, Housekeeper housekeeper) throws IOException {
     super(address, settings, Collections.<String, Class<?>>emptyMap());
 
     this.activeStatements = new ArrayList<>();

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -70,11 +70,11 @@ class PGDatabaseMetaData implements DatabaseMetaData {
       "returns,rule,recipe,setof,stdin,stdout,store," +
       "vacuum,verbose,version";
 
-  PGConnection connection;
+  PGConnectionImpl connection;
   int maxNameLength;
   int maxIndexKeys;
 
-  PGDatabaseMetaData(PGConnection connection) {
+  PGDatabaseMetaData(PGConnectionImpl connection) {
     this.connection = connection;
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDriver.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDriver.java
@@ -28,6 +28,7 @@
  */
 package com.impossibl.postgres.jdbc;
 
+import com.impossibl.postgres.api.jdbc.PGConnection;
 import com.impossibl.postgres.system.Context;
 import com.impossibl.postgres.system.NoticeException;
 import com.impossibl.postgres.system.Version;
@@ -129,7 +130,7 @@ public class PGDriver implements Driver {
 
       try {
 
-        PGConnection conn = new PGConnection(address, settings, housekeeper);
+        PGConnectionImpl conn = new PGConnectionImpl(address, settings, housekeeper);
 
         conn.init();
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -102,7 +102,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
   boolean parsed;
 
 
-  PGPreparedStatement(PGConnection connection, int type, int concurrency, int holdability, String name, String sqlText, int parameterCount, String cursorName) {
+  PGPreparedStatement(PGConnectionImpl connection, int type, int concurrency, int holdability, String name, String sqlText, int parameterCount, String cursorName) {
     super(connection, type, concurrency, holdability, name, null);
     this.sqlText = sqlText;
     this.parameterTypes = asList(new Type[parameterCount]);

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -1965,7 +1965,7 @@ class CommandScroller extends ListScroller {
 
 class CursorScroller extends Scroller {
 
-  PGConnection connection;
+  PGConnectionImpl connection;
   String cursorName;
   int type;
   int holdability;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSetMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSetMetaData.java
@@ -43,11 +43,11 @@ import java.util.Map;
 
 class PGResultSetMetaData implements ResultSetMetaData {
 
-  PGConnection connection;
+  PGConnectionImpl connection;
   List<ResultField> resultFields;
   Map<String, Class<?>> typeMap;
 
-  PGResultSetMetaData(PGConnection connection, List<ResultField> resultFields, Map<String, Class<?>> typeMap) {
+  PGResultSetMetaData(PGConnectionImpl connection, List<ResultField> resultFields, Map<String, Class<?>> typeMap) {
     this.connection = connection;
     this.resultFields = resultFields;
     this.typeMap = typeMap;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGSQLInput.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGSQLInput.java
@@ -80,14 +80,14 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class PGSQLInput implements SQLInput {
 
-  private PGConnection connection;
+  private PGConnectionImpl connection;
   private CompositeType type;
   private Map<String, Class<?>> typeMap;
   private int currentAttrIdx;
   private Object[] attributeValues;
   private Boolean nullFlag;
 
-  public PGSQLInput(PGConnection connection, CompositeType type, Map<String, Class<?>> typeMap, Object[] attributeValues) {
+  public PGSQLInput(PGConnectionImpl connection, CompositeType type, Map<String, Class<?>> typeMap, Object[] attributeValues) {
     this.connection = connection;
     this.type = type;
     this.typeMap = typeMap;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGSQLOutput.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGSQLOutput.java
@@ -62,12 +62,12 @@ import java.util.Collections;
 
 public class PGSQLOutput implements SQLOutput {
 
-  private PGConnection connection;
+  private PGConnectionImpl connection;
   private CompositeType type;
   private int currentAttributeIdx;
   private Object[] attributeValues;
 
-  public PGSQLOutput(PGConnection connection, CompositeType type) {
+  public PGSQLOutput(PGConnectionImpl connection, CompositeType type) {
     this.connection = connection;
     this.type = type;
     this.attributeValues = new Object[type.getAttributes().size()];

--- a/src/main/java/com/impossibl/postgres/jdbc/PGSQLXML.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGSQLXML.java
@@ -113,21 +113,21 @@ public class PGSQLXML implements SQLXML {
   }
 
 
-  private PGConnection connection;
+  private PGConnectionImpl connection;
   private byte[] data;
   private int dataLen;
   private boolean initialized;
 
 
-  public PGSQLXML(PGConnection conn) {
+  public PGSQLXML(PGConnectionImpl conn) {
     this(conn, null, false);
   }
 
-  public PGSQLXML(PGConnection conn, byte[] data) {
+  public PGSQLXML(PGConnectionImpl conn, byte[] data) {
     this(conn, data, true);
   }
 
-  private PGSQLXML(PGConnection connection, byte[] data, boolean initialized) {
+  private PGSQLXML(PGConnectionImpl connection, byte[] data, boolean initialized) {
     this.connection = connection;
     this.data = data;
     this.dataLen = data != null ? data.length : -1;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
@@ -55,7 +55,7 @@ class PGSimpleStatement extends PGStatement {
 
   SQLText batchCommands;
 
-  public PGSimpleStatement(PGConnection connection, int type, int concurrency, int holdability) {
+  public PGSimpleStatement(PGConnectionImpl connection, int type, int concurrency, int holdability) {
     super(connection, type, concurrency, holdability, null, null);
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGStatement.java
@@ -70,12 +70,12 @@ abstract class PGStatement implements Statement {
    */
   static class Cleanup implements Runnable {
 
-    PGConnection connection;
+    PGConnectionImpl connection;
     String name;
     List<WeakReference<PGResultSet>> resultSets;
     Exception allocationTrace;
 
-    public Cleanup(PGConnection connection, String name, List<WeakReference<PGResultSet>> resultSets) {
+    public Cleanup(PGConnectionImpl connection, String name, List<WeakReference<PGResultSet>> resultSets) {
       this.connection = connection;
       this.name = name;
       this.resultSets = resultSets;
@@ -104,7 +104,7 @@ abstract class PGStatement implements Statement {
 
 
 
-  PGConnection connection;
+  PGConnectionImpl connection;
   String cursorName;
   int resultSetType;
   int resultSetConcurrency;
@@ -127,8 +127,7 @@ abstract class PGStatement implements Statement {
   final Object cleanupKey;
 
 
-
-  PGStatement(PGConnection connection, int resultSetType, int resultSetConcurrency, int resultSetHoldability, String name, List<ResultField> resultFields) {
+  PGStatement(PGConnectionImpl connection, int resultSetType, int resultSetConcurrency, int resultSetHoldability, String name, List<ResultField> resultFields) {
     super();
 
     this.connection = connection;
@@ -170,7 +169,7 @@ abstract class PGStatement implements Statement {
    * @throws SQLException
    *          If an error occurs during disposal
    */
-  public static void dispose(PGConnection connection, ServerObjectType objectType, String objectName) throws SQLException {
+  public static void dispose(PGConnectionImpl connection, ServerObjectType objectType, String objectName) throws SQLException {
 
     if (objectName == null)
       return;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGStruct.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGStruct.java
@@ -40,11 +40,11 @@ import java.util.Map;
 
 public class PGStruct implements Struct {
 
-  PGConnection connection;
+  PGConnectionImpl connection;
   CompositeType type;
   Object[] values;
 
-  public PGStruct(PGConnection connection, CompositeType type, Object[] values) {
+  public PGStruct(PGConnectionImpl connection, CompositeType type, Object[] values) {
     super();
     this.connection = connection;
     this.type = type;

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTypeUtils.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTypeUtils.java
@@ -122,12 +122,12 @@ class SQLTypeUtils {
     return targetType;
   }
 
-  public static Object coerce(Object val, Type sourceType, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnection connection) throws SQLException {
+  public static Object coerce(Object val, Type sourceType, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnectionImpl connection) throws SQLException {
 
     return coerce(val, sourceType, targetType, typeMap, TimeZone.getDefault(), connection);
   }
 
-  public static Object coerce(Object val, Type sourceType, Class<?> targetType, Map<String, Class<?>> typeMap, TimeZone zone, PGConnection connection) throws SQLException {
+  public static Object coerce(Object val, Type sourceType, Class<?> targetType, Map<String, Class<?>> typeMap, TimeZone zone, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
       return null;
@@ -625,7 +625,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), URL.class);
   }
 
-  public static Blob coerceToBlob(Object val, PGConnection connection) throws SQLException {
+  public static Blob coerceToBlob(Object val, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
       return null;
@@ -683,7 +683,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), byte[].class);
   }
 
-  public static Object coerceToArray(Object val, Type type, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnection connection) throws SQLException {
+  public static Object coerceToArray(Object val, Type type, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
       return null;
@@ -698,7 +698,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), targetType);
   }
 
-  public static Object coerceToArray(Object val, int index, int count, Type type, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnection connection) throws SQLException {
+  public static Object coerceToArray(Object val, int index, int count, Type type, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
       return null;
@@ -763,7 +763,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), targetType);
   }
 
-  public static Struct coerceToStruct(Object val, Type sourceType, Map<String, Class<?>> typeMap, PGConnection connection) throws SQLException {
+  public static Struct coerceToStruct(Object val, Type sourceType, Map<String, Class<?>> typeMap, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
 
@@ -791,7 +791,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), Struct.class);
   }
 
-  public static Record coerceToRecord(Object val, Type sourceType, Map<String, Class<?>> typeMap, PGConnection connection) throws SQLException {
+  public static Record coerceToRecord(Object val, Type sourceType, Map<String, Class<?>> typeMap, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
 
@@ -831,7 +831,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), Struct.class);
   }
 
-  public static Object coerceToCustomType(Object val, Type sourceType, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnection connection) throws SQLException {
+  public static Object coerceToCustomType(Object val, Type sourceType, Class<?> targetType, Map<String, Class<?>> typeMap, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
 
@@ -891,7 +891,7 @@ class SQLTypeUtils {
     throw createCoercionException(val.getClass(), UUID.class);
   }
 
-  public static SQLXML coerceToXML(Object val, PGConnection connection) throws SQLException {
+  public static SQLXML coerceToXML(Object val, PGConnectionImpl connection) throws SQLException {
 
     if (val == null) {
       return null;

--- a/src/main/java/com/impossibl/postgres/jdbc/Unwrapping.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/Unwrapping.java
@@ -40,7 +40,7 @@ import java.sql.SQLException;
 
 public class Unwrapping {
 
-  static Object unwrapObject(PGConnection connection, Object x) throws SQLException {
+  static Object unwrapObject(PGConnectionImpl connection, Object x) throws SQLException {
 
     if (x instanceof Blob) {
       return unwrapBlob(connection, (Blob) x);
@@ -49,7 +49,7 @@ public class Unwrapping {
     return x;
   }
 
-  static PGBlob unwrapBlob(PGConnection connection, Blob x) throws SQLException {
+  static PGBlob unwrapBlob(PGConnectionImpl connection, Blob x) throws SQLException {
 
     if (x instanceof PGBlob)
       return (PGBlob) x;

--- a/src/test/java/com/impossibl/postgres/jdbc/CodecTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/CodecTest.java
@@ -67,12 +67,12 @@ public class CodecTest {
 
   public Object[][] dataRows;
 
-  PGConnection conn;
+  PGConnectionImpl conn;
 
   @Before
   public void setUp() throws Exception {
 
-    conn = (PGConnection) TestUtil.openDB();
+    conn = (PGConnectionImpl) TestUtil.openDB();
 
     TestUtil.createType(conn, "teststruct" , "str text, str2 text, id uuid, num float");
 

--- a/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
@@ -204,13 +204,13 @@ public class ConnectionTest {
     String testStr = "This Is OuR TeSt message";
 
     // The connection must be ours!
-    assertTrue(con instanceof PGConnection);
+    assertTrue(con instanceof PGConnectionImpl);
 
     // Clear any existing warnings
     con.clearWarnings();
 
     // Set the test warning
-    ((PGConnection)con).addWarning(new SQLWarning(testStr));
+    ((PGConnectionImpl)con).addWarning(new SQLWarning(testStr));
 
     // Retrieve it
     SQLWarning warning = con.getWarnings();

--- a/src/test/java/com/impossibl/postgres/jdbc/CursorFetchTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/CursorFetchTest.java
@@ -79,6 +79,7 @@ public class CursorFetchTest {
       stmt.setInt(1, i);
       stmt.executeUpdate();
     }
+    stmt.close();
     con.commit();
   }
 
@@ -141,7 +142,11 @@ public class CursorFetchTest {
           assertEquals("query value error on iteration " + j + "/" + k + " with fetch size " + testSizes[i], position, rs.getInt(1));
         }
       }
+
+      rs.close();
     }
+
+    stmt.close();
   }
 
   @Test
@@ -171,7 +176,11 @@ public class CursorFetchTest {
         assertTrue("ran out of rows doing an absolute fetch at " + position + " on iteration " + j + " with fetchsize" + testSizes[i], rs.absolute(position + 1));
         assertEquals("query value error with fetch size " + testSizes[i], position, rs.getInt(1));
       }
+
+      rs.close();
     }
+
+    stmt.close();
   }
 
   //
@@ -199,6 +208,8 @@ public class CursorFetchTest {
     }
 
     assertEquals(100, count);
+    rs.close();
+    stmt.close();
   }
 
   // test two:
@@ -225,6 +236,9 @@ public class CursorFetchTest {
     }
 
     assertEquals(100, count);
+
+    rs.close();
+    stmt.close();
   }
 
   // test three:
@@ -253,6 +267,8 @@ public class CursorFetchTest {
     }
 
     assertEquals(100, count);
+    rs.close();
+    stmt.close();
   }
 
   // test four:
@@ -281,6 +297,8 @@ public class CursorFetchTest {
     }
 
     assertEquals(100, count);
+    rs.close();
+    stmt.close();
   }
 
   @Test
@@ -413,6 +431,7 @@ public class CursorFetchTest {
     PreparedStatement stmt = con.prepareStatement("insert into test_fetch(value) values(1)");
     stmt.setFetchSize(100); // Should be meaningless.
     stmt.executeUpdate();
+    stmt.close();
   }
 
   @Test
@@ -434,6 +453,8 @@ public class CursorFetchTest {
     }
 
     assertEquals(101, count);
+    rs.close();
+    stmt.close();
   }
 
   // if the driver tries to use a cursor with autocommit on
@@ -452,6 +473,8 @@ public class CursorFetchTest {
     }
 
     assertEquals(10, count);
+    rs.close();
+    stmt.close();
   }
 
   @Test
@@ -466,6 +489,8 @@ public class CursorFetchTest {
       assertEquals(count, rs.getRow());
     }
     assertEquals(3, count);
+    rs.close();
+    stmt.close();
   }
 
 }

--- a/src/test/java/com/impossibl/postgres/jdbc/DatabaseMetaDataPropertiesTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/DatabaseMetaDataPropertiesTest.java
@@ -28,6 +28,8 @@
  */
 package com.impossibl.postgres.jdbc;
 
+import com.impossibl.postgres.api.jdbc.PGConnection;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;

--- a/src/test/java/com/impossibl/postgres/jdbc/LeakTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/LeakTest.java
@@ -44,6 +44,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -68,8 +69,8 @@ public class LeakTest {
   }
 
   ThreadedHousekeeper getHousekeeper() {
-    if (((PGConnection) conn).housekeeper != null)
-      return (ThreadedHousekeeper)((PGConnection) conn).housekeeper;
+    if (((PGConnectionImpl) conn).housekeeper != null)
+      return (ThreadedHousekeeper)((PGConnectionImpl) conn).housekeeper;
     else
       return null;
   }
@@ -78,6 +79,7 @@ public class LeakTest {
   public void testResultSetLeak() throws SQLException {
 
     ThreadedHousekeeper housekeeper = getHousekeeper();
+    assertNotNull(housekeeper);
 
     int connId = System.identityHashCode(conn);
 
@@ -102,6 +104,7 @@ public class LeakTest {
   public void testResultSetNoLeak() throws SQLException {
 
     ThreadedHousekeeper housekeeper = getHousekeeper();
+    assertNotNull(housekeeper);
 
     int connId = System.identityHashCode(conn);
 
@@ -125,6 +128,7 @@ public class LeakTest {
   public void testStatementLeak() throws SQLException {
 
     ThreadedHousekeeper housekeeper = getHousekeeper();
+    assertNotNull(housekeeper);
 
     int connId = System.identityHashCode(conn);
 
@@ -149,6 +153,7 @@ public class LeakTest {
   public void testStatementNoLeak() throws SQLException {
 
     ThreadedHousekeeper housekeeper = getHousekeeper();
+    assertNotNull(housekeeper);
 
     int connId = System.identityHashCode(conn);
 
@@ -173,6 +178,7 @@ public class LeakTest {
   public void testConnectionLeak() throws SQLException {
 
     ThreadedHousekeeper housekeeper = getHousekeeper();
+    assertNotNull(housekeeper);
 
     int connId = System.identityHashCode(conn);
 
@@ -210,6 +216,7 @@ public class LeakTest {
     conn.close();
 
     ThreadedHousekeeper housekeeper = getHousekeeper();
+    assertNotNull(housekeeper);
 
     sleep();
     assertTrue(housekeeper.testCheckCleaned(rsId));
@@ -229,7 +236,7 @@ public class LeakTest {
       try (Statement stmt = conn.createStatement()) {
         try (ResultSet rs = stmt.executeQuery("SELECT 1")) {
 
-          Housekeeper housekeeper = ((PGConnection) conn).housekeeper;
+          Housekeeper housekeeper = ((PGConnectionImpl) conn).housekeeper;
           assertNull(housekeeper);
 
         }
@@ -241,7 +248,7 @@ public class LeakTest {
   private void sleep() {
     System.gc();
     try {
-      Thread.sleep(50);
+      Thread.sleep(100);
     }
     catch (InterruptedException e) {
       // Ignore...

--- a/src/test/java/com/impossibl/postgres/jdbc/ServerErrorTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/ServerErrorTest.java
@@ -80,7 +80,7 @@ public class ServerErrorTest {
   @Test
   public void testPrimaryKey() throws Exception {
 
-    if (!((PGConnection)con).getServerVersion().isMinimum(9, 3))
+    if (!((PGConnectionImpl)con).getServerVersion().isMinimum(9, 3))
       return;
 
     Statement stmt = con.createStatement();
@@ -105,7 +105,7 @@ public class ServerErrorTest {
   @Test
   public void testColumn() throws Exception {
 
-    if (!((PGConnection)con).getServerVersion().isMinimum(9, 3))
+    if (!((PGConnectionImpl)con).getServerVersion().isMinimum(9, 3))
       return;
 
     Statement stmt = con.createStatement();
@@ -129,7 +129,7 @@ public class ServerErrorTest {
   @Test
   public void testDatatype() throws Exception {
 
-    if (!((PGConnection)con).getServerVersion().isMinimum(9, 3))
+    if (!((PGConnectionImpl)con).getServerVersion().isMinimum(9, 3))
       return;
 
     Statement stmt = con.createStatement();

--- a/src/test/java/com/impossibl/postgres/jdbc/WrapperTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/WrapperTest.java
@@ -28,6 +28,8 @@
  */
 package com.impossibl.postgres.jdbc;
 
+import com.impossibl.postgres.api.jdbc.PGConnection;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;


### PR DESCRIPTION
- Add .api.jdbc.PGConnection for initial public API
- Change existing classes to use internal API
- Change test cases to use either public API or internal API

A candidate for the public API could be "boolean isMinimumServerVersion(int, int)".

The DataSource related classes will provide alternative implementations of the public API.
