### PR TITLE
Introduce a parsed SQL cache for SQLText hierarchies.

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -29,6 +29,7 @@
 package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.system.Context;
+import com.impossibl.postgres.system.Settings;
 
 import java.io.PrintWriter;
 import java.sql.SQLException;
@@ -51,6 +52,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
   private String user;
   private String password;
   private boolean housekeeper;
+  private int parsedSqlCache;
 
   /**
    * Constructor
@@ -63,6 +65,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
     this.user = null;
     this.password = null;
     this.housekeeper = true;
+    this.parsedSqlCache = 250;
   }
 
   /**
@@ -198,6 +201,24 @@ public abstract class AbstractDataSource implements CommonDataSource {
   }
 
   /**
+   * Get the size of the parsed SQL cache.
+   * @return the number of SQL statements' parsed structures allowed in the cache
+   */
+  public int getParsedSqlCacheSize() {
+    return parsedSqlCache;
+  }
+
+  /**
+   * Set the size of the parsed SQL cache.  A value of 0 will disable
+   * the cache.  This value is only honored before the creation of the
+   * first Connection, changing it at a later time will have no effect.
+   * @param cacheSize the number of SQL statements' parsed structures to cache
+   */
+  public void setParsedSqlCacheSize(int cacheSize) {
+    parsedSqlCache = cacheSize;
+  }
+
+  /**
    * Create a connection
    * @param u The user name
    * @param p The password
@@ -231,6 +252,8 @@ public abstract class AbstractDataSource implements CommonDataSource {
     Housekeeper hk = null;
     if (housekeeper)
       hk = new ThreadedHousekeeper();
+
+    props.put(Settings.PARSED_SQL_CACHE, parsedSqlCache);
 
     return ConnectionUtil.createConnection(url, props, hk);
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -67,6 +67,7 @@ import static com.impossibl.postgres.jdbc.SQLTextUtils.isTrue;
 import static com.impossibl.postgres.jdbc.SQLTextUtils.prependCursorDeclaration;
 import static com.impossibl.postgres.protocol.TransactionStatus.Idle;
 import static com.impossibl.postgres.system.Settings.CONNECTION_READONLY;
+import static com.impossibl.postgres.system.Settings.PARSED_SQL_CACHE;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -92,6 +93,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -165,11 +167,26 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
   final Housekeeper housekeeper;
   final Object cleanupKey;
 
+  static Map<String, SQLText> parsedSqlCache;
 
   PGConnectionImpl(SocketAddress address, Properties settings, Housekeeper housekeeper) throws IOException, NoticeException {
     super(address, settings, Collections.<String, Class<?>>emptyMap());
 
     this.activeStatements = new ArrayList<>();
+
+    final int sqlCacheSize = getSetting(PARSED_SQL_CACHE, 250);
+    if (sqlCacheSize > 0) {
+      synchronized (PGConnectionImpl.class) {
+        if (parsedSqlCache == null) {
+          parsedSqlCache = Collections.synchronizedMap(new LinkedHashMap<String, SQLText>(sqlCacheSize + 1, 1.1f, true) {
+            private static final long serialVersionUID = 1L;
+            protected boolean removeEldestEntry(Map.Entry<String, SQLText> eldest) {
+              return size() > sqlCacheSize;
+            }
+          });
+        }
+      }
+    }
 
     this.housekeeper = housekeeper;
     if (this.housekeeper != null)
@@ -335,8 +352,19 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
   }
 
   SQLText parseSQL(String sqlText) throws SQLException {
+
     try {
-      return new SQLText(sqlText);
+      if (parsedSqlCache == null) {
+        return new SQLText(sqlText);
+      }
+
+      SQLText parsedSql = parsedSqlCache.get(sqlText);
+      if (parsedSql == null) {
+        parsedSql = new SQLText(sqlText);
+        parsedSqlCache.put(sqlText, parsedSql);
+      }
+
+      return parsedSql.copy();
     }
     catch (ParseException e) {
 

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
@@ -58,6 +58,14 @@ public class SQLText {
     root = parse(sqlText);
   }
 
+  private SQLText(MultiStatementNode copyRoot) {
+    root = copyRoot;
+  }
+
+  public SQLText copy() {
+    return new SQLText((MultiStatementNode) root.copy());
+  }
+
   public int getStatementCount() {
     if (root == null)
       return 0;

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
@@ -54,6 +54,10 @@ public class SQLTextTree {
       this.endPos = endPos;
     }
 
+    public Node copy() {
+      return this;
+    }
+
     public int getStartPos() {
       return startPos;
     }
@@ -113,6 +117,20 @@ public class SQLTextTree {
     public CompositeNode(List<Node> nodes, int startPos) {
       super(startPos, -1);
       this.nodes = nodes;
+    }
+
+    @Override
+    public Node copy() {
+      CompositeNode clone = new CompositeNode(getStartPos());
+      copyNodes(clone);
+      return clone;
+    }
+
+    protected void copyNodes(CompositeNode newNode) {
+      newNode.nodes = new ArrayList<>(nodes.size());
+      for (Node node : nodes) {
+        newNode.nodes.add((Node) node.copy());
+      }
     }
 
     @Override
@@ -234,6 +252,13 @@ public class SQLTextTree {
     }
 
     @Override
+    public Node copy() {
+      MultiStatementNode clone = new MultiStatementNode(getStartPos());
+      copyNodes(clone);
+      return clone;
+    }
+
+    @Override
     void build(StringBuilder builder) {
 
       Iterator<Node> nodeIter = iterator();
@@ -252,12 +277,25 @@ public class SQLTextTree {
       super(startPos);
     }
 
+    @Override
+    public Node copy() {
+      StatementNode clone = new StatementNode(getStartPos());
+      copyNodes(clone);
+      return clone;
+    }
   }
 
   public static class EscapeNode extends CompositeNode {
 
     public EscapeNode(int startPos) {
       super(startPos);
+    }
+
+    @Override
+    public Node copy() {
+      EscapeNode clone = new EscapeNode(getStartPos());
+      copyNodes(clone);
+      return clone;
     }
 
     @Override
@@ -276,6 +314,13 @@ public class SQLTextTree {
 
     public ParenGroupNode(int startPos) {
       super(startPos);
+    }
+
+    @Override
+    public Node copy() {
+      ParenGroupNode clone = new ParenGroupNode(getStartPos());
+      copyNodes(clone);
+      return clone;
     }
 
     @Override
@@ -334,6 +379,11 @@ public class SQLTextTree {
     ParameterPiece(int idx, int pos) {
       super("$" + idx, pos);
       this.idx = idx;
+    }
+
+    @Override
+    public Node copy() {
+      return new ParameterPiece(idx, getStartPos());
     }
 
     public int getIdx() {

--- a/src/main/java/com/impossibl/postgres/system/Settings.java
+++ b/src/main/java/com/impossibl/postgres/system/Settings.java
@@ -40,6 +40,8 @@ public class Settings {
 
   public static final String CONNECTION_READONLY = "readOnly";
 
+  public static final String PARSED_SQL_CACHE = "parsedSqlCacheSize";
+
   public static final String CLIENT_ENCODING = "client_encoding";
   public static final String APPLICATION_NAME = "application_name";
 

--- a/src/test/java/com/impossibl/postgres/jdbc/DriverTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/DriverTest.java
@@ -28,13 +28,17 @@
  */
 package com.impossibl.postgres.jdbc;
 
+import com.impossibl.postgres.system.Settings;
+
 import java.net.InetSocketAddress;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.util.Properties;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
 import static org.junit.Assert.*;
 
 /*
@@ -134,4 +138,13 @@ public class DriverTest {
     con.close();
   }
 
+  /*
+   * Test that the parsedSqlCacheSize property works.
+   */
+  @Test
+  public void testParsedSqlCacheSize() throws Exception {
+    ConnectionUtil.ConnectionSpecifier connSpec = ConnectionUtil.parseURL("jdbc:pgsql://localhost/test?parsedSqlCacheSize=100");
+    Properties parameters = connSpec.getParameters();
+    assertSame(100, Integer.parseInt(parameters.getProperty(Settings.PARSED_SQL_CACHE)));
+  }
 }


### PR DESCRIPTION
Ok this is a freshened-up pull request.  I added the ability to configure the cache size and removed the dependency on Google ConcurrentLinkedHashMap.  Note also that this does not use Java serialization, it uses custom code to perform the SQLText deep-copy which performs almost an order of magnitude faster than standard (notoriously slow) Java serialization.

Unlike the (forthcoming) prepared statement cache which will default to 'off', the parsed SQL cache defaults to 'on' because it not only improves performance, with no side-effects, but also reduces GC pressure which we should view as a good thing.  One of the primary goals of Netty4 was reducing GC pressure, because in a long-running high-performance system it starts to become an issue.
