### PR TITLE
Update Maven dependencies. Also update plugin dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
 		<project.osgi.imports>io.netty.buffer,io.netty.channel,io.netty.channel.nio,io.netty.channel.socket,io.netty.channel.socket.nio,io.netty.bootstrap,io.netty.util,io.netty.util.concurrent,io.netty.handler.codec,io.netty.handler.ssl</project.osgi.imports>
 	</properties>
 
+	<prerequisites>
+		<maven>3.1</maven>
+	</prerequisites>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -64,7 +68,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.0.15.Final</version>
+			<version>4.0.19.Final</version>
 		</dependency>
 	</dependencies>
 
@@ -73,7 +77,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.1</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
@@ -95,7 +99,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.1</version>
+				<version>2.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -123,7 +127,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.14.1</version>
+				<version>2.17</version>
 				<configuration>
 					<excludes>
 						<exclude>**/PerformanceTest.java</exclude>
@@ -173,13 +177,14 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.10</version>
+					<version>2.12.1</version>
 					<configuration>
 						<configLocation>src/support/checkstyle.xml</configLocation>
 						<sourceDirectory>.</sourceDirectory>
 						<consoleOutput>true</consoleOutput>
 						<failsOnError>true</failsOnError>
 						<useFile />
+						<excludes>src/main/java/com/impossibl/postgres/utils/guava/**</excludes>
 					</configuration>
 					<executions>
 						<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.0.19.Final</version>
+			<version>4.0.20.Final</version>
 		</dependency>
 	</dependencies>
 
@@ -86,7 +86,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.8</version>
+				<version>1.9</version>
 				<executions>
 					<execution>
 						<id>parse-version</id>


### PR DESCRIPTION
Add a prerequisite for Maven version.
The output of the Maven versions plugin is more readable
with a minimal Maven version and 3.1 looks like a reasonable base
version.

Exclude the Guava classes from the checkstyle scan as they don't
respect the new checkstyle rules but we want to keep them in sync
with Guava's original classes.
