### PR TITLE
Implement prepared statement caching.

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -53,6 +53,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
   private String password;
   private boolean housekeeper;
   private int parsedSqlCache;
+  private int prepStmtCacheSize;
 
   /**
    * Constructor
@@ -66,6 +67,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
     this.password = null;
     this.housekeeper = true;
     this.parsedSqlCache = 250;
+    this.prepStmtCacheSize = 0;
   }
 
   /**
@@ -218,6 +220,23 @@ public abstract class AbstractDataSource implements CommonDataSource {
     parsedSqlCache = cacheSize;
   }
 
+  /*
+   * Get the size of the PreparedStatment cache.
+   * @return the maximum number of PreparedStatements cached per connection
+   */
+  public int getPreparedStatementCacheSize() {
+    return prepStmtCacheSize;
+  }
+
+  /**
+   * Set the size of the PreparedStatment cache. A value of 0 will disable
+   * the cache.
+   * @return the maximum number of PreparedStatements cached per connection
+   */
+  public void setPreparedStatementCacheSize(int cacheSize) {
+    this.prepStmtCacheSize = cacheSize;
+  }
+
   /**
    * Create a connection
    * @param u The user name
@@ -254,6 +273,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
       hk = new ThreadedHousekeeper();
 
     props.put(Settings.PARSED_SQL_CACHE, parsedSqlCache);
+    props.put(Settings.PREPARED_STATEMENT_CACHE, prepStmtCacheSize);
 
     return ConnectionUtil.createConnection(url, props, hk);
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/LruStatementCache.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/LruStatementCache.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.jdbc;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Last Recently Used PreparedStatement cache with eviction listener support
+ * implementation.
+ * 
+ * @author Brett Wooldridge
+ */
+class LruStatementCache {
+
+  /**
+   * The maxSize of the cache.
+   */
+  private final int maxSize;
+
+  /**
+   * We use a LinkedHashMap with _access order_ specified in the constructor.
+   * See LinkedHashMap documentation.
+   */
+  private final LinkedHashMap<CacheKey, PGPreparedStatement> cache;
+
+  /**
+   * A listener concerned with prepared statement cache evictions.
+   */
+  private final LruEvictionListener evictionListner;
+
+  /**
+   * See the LinkedHashMap documentation. We maintain our own size here, rather than
+   * calling size(), because size() on a LinkedHashMap is proportional in time O(n)
+   * with the size of the collection. Tracking size ourselves provides O(1) access.
+   */
+  private volatile int size;
+
+  /**
+   * A flag that is set during clear operations to prevent statements that are
+   * closing from coming back into the cache.
+   */
+  private AtomicBoolean clearInProgress;
+
+  public LruStatementCache(int maxSize, LruEvictionListener evictionListener) {
+    this.maxSize = maxSize;
+    this.cache = new LinkedHashMap<CacheKey, PGPreparedStatement>(maxSize + 1, 1.1f, true);
+    this.evictionListner = evictionListener;
+    this.clearInProgress = new AtomicBoolean();
+  }
+
+  /**
+   * The provided key contains all pertinent information such as SQL statement,
+   * auto-generated keys, cursor holdability, etc. It is a complete key for a
+   * cached statement.  If the prepared statement exists in the cache it is
+   * removed while in use, and returned later when the statement is closed.
+   * 
+   * @param key the calculated cache key
+   * @return the cached PGPreparedStatement statement, or null
+   */
+  public PGPreparedStatement borrowStatement(CacheKey key) {
+    PGPreparedStatement statement = cache.remove(key);
+    if (statement != null) {
+      --size;
+      return statement;
+    }
+
+    return null;
+  }
+
+  /**
+   * Return a statement to the cache, this is called when a statement is
+   * closed.  If there is an existing cached statement for the same SQL,
+   * the existing entry is evicted and replaced with this returning
+   * statement (it's "fresher").
+   * 
+   * @param key a prepared statement calculated key
+   * @return a prepared statement
+   */
+  public void returnStatement(CacheKey key, PGPreparedStatement statement) {
+    if (clearInProgress.get() || maxSize < 1) {
+      return;
+    }
+
+    PGPreparedStatement cached = cache.get(key);
+    if (cached == null) {
+      cache.put(key, statement);
+      size++;
+    }
+    else {
+      evictionListner.onEviction(cached);
+      cache.put(key, statement);
+    }
+
+    // If the size is exceeded, we will evict one (or more)
+    // statements until the max level is again reached.
+    if (size > maxSize) {
+      tryEviction();
+    }
+  }
+
+  /**
+   * Evict all statements from the cache. This likely happens on connection close.
+   */
+  protected void clear() {
+    if (clearInProgress.compareAndSet(false, true)) {
+      try {
+        Iterator<Entry<CacheKey, PGPreparedStatement>> it = cache.entrySet().iterator();
+        while (it.hasNext()) {
+          Entry<CacheKey, PGPreparedStatement> entry = it.next();
+          PGPreparedStatement statement = entry.getValue();
+          it.remove();
+          evictionListner.onEviction(statement);
+        }
+        cache.clear();
+        size = 0;
+      }
+      finally {
+        clearInProgress.set(false);
+      }
+    }
+  }
+
+  /**
+   * Try to evict statements from the cache until the cache is reduced to maxSize.
+   */
+  private void tryEviction() {
+    // Iteration order of the LinkedHashMap is from LRU to MRU
+    Iterator<Entry<CacheKey, PGPreparedStatement>> it = cache.entrySet().iterator();
+    while (it.hasNext() && size > maxSize) {
+      Entry<CacheKey, PGPreparedStatement> entry = it.next();
+      PGPreparedStatement statement = entry.getValue();
+      it.remove();
+      size--;
+      evictionListner.onEviction(statement);
+    }
+  }
+
+  /**
+   * Eviction listener interface for {@link LruStatementCache}.
+   */
+  interface LruEvictionListener {
+    void onEviction(PGPreparedStatement value);
+  }
+
+  static final class CacheKey {
+    // All of these attributes must match a proposed statement before the
+    // statement can be considered "the same" and delivered from the cache.
+    private String sql;
+    private int resultSetType;
+    private int resultSetConcurrency;
+    private int resultSetHoldability;
+    private boolean autoGeneratedKeys;
+    private String[] columnNames;
+
+    public CacheKey(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability, String[] columnNames) {
+      this.sql = sql;
+      this.resultSetType = resultSetType;
+      this.resultSetConcurrency = resultSetConcurrency;
+      this.resultSetHoldability = resultSetHoldability;
+      if (columnNames != null) {
+        this.autoGeneratedKeys = true;
+        this.columnNames = new String[columnNames.length];
+        System.arraycopy(columnNames, 0, this.columnNames, 0, columnNames.length);
+      }
+    }
+
+    /**
+     * Overridden equals() that takes all PreparedStatement attributes into account.
+     */
+    public boolean equals(Object obj) {
+      if (!(obj instanceof CacheKey)) {
+        return false;
+      }
+
+      CacheKey otherKey = (CacheKey) obj;
+      if (!sql.equals(otherKey.sql)) {
+        return false;
+      }
+      else if (resultSetType != otherKey.resultSetType) {
+        return false;
+      }
+      else if (resultSetConcurrency != otherKey.resultSetConcurrency) {
+        return false;
+      }
+      else if (!Arrays.equals(columnNames, otherKey.columnNames)) {
+        return false;
+      }
+      else if (autoGeneratedKeys != otherKey.autoGeneratedKeys) {
+        return false;
+      }
+      else if (resultSetHoldability != otherKey.resultSetHoldability) {
+        return false;
+      }
+
+      return true;
+    }
+
+    public int hashCode() {
+      return sql != null ? sql.hashCode() : System.identityHashCode(this);
+    }
+  }
+}

--- a/src/main/java/com/impossibl/postgres/system/Settings.java
+++ b/src/main/java/com/impossibl/postgres/system/Settings.java
@@ -41,6 +41,7 @@ public class Settings {
   public static final String CONNECTION_READONLY = "readOnly";
 
   public static final String PARSED_SQL_CACHE = "parsedSqlCacheSize";
+  public static final String PREPARED_STATEMENT_CACHE = "preparedStatementCacheSize";
 
   public static final String CLIENT_ENCODING = "client_encoding";
   public static final String APPLICATION_NAME = "application_name";

--- a/src/test/java/com/impossibl/postgres/jdbc/ArrayTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/ArrayTest.java
@@ -133,6 +133,7 @@ public class ArrayTest {
     String[] strarr = (String[]) arr.getArray();
     assertEquals("abc", strarr[0]);
     assertEquals("def", strarr[1]);
+    ps.close();
   }
 
   @Test
@@ -450,6 +451,7 @@ public class ArrayTest {
     assertEquals(2, i[0][1].intValue());
     assertEquals(3, i[1][0].intValue());
     assertEquals(4, i[1][1].intValue());
+    pstmt.close();
   }
 
   @Test
@@ -470,6 +472,7 @@ public class ArrayTest {
     assertEquals(0, out[0].intValue());
     assertEquals(-1, out[1].intValue());
     assertEquals(2, out[2].intValue());
+    pstmt.close();
   }
 
   @Test
@@ -493,6 +496,7 @@ public class ArrayTest {
     assertEquals("", out[0][1]);
     assertEquals("\\", out[1][0]);
     assertEquals("\"\\'z", out[1][1]);
+    pstmt.close();
   }
 
   @Test
@@ -514,6 +518,7 @@ public class ArrayTest {
     assertEquals(2, out.length);
     assertNull(out[0]);
     assertNull(out[1]);
+    pstmt.close();
   }
 
   @Test
@@ -532,6 +537,7 @@ public class ArrayTest {
 
     ResultSet arrRs = arr.getResultSet();
     assertFalse(arrRs.next());
+    pstmt.close();
   }
 
   @Test

--- a/src/test/java/com/impossibl/postgres/jdbc/CursorFetchTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/CursorFetchTest.java
@@ -105,6 +105,7 @@ public class CursorFetchTest {
 
       assertEquals("total query size error with fetch size " + testSizes[i], 100, count);
     }
+    stmt.close();
   }
 
   // Similar, but for scrollable resultsets.


### PR DESCRIPTION
This is a pull request that implements #58 (Implement driver-side prepared statement cache).

The largest block of code below is the class `LruStatementCache`.  This class is a _modified_ version of a prepared statement cache that I wrote for the [Bitronix JTA Transaction Manager](https://github.com/bitronix/btm).  The BTM original class is [here](https://github.com/bitronix/btm/blob/master/btm/src/main/java/bitronix/tm/resource/jdbc/LruStatementCache.java) and has been in use for several years, so it's pretty solid (no reported bugs).  It is Apache Licensed, and I wrote it, so there should be no issue using it.

The performance numbers for this change are as follows for 100,000 prepare statements:

```
Original                         : 27945ms
Original+parsed SQL cache (PSC)  : 11721ms
Original+PSC+statement cache     : 56ms
```

<sup>1</sup> The [parsed SQL cache](https://github.com/impossibl/pgjdbc-ng/pull/62) was recently pulled.

The prepared statement cache is per-connection.  PGPreparedStatements are "single-use", by which I mean ... when a statement is prepared, if it exists in the cache it is removed from the cache and re-used, during which time if the client re-prepares the same statement it is _not_ found in the cache and a new PGPreparedStatement will be created.  When a PGPreparedStatement is closed, it is returned to the cache.  The cache is this case is acting more like a "pool" (a "pool" is technically still a "cache").

The next biggest change after the inclusion of `LruStatementCache` are the changes to `PGConnectionImpl`. The `PGConnectionImpl.java` diffs below are a little difficult to read as rendered, but in fact are rather simple in nature.  I suggest opening `PGConnectionImpl.java` in a separate browser window and following the diffs along in the full source for readability.

All tests are passing with both the cache turned on and with the cache turned off.  There are two changes to unit tests included here which were leaking statements and causing noise in the test output, so I added close() calls to those tests' statements.
