### PR TITLE
Fix #96 many implicit conversions to/from String were broken.

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -368,7 +368,7 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
     checkClosed();
     parameterIndex = mapToOutParameterIndex(parameterIndex);
 
-    return coerceToString(get(parameterIndex), connection);
+    return coerceToString(get(parameterIndex), getOutType(parameterIndex), connection);
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -592,7 +592,7 @@ class PGResultSet implements ResultSet {
     checkRow();
     checkColumnIndex(columnIndex);
 
-    return coerceToString(get(columnIndex), statement.connection);
+    return coerceToString(get(columnIndex), getType(columnIndex), statement.connection);
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/jdbc/PGSQLInputImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGSQLInputImpl.java
@@ -111,7 +111,7 @@ public class PGSQLInputImpl implements PGSQLInput {
 
   @Override
   public String readString() throws SQLException {
-    return coerceToString(getNextAttributeValue(), connection);
+    return coerceToString(getNextAttributeValue(), type, connection);
   }
 
   @Override
@@ -196,12 +196,12 @@ public class PGSQLInputImpl implements PGSQLInput {
 
   @Override
   public Reader readCharacterStream() throws SQLException {
-    return new StringReader(coerceToString(getNextAttributeValue(), connection));
+    return new StringReader(coerceToString(getNextAttributeValue(), type, connection));
   }
 
   @Override
   public InputStream readAsciiStream() throws SQLException {
-    return new ByteArrayInputStream(coerceToString(getNextAttributeValue(), connection).getBytes(US_ASCII));
+    return new ByteArrayInputStream(coerceToString(getNextAttributeValue(), type, connection).getBytes(US_ASCII));
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/system/procs/Strings.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Strings.java
@@ -168,7 +168,15 @@ public class Strings extends SimpleProcProvider {
     @Override
     public void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
 
-      buffer.append((String)val);
+      if (val instanceof String) {
+        buffer.append((String)val);
+      }
+      else if (val.getClass() == byte[].class) {
+        buffer.append(new String((byte[]) val, context.getCharset()));
+      }
+      else {
+        throw new IOException(val.getClass() + " cannot be encoded as a String");
+      }
     }
 
   }

--- a/src/test/java/com/impossibl/postgres/jdbc/IntervalTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/IntervalTest.java
@@ -36,6 +36,7 @@
 package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.api.data.Interval;
+import com.impossibl.postgres.types.Type;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -139,7 +140,9 @@ public class IntervalTest {
   @Test
   public void testIntervalToStringCoercion() throws SQLException {
     Interval interval = new Interval("1 year 3 months");
-    String coercedStringValue = SQLTypeUtils.coerceToString(interval, _conn.unwrap(PGConnectionImpl.class));
+    PGConnectionImpl pgConnectionImpl = _conn.unwrap(PGConnectionImpl.class);
+    Type type = pgConnectionImpl.getRegistry().loadType("Interval");
+    String coercedStringValue = SQLTypeUtils.coerceToString(interval, type, pgConnectionImpl);
 
     assertEquals("@ 1 years 3 months 0 days 0 hours 0 minutes 0.000000 seconds", coercedStringValue);
   }

--- a/src/test/java/com/impossibl/postgres/jdbc/NetworkTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/NetworkTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2014, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.impossibl.postgres.jdbc;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NetworkTest {
+
+  private Connection conn;
+
+  @Before
+  public void before() throws Exception {
+    conn = TestUtil.openDB();
+    TestUtil.createTable(conn, "mactest", "mac_address macaddr, cidr_mask cidr");
+  }
+
+  @After
+  public void after() throws SQLException {
+    TestUtil.dropTable(conn, "mactest");
+    TestUtil.closeDB(conn);
+  }
+
+  @Test
+  public void testMacStringConversion() throws SQLException {
+    try (Statement stmt = conn.createStatement()) {
+      int rows = stmt.executeUpdate("INSERT into mactest(mac_address) VALUES ('08:00:2b:01:02:03')");
+      assertEquals("Number of inserted rows not as expected", 1, rows);
+
+      ResultSet resultSet = stmt.executeQuery("SELECT mac_address FROM mactest WHERE mac_address='08:00:2b:01:02:03'");
+      assertTrue(resultSet.next());
+      assertEquals("08:00:2b:01:02:03", resultSet.getString(1));
+    }
+  }
+
+  @Test
+  public void testMacPreparedStatement() throws SQLException {
+    try (PreparedStatement stmt = conn.prepareStatement("INSERT into mactest(mac_address) VALUES (?)")) {
+      stmt.setString(1, "08:00:2b:01:02:03");
+      int rows = stmt.executeUpdate();
+      assertEquals("Number of inserted rows not as expected", 1, rows);
+    }
+  }
+
+  @Test
+  public void testMacBatch() throws SQLException {
+    try (PreparedStatement stmt = conn.prepareStatement("INSERT into mactest(mac_address) VALUES (CAST (? AS macaddr))")) {
+      stmt.setString(1, "08:00:2b:01:02:03");
+      stmt.addBatch();
+      stmt.setString(1, "08-00-2b-01-02-03");
+      stmt.addBatch();
+      stmt.setString(1, "08002b:010203");
+      stmt.addBatch();
+      stmt.setString(1, "08002b-010203");
+      stmt.addBatch();
+      stmt.setString(1, "0800.2b01.0203");
+      stmt.addBatch();
+      stmt.setString(1, "08002b010203");
+      stmt.addBatch();
+      int[] batchResult = stmt.executeBatch();
+      assertEquals("Number of inserted rows not as expected", 6, batchResult.length);
+      for (int rows : batchResult) {
+        assertEquals("Number of inserted rows not as expected", 1, rows);
+      }
+    }
+  }
+
+  @Test
+  public void testCidrStringConversion() throws SQLException {
+    try (Statement stmt = conn.createStatement()) {
+      int rows = stmt.executeUpdate("INSERT into mactest(cidr_mask) VALUES ('192.168/24')");
+      assertEquals("Number of inserted rows not as expected", 1, rows);
+
+      ResultSet resultSet = stmt.executeQuery("SELECT cidr_mask FROM mactest WHERE cidr_mask='192.168.0.0/24'");
+      assertTrue(resultSet.next());
+      assertEquals("192.168.0.0/24", resultSet.getString(1));
+    }
+  }
+
+  @Test
+  public void testCidrPreparedStatement() throws SQLException {
+    try (PreparedStatement stmt = conn.prepareStatement("INSERT into mactest(cidr_mask) VALUES (?)")) {
+      stmt.setString(1, "192.168.100.128/25");
+      int rows = stmt.executeUpdate();
+      assertEquals("Number of inserted rows not as expected", 1, rows);
+    }
+  }
+
+  @Test
+  public void testCidrBatch() throws SQLException {
+    try (PreparedStatement stmt = conn.prepareStatement("INSERT into mactest(cidr_mask) VALUES (CAST (? AS cidr))")) {
+      stmt.setString(1, "192.168/25");
+      stmt.addBatch();
+      stmt.setString(1, "192.168.1");
+      stmt.addBatch();
+      stmt.setString(1, "128");
+      stmt.addBatch();
+      stmt.setString(1, "2001:4f8:3:ba::/64");
+      stmt.addBatch();
+      stmt.setString(1, "2001:4f8:3:ba:2e0:81ff:fe22:d1f1/128");
+      stmt.addBatch();
+      stmt.setString(1, "::ffff:1.2.3.0/120");
+      stmt.addBatch();
+      int[] batchResult = stmt.executeBatch();
+      assertEquals("Number of inserted rows not as expected", 6, batchResult.length);
+      for (int rows : batchResult) {
+        assertEquals("Number of inserted rows not as expected", 1, rows);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changed `SQLTypeUtils.coerceToString()` to accept a `Type` parameter and use the type-appropriate `TextCodec` if available.  Changed `SQLTypeUtils.coerce()` to handle coercions from `String` to the required type if the text parameter format is supported for that type using the type-appropriate `TextCodec`.   Changed `SQLTypeUtils.coerceToBytes()` to use type-appropriate `TextCodec` if the source value is a String and a codec exists.

Added test case to cover original issue, plus additional tests that uncovered further conversion issues.  All suite tests passing.
