### PR TITLE
Much more efficient statement name generation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>netty</artifactId>
 			<version>3.8.0.Final</version>
 		</dependency>
+        <dependency>
+        	<groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+        	<artifactId>concurrentlinkedhashmap-lru</artifactId>
+        	<version>1.4</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -270,9 +270,7 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
    * @return New unique statement name
    */
   String getNextStatementName() {
-    StringBuilder sb = new StringBuilder("0000000000000000");
-    sb.append(Long.toHexString(++statementId));
-    return sb.substring(sb.length() - 16);
+    return Long.toHexString(++statementId);
   }
 
   /**
@@ -281,7 +279,7 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
    * @return New unique portal name
    */
   String getNextPortalName() {
-    return String.format("%016X", ++portalId);
+    return Long.toHexString(++portalId);
   }
 
   /**

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -270,7 +270,9 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
    * @return New unique statement name
    */
   String getNextStatementName() {
-    return String.format("%016X", ++statementId);
+    StringBuilder sb = new StringBuilder("0000000000000000");
+    sb.append(Long.toHexString(++statementId));
+    return sb.substring(sb.length() - 16);
   }
 
   /**

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
@@ -58,6 +58,14 @@ public class SQLText {
     root = parse(sqlText);
   }
 
+  private SQLText(MultiStatementNode copyRoot) {
+    root = copyRoot;
+  }
+
+  public SQLText copy() {
+    return new SQLText((MultiStatementNode) root.copy());
+  }
+
   public int getStatementCount() {
     if (root == null)
       return 0;

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
@@ -54,6 +54,10 @@ public class SQLTextTree {
       this.endPos = endPos;
     }
 
+    public Node copy() {
+      return this;
+    }
+
     public int getStartPos() {
       return startPos;
     }
@@ -113,6 +117,23 @@ public class SQLTextTree {
     public CompositeNode(List<Node> nodes, int startPos) {
       super(startPos, -1);
       this.nodes = nodes;
+    }
+
+    @Override
+    public Node copy() {
+      CompositeNode clone = new CompositeNode(getStartPos());
+      clone.nodes = new ArrayList<>(nodes.size());
+      for (Node node : nodes) {
+        clone.nodes.add((Node) node.copy());
+      }
+      return clone;
+    }
+
+    protected void copyNodes(CompositeNode newNode) {
+      newNode.nodes = new ArrayList<>(nodes.size());
+      for (Node node : nodes) {
+        newNode.nodes.add((Node) node.copy());
+      }
     }
 
     @Override
@@ -234,6 +255,13 @@ public class SQLTextTree {
     }
 
     @Override
+    public Node copy() {
+      MultiStatementNode clone = new MultiStatementNode(getStartPos());
+      copyNodes(clone);
+      return clone;
+    }
+
+    @Override
     void build(StringBuilder builder) {
 
       Iterator<Node> nodeIter = iterator();
@@ -252,12 +280,25 @@ public class SQLTextTree {
       super(startPos);
     }
 
+    @Override
+    public Node copy() {
+      StatementNode clone = new StatementNode(getStartPos());
+      copyNodes(clone);
+      return clone;
+    }
   }
 
   public static class EscapeNode extends CompositeNode {
 
     public EscapeNode(int startPos) {
       super(startPos);
+    }
+
+    @Override
+    public Node copy() {
+      EscapeNode clone = new EscapeNode(getStartPos());
+      copyNodes(clone);
+      return clone;
     }
 
     @Override
@@ -276,6 +317,13 @@ public class SQLTextTree {
 
     public ParenGroupNode(int startPos) {
       super(startPos);
+    }
+
+    @Override
+    public Node copy() {
+      ParenGroupNode clone = new ParenGroupNode(getStartPos());
+      copyNodes(clone);
+      return clone;
     }
 
     @Override
@@ -334,6 +382,11 @@ public class SQLTextTree {
     ParameterPiece(int idx, int pos) {
       super("$" + idx, pos);
       this.idx = idx;
+    }
+
+    @Override
+    public Node copy() {
+      return new ParameterPiece(idx, getStartPos());
     }
 
     public int getIdx() {

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
@@ -122,10 +122,7 @@ public class SQLTextTree {
     @Override
     public Node copy() {
       CompositeNode clone = new CompositeNode(getStartPos());
-      clone.nodes = new ArrayList<>(nodes.size());
-      for (Node node : nodes) {
-        clone.nodes.add((Node) node.copy());
-      }
+      copyNodes(clone);
       return clone;
     }
 


### PR DESCRIPTION
This is a trivial change, but in a test in which I was creating 100,000 prepared statements, the `getNextStatementName` went from consuming 8.8% of the measured time to not even being registered by the profiler.  
