### PR TITLE
Fix #95 handle various orderings of IN, OUT, and INOUT parameters

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -124,17 +124,22 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
 
     sqlText = fullSqlText;
 
+    int reSeq = 1;
     for (int c = 0; c < allParameterModes.size(); ++c) {
 
       if (allParameterModes.get(c) == ParameterMode.Out) {
-        sqlText = sqlText.replaceAll("\\s*\\$" + (c + 1) + "\\s*", "");
+        sqlText = sqlText.replaceAll("\\s*\\$" + (c + 1) + "\\s*([,)])|\\s*\\$" + (c + 1) + "(\\s*)$", "$1$2");
+      }
+      else {  // re-sequence
+        sqlText = sqlText.replaceAll("\\s*\\$(" + (c + 1) + ")\\s*([,)])|\\s*\\$(" + (c + 1) + ")(\\s*)$", "\\$" + reSeq + "$2$4");
+        ++reSeq;
       }
 
     }
 
-    sqlText = sqlText.replaceAll("\\(\\s*,", "(");
-    sqlText = sqlText.replaceAll(",\\s*,", ",");
-    sqlText = sqlText.replaceAll(",\\s*\\)", ")");
+    sqlText = sqlText.replaceAll("\\(\\s*,+", "(");
+    sqlText = sqlText.replaceAll(",+\\s*,", ",");
+    sqlText = sqlText.replaceAll(",+\\s*\\)", ")");
 
     super.parseIfNeeded();
   }


### PR DESCRIPTION
The existing code only works if IN or INOUT parameters occur before OUT parameters.

Given the (processed) SQL `( SELECT * FROM test_somein_someout3 ($1,$2,$3))`, where `$1` and `$2` are OUT parameters and `$3` is an IN parameter, the former could would produce processed SQL like `( SELECT * FROM test_somein_someout3 ($3))` (OUT parameters must be removed).  The problem with this is that PostgreSQL is expecting placeholders to start from `$1`.  As placeholders are processed the need to be "re-sequenced".  If `$2` is removed, the remaining placeholders should be `($1,$2)` (with `$3`→`$2`).

The existing regexes also had other issues.  For example, if there were 10 or more parameters, `SELECT ... ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, the regex for `$1` would also match the `$1` of `$10` and redact it, leaving `$0`.  While the new regex is quite a bit more complex, it covers every variation I would think of.

The existing regexes also had other issues, for example, when redacting `$1`, `$2`, and `$3` out of `($1,$2,$3,$4)` the result was `(,,$1)` (after the re-sequencing fix).  The regexes were adjusted to remove multiple occurrences of sequential commas, so the result is a clean `($1)`.

Additional test cases were added to cover various orderings of parameter types.  Given the complexity of the regex changes, I'm not sure how easy it is for someone to review, but if you'd like to take a look...

I can expound more on what the regex is doing if requested.
