### PR TITLE
Fix #99 Code for handling command complete only allows one "part" after "ALTER"...

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
@@ -1114,6 +1114,10 @@ public class ProtocolImpl implements Protocol {
           command += " " + parts[1];
           rowsAffected = 0L;
         }
+        else if (parts.length == 3) {
+          command += " " + parts[1] + " " + parts[2];
+          rowsAffected = 0L;
+        }
         else {
           throw new IOException("error parsing command tag");
         }

--- a/src/test/java/com/impossibl/postgres/jdbc/StatementTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/StatementTest.java
@@ -211,6 +211,12 @@ public class StatementTest {
   }
 
   @Test
+  public void testAlterTable() throws SQLException {
+    Statement stmt = con.createStatement();
+    stmt.execute("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO pgjdbc");
+  }
+
+  @Test
   public void testNumericFunctions() throws SQLException {
     Statement stmt = con.createStatement();
 


### PR DESCRIPTION
... but in this case there are two, "DEFAULT" and "PRIVILEGES".
