### PR TITLE
Fix NPE in the PGPreparedStatementDelegator due to unassigned class member

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatementDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatementDelegator.java
@@ -64,6 +64,7 @@ public class PGPreparedStatementDelegator extends PGStatementDelegator implement
    */
   public PGPreparedStatementDelegator(PGPooledConnectionDelegator owner, PreparedStatement delegator) {
     super(owner, delegator);
+    this.owner = owner;
     this.delegator = delegator;
   }
 


### PR DESCRIPTION
Using the XADataSource I was getting an NPE from prepared statements, this uninitialized member was the cause.
