### PR TITLE
Change jdbc:postgresql to jdbc:pgsql

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A new JDBC driver for PostgreSQL aimed at supporting the advanced features of JD
 
 The connection format for the pgjdbc-ng driver is
 
-	jdbc:postgresql://<server>[:<port>]/<database>
+	jdbc:pgsql://<server>[:<port>]/<database>
 
 An example
 
-	jdbc:postgresql://localhost:5432/test
+	jdbc:pgsql://localhost:5432/test
 
 ## DataSource / XADataSource
 

--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -241,7 +241,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
     if (getDatabase() == null)
        throw new SQLException("Database parameter mandatory for " + getHost() + ":" + getPort());
 
-    sb = sb.append("jdbc:postgresql://");
+    sb = sb.append("jdbc:pgsql://");
     sb = sb.append(getHost());
     sb = sb.append(":");
     sb = sb.append(getPort());

--- a/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
@@ -212,20 +212,20 @@ class ConnectionUtil {
     settings.put(CREDENTIALS_PASSWORD, settings.getProperty(JDBC_PASSWORD_PARAM, ""));
 
     //Create & store URL
-    settings.put(DATABASE_URL, "jdbc:postgresql://" + connSpec.getHosts() + "/" + connSpec.getDatabase());
+    settings.put(DATABASE_URL, "jdbc:pgsql://" + connSpec.getHosts() + "/" + connSpec.getDatabase());
 
     return settings;
   }
 
   /*
-   * URL Pattern jdbc:postgresql:(?://((?:[a-zA-Z0-9\-\.]+|\[[0-9a-f\:]+\])(?:\:(?:\d+))?(?:,(?:[a-zA-Z0-9\-\.]+|\[[0-9a-f\:]+\])(?:\:(?:\d+))?)*)/)?(\w+)(?:\?(.*))?
+   * URL Pattern jdbc:pgsql:(?://((?:[a-zA-Z0-9\-\.]+|\[[0-9a-f\:]+\])(?:\:(?:\d+))?(?:,(?:[a-zA-Z0-9\-\.]+|\[[0-9a-f\:]+\])(?:\:(?:\d+))?)*)/)?(\w+)(?:\?(.*))?
    *  Capturing Groups:
    *    1 = (host name, IPv4, IPv6 : port) pairs  (optional)
    *    2 = database name         (required)
    *    3 = parameters            (optional)
    */
   private static final Pattern URL_PATTERN =
-      Pattern.compile("jdbc:postgresql:(?://((?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?(?:,(?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?)*)/)?((?:\\w|-|_)+)(?:[\\?\\&](.*))?");
+      Pattern.compile("jdbc:pgsql:(?://((?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?(?:,(?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?)*)/)?((?:\\w|-|_)+)(?:[\\?\\&](.*))?");
 
   private static final Pattern ADDRESS_PATTERN = Pattern.compile("(?:([a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(\\d+))?)");
 

--- a/src/test/java/com/impossibl/postgres/jdbc/DriverTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/DriverTest.java
@@ -55,24 +55,24 @@ public class DriverTest {
     assertNotNull(drv);
 
     // These are always correct
-    verifyUrl(drv, "jdbc:postgresql:test", "test", "localhost", 5432);
-    verifyUrl(drv, "jdbc:postgresql://localhost/test", "test", "localhost", 5432);
-    verifyUrl(drv, "jdbc:postgresql://localhost:5432/test", "test", "localhost", 5432);
-    verifyUrl(drv, "jdbc:postgresql://127.0.0.1/anydbname", "anydbname", "127.0.0.1", 5432);
-    verifyUrl(drv, "jdbc:postgresql://127.0.0.1:5433/hidden", "hidden", "127.0.0.1", 5433);
-    verifyUrl(drv, "jdbc:postgresql://[::1]:5740/db", "db", "0:0:0:0:0:0:0:1", 5740);
+    verifyUrl(drv, "jdbc:pgsql:test", "test", "localhost", 5432);
+    verifyUrl(drv, "jdbc:pgsql://localhost/test", "test", "localhost", 5432);
+    verifyUrl(drv, "jdbc:pgsql://localhost:5432/test", "test", "localhost", 5432);
+    verifyUrl(drv, "jdbc:pgsql://127.0.0.1/anydbname", "anydbname", "127.0.0.1", 5432);
+    verifyUrl(drv, "jdbc:pgsql://127.0.0.1:5433/hidden", "hidden", "127.0.0.1", 5433);
+    verifyUrl(drv, "jdbc:pgsql://[::1]:5740/db", "db", "0:0:0:0:0:0:0:1", 5740);
 
     // Badly formatted url's
     assertTrue(!drv.acceptsURL("jdbc:postgres:test"));
     assertTrue(!drv.acceptsURL("postgresql:test"));
     assertTrue(!drv.acceptsURL("db"));
-    assertTrue(!drv.acceptsURL("jdbc:postgresql://localhost:5432a/test"));
+    assertTrue(!drv.acceptsURL("jdbc:pgsql://localhost:5432a/test"));
 
     // failover urls
-    verifyUrl(drv, "jdbc:postgresql://localhost,127.0.0.1:5432/test", "test", "localhost", 5432, "127.0.0.1", 5432);
-    verifyUrl(drv, "jdbc:postgresql://localhost:5433,127.0.0.1:5432/test", "test", "localhost", 5433, "127.0.0.1", 5432);
-    verifyUrl(drv, "jdbc:postgresql://[::1],[::1]:5432/db", "db", "0:0:0:0:0:0:0:1", 5432, "0:0:0:0:0:0:0:1", 5432);
-    verifyUrl(drv, "jdbc:postgresql://[::1]:5740,127.0.0.1:5432/db", "db", "0:0:0:0:0:0:0:1", 5740, "127.0.0.1", 5432);
+    verifyUrl(drv, "jdbc:pgsql://localhost,127.0.0.1:5432/test", "test", "localhost", 5432, "127.0.0.1", 5432);
+    verifyUrl(drv, "jdbc:pgsql://localhost:5433,127.0.0.1:5432/test", "test", "localhost", 5433, "127.0.0.1", 5432);
+    verifyUrl(drv, "jdbc:pgsql://[::1],[::1]:5432/db", "db", "0:0:0:0:0:0:0:1", 5432, "0:0:0:0:0:0:0:1", 5432);
+    verifyUrl(drv, "jdbc:pgsql://[::1]:5740,127.0.0.1:5432/db", "db", "0:0:0:0:0:0:0:1", 5740, "127.0.0.1", 5432);
   }
 
   private void verifyUrl(PGDriver drv, String url, String dbName, Object... hosts) throws Exception {
@@ -106,7 +106,7 @@ public class DriverTest {
     con.close();
 
     // Test with failover url
-    String url = "jdbc:postgresql://invalidhost.not.here," + TestUtil.getServer() + ":" + TestUtil.getPort() + "/" + TestUtil.getDatabase();
+    String url = "jdbc:pgsql://invalidhost.not.here," + TestUtil.getServer() + ":" + TestUtil.getPort() + "/" + TestUtil.getDatabase();
     con = DriverManager.getConnection(url, TestUtil.getUser(), TestUtil.getPassword());
     assertNotNull(con);
     con.close();

--- a/src/test/java/com/impossibl/postgres/jdbc/TestUtil.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/TestUtil.java
@@ -54,10 +54,10 @@ public class TestUtil {
     }
 
     if (!"5432".equals(getPort())) {
-      return "jdbc:postgresql://" + getServer() + ":" + getPort() + "/" + getDatabase() + query;
+      return "jdbc:pgsql://" + getServer() + ":" + getPort() + "/" + getDatabase() + query;
     }
     else {
-      return "jdbc:postgresql://" + getServer() + "/" + getDatabase() + query;
+      return "jdbc:pgsql://" + getServer() + "/" + getDatabase() + query;
     }
   }
 

--- a/src/test/resources/ssltest.properties
+++ b/src/test/resources/ssltest.properties
@@ -5,25 +5,25 @@ certdir=src/test/resources/certdir
 ssloff=
 ssloffprefix=
 
-sslhostnossl=jdbc:postgresql://127.0.0.1:5432/hostnossldb?ssl.password=sslpwd
+sslhostnossl=jdbc:pgsql://127.0.0.1:5432/hostnossldb?ssl.password=sslpwd
 sslhostnosslprefix=
 
-sslhostgh=jdbc:postgresql://localhost:5432/hostdb?ssl.password=sslpwd
+sslhostgh=jdbc:pgsql://localhost:5432/hostdb?ssl.password=sslpwd
 sslhostghprefix=
-sslhostbh=jdbc:postgresql://127.0.0.1:5432/hostdb?ssl.password=sslpwd
+sslhostbh=jdbc:pgsql://127.0.0.1:5432/hostdb?ssl.password=sslpwd
 sslhostbhprefix=
 
-sslhostsslgh=jdbc:postgresql://localhost:5432/hostssldb?ssl.password=sslpwd
+sslhostsslgh=jdbc:pgsql://localhost:5432/hostssldb?ssl.password=sslpwd
 sslhostsslghprefix=
-sslhostsslbh=jdbc:postgresql://127.0.0.1:5432/hostssldb?ssl.password=sslpwd
+sslhostsslbh=jdbc:pgsql://127.0.0.1:5432/hostssldb?ssl.password=sslpwd
 sslhostsslbhprefix=
 
-sslhostsslcertgh=jdbc:postgresql://localhost:5432/hostsslcertdb?ssl.password=sslpwd
+sslhostsslcertgh=jdbc:pgsql://localhost:5432/hostsslcertdb?ssl.password=sslpwd
 sslhostsslcertghprefix=
-sslhostsslcertbh=jdbc:postgresql://127.0.0.1:5432/hostsslcertdb?ssl.password=sslpwd
+sslhostsslcertbh=jdbc:pgsql://127.0.0.1:5432/hostsslcertdb?ssl.password=sslpwd
 sslhostsslcertbhprefix=
 
-sslcertgh=jdbc:postgresql://localhost:5432/certdb?ssl.password=sslpwd
+sslcertgh=jdbc:pgsql://localhost:5432/certdb?ssl.password=sslpwd
 sslcertghprefix=
-sslcertbh=jdbc:postgresql://127.0.0.1:5432/certdb?ssl.password=sslpwd
+sslcertbh=jdbc:pgsql://127.0.0.1:5432/certdb?ssl.password=sslpwd
 sslcertbhprefix=


### PR DESCRIPTION
The original driver uses jdbc:postgresql and DriverManager in order to create connections. This can lead to problems if both the original driver and pgjdbc-ng are deployed.

Hence change the URL to jdbc:pgsql in order to not cause collisions.

DriverManager is really a broken concept :/
