### PR TITLE
Fix #95 cleaner implementation of parse/redaction.

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -81,6 +81,9 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.math.RoundingMode.HALF_UP;
 import static java.util.Collections.nCopies;
@@ -103,6 +106,10 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
   Map<String, Class<?>> typeMap;
   Boolean nullFlag;
 
+  private static final Map<Integer, Matcher> PARAM_REPLACE_REGEXES = new ConcurrentHashMap<>();
+  private static final Matcher CLEANUP_LEADING_COMMAS_REGEX = Pattern.compile("\\(\\s*,+").matcher("");
+  private static final Matcher CLEANUP_MIDDLE_COMMAS_REGEX = Pattern.compile(",\\s*,").matcher("");
+  private static final Matcher CLEANUP_TAILING_COMMAS_REGEX = Pattern.compile(",+\\s*\\)").matcher("");
 
   PGCallableStatement(PGConnectionImpl connection, int type, int concurrency, int holdability, String name, String sqlText, int parameterCount, String cursorName, boolean hasAssign) throws SQLException {
     super(connection, type, concurrency, holdability, name, sqlText, 0, cursorName);
@@ -124,19 +131,34 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
 
     sqlText = fullSqlText;
 
+    int reSeq = 1;
     for (int c = 0; c < allParameterModes.size(); ++c) {
 
-      if (allParameterModes.get(c) == ParameterMode.Out) {
-        sqlText = sqlText.replaceAll("\\s*\\$" + (c + 1) + "\\s*", "");
+      Matcher matcher = getMatcherForParameter(c + 1).reset(sqlText);
+      if (allParameterModes.get(c) == ParameterMode.Out) {  // redact parameter
+        sqlText = matcher.replaceFirst("$2");
       }
-
+      else {  // re-sequence parameter
+        sqlText = matcher.replaceFirst("\\$" + (reSeq++) + "$2");
+      }
     }
 
-    sqlText = sqlText.replaceAll("\\(\\s*,", "(");
-    sqlText = sqlText.replaceAll(",\\s*,", ",");
-    sqlText = sqlText.replaceAll(",\\s*\\)", ")");
+    sqlText = CLEANUP_LEADING_COMMAS_REGEX.reset(sqlText).replaceAll("(");
+    sqlText = CLEANUP_MIDDLE_COMMAS_REGEX.reset(sqlText).replaceAll(",");
+    sqlText = CLEANUP_TAILING_COMMAS_REGEX.reset(sqlText).replaceAll(")");
 
     super.parseIfNeeded();
+  }
+
+  private Matcher getMatcherForParameter(int paramIndex) {
+
+    Matcher matcher = PARAM_REPLACE_REGEXES.get(paramIndex);
+    if (matcher == null) {
+      matcher = Pattern.compile("\\s*\\$(" + paramIndex + ")\\s*([,)])").matcher("");
+      PARAM_REPLACE_REGEXES.put(paramIndex, matcher);
+    }
+
+    return matcher;
   }
 
   @Override


### PR DESCRIPTION
The existing code only works if IN or INOUT parameters occur before OUT parameters.

Given the (processed) SQL `( SELECT * FROM test_somein_someout3 ($1,$2,$3))`, where `$1` and `$2` are OUT parameters and `$3` is an IN parameter, the former could would produce processed SQL like `( SELECT * FROM test_somein_someout3 ($3))` (OUT parameters must be removed).  The problem with this is that PostgreSQL is expecting placeholders to start from `$1`.  As placeholders are processed the need to be "re-sequenced".  If `$2` is removed, the remaining placeholders should be `($1,$2)` (with `$3`→`$2`).

The existing regexes also had other issues.  For example, if there were 10 or more parameters, `SELECT ... ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, the regex for `$1` would also match the `$1` of `$10` and redact it, leaving `$0`.  While the new regex is quite a bit more complex, it covers every variation I would think of.

The existing regexes also had other issues, for example, when redacting `$1`, `$2`, and `$3` out of `($1,$2,$3,$4)` the result was `(,,$1)` (after the re-sequencing fix).  The regexes were adjusted to remove multiple occurrences of sequential commas, so the result is a clean `($1)`.

Additional test cases were added to cover various orderings of parameter types.  Regex are simplified over previous pull request.
