### PR TITLE
Remove some synchronized stuff

### DIFF
--- a/src/main/java/com/impossibl/postgres/datetime/ISODateFormat.java
+++ b/src/main/java/com/impossibl/postgres/datetime/ISODateFormat.java
@@ -125,7 +125,6 @@ public class ISODateFormat implements DateTimeFormat {
       String monthString;
       String dayString;
       String yearZeros = "0000";
-      StringBuffer timestampBuf;
 
       if (year < 1000) {
         // Add leading zeros
@@ -148,8 +147,8 @@ public class ISODateFormat implements DateTimeFormat {
         dayString = Integer.toString(day);
       }
 
-      // do a string buffer here instead.
-      timestampBuf = new StringBuffer(20);
+      // do a string builder here instead.
+      StringBuilder timestampBuf = new StringBuilder(20);
       timestampBuf.append(yearString);
       timestampBuf.append("-");
       timestampBuf.append(monthString);

--- a/src/main/java/com/impossibl/postgres/datetime/ISOTimeFormat.java
+++ b/src/main/java/com/impossibl/postgres/datetime/ISOTimeFormat.java
@@ -156,7 +156,6 @@ public class ISOTimeFormat implements DateTimeFormat {
       String secondString;
       String microsString;
       String zeros = "000000000";
-      StringBuffer timestampBuf;
 
       if (hour < 10) {
         hourString = "0" + hour;
@@ -196,8 +195,8 @@ public class ISOTimeFormat implements DateTimeFormat {
         microsString = new String(microsChar, 0, truncIndex + 1);
       }
 
-      // do a string buffer here instead.
-      timestampBuf = new StringBuffer(20 + microsString.length());
+      // do a string builder here instead.
+      StringBuilder timestampBuf = new StringBuilder(20 + microsString.length());
       timestampBuf.append(hourString);
       timestampBuf.append(":");
       timestampBuf.append(minuteString);

--- a/src/main/java/com/impossibl/postgres/datetime/ISOTimestampFormat.java
+++ b/src/main/java/com/impossibl/postgres/datetime/ISOTimestampFormat.java
@@ -138,7 +138,6 @@ public class ISOTimestampFormat implements DateTimeFormat {
       String microsString;
       String zeros = "000000000";
       String yearZeros = "0000";
-      StringBuffer timestampBuf;
 
       if (year < 1000) {
         // Add leading zeros
@@ -198,8 +197,8 @@ public class ISOTimestampFormat implements DateTimeFormat {
         microsString = new String(microsChar, 0, truncIndex + 1);
       }
 
-      // do a string buffer here instead.
-      timestampBuf = new StringBuffer(20 + microsString.length());
+      // do a string builder here instead.
+      StringBuilder timestampBuf = new StringBuilder(20 + microsString.length());
       timestampBuf.append(yearString);
       timestampBuf.append("-");
       timestampBuf.append(monthString);


### PR DESCRIPTION
- I removed a couple of simple StringBuilder which should have been StringBuffers
- I worked on TimestampUtils to remove the need of the synchronized keyword on a lot of methods. I think what I did is safe but it would be nice to have a second pair of eyes on it.

The only StringBuffer left in the code is used with appendReplacement and we cannot remove it.
