### PR TITLE
Hand written SQL-parser, based off of former regexes.

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextTree.java
@@ -352,6 +352,11 @@ public class SQLTextTree {
       this.text = text;
     }
 
+    void coalesce(PieceNode otherPiece) {
+      setText(getText() + otherPiece.getText());
+      setEndPos(getStartPos() + getText().length());
+    }
+
     @Override
     void build(StringBuilder builder) {
       builder.append(text);


### PR DESCRIPTION
The diffs are probably not that useful because of the size of the change.  I recommend looking at the SQLText.java file directly, it's more readable than the diff.

All tests are passing, plus an additional test from bug #65 added.

Note, this bring us back to "parsing parity" with the existing code.  However, as I was researching the PostgreSQL syntax, I noticed quite a few additions between PostgreSQL 8.x and 9.x.  Things like binary constants and unicode constants.  I do not know whether the parser handles these effective (former or current), but probably additional tests (and parsing) will need to be done in the future to cover these cases.
