### PR TITLE
General fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.0.25.Final</version>
+			<version>4.0.26.Final</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -39,6 +39,10 @@ import java.util.logging.Logger;
 
 import static java.lang.Boolean.parseBoolean;
 
+import javax.naming.NamingException;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
 import javax.sql.CommonDataSource;
 
 /**
@@ -115,6 +119,114 @@ public abstract class AbstractDataSource implements CommonDataSource {
   @Override
   public Logger getParentLogger() throws SQLFeatureNotSupportedException {
     return Logger.getLogger(Context.class.getPackage().getName());
+  }
+
+  /**
+   * Create a reference using the correct ObjectFactory instance
+   * @return The reference
+   */
+  protected abstract Reference createReference();
+
+  /**
+   * {@inheritDoc}
+   */
+  public Reference getReference() throws NamingException {
+    Reference ref = createReference();
+
+    if (host != null)
+      ref.add(new StringRefAddr("host", host));
+
+    if (port != 5432)
+      ref.add(new StringRefAddr("port", Integer.toString(port)));
+
+    if (database != null)
+      ref.add(new StringRefAddr("database", database));
+
+    if (user != null)
+      ref.add(new StringRefAddr("user", user));
+
+    if (password != null)
+      ref.add(new StringRefAddr("password", password));
+
+    if (housekeeper != parseBoolean(PGSettings.HOUSEKEEPER_ENABLED_DEFAULT_DATASOURCE))
+      ref.add(new StringRefAddr("housekeeper", Boolean.toString(housekeeper)));
+
+    if (parsedSqlCacheSize != Settings.PARSED_SQL_CACHE_SIZE_DEFAULT)
+      ref.add(new StringRefAddr("parsedSqlCacheSize", Integer.toString(parsedSqlCacheSize)));
+
+    if (preparedStatementCacheSize != Settings.PREPARED_STATEMENT_CACHE_SIZE_DEFAULT)
+      ref.add(new StringRefAddr("preparedStatementCacheSize", Integer.toString(preparedStatementCacheSize)));
+
+    if (applicationName != null)
+      ref.add(new StringRefAddr("applicationName", applicationName));
+
+    if (clientEncoding != null)
+      ref.add(new StringRefAddr("clientEncoding", clientEncoding));
+
+    return ref;
+  }
+
+  /**
+   * Init
+   * @param reference The reference
+   */
+  public void init(Reference reference) {
+    String value = null;
+
+    value = getReferenceValue(reference, "host");
+    if (value != null)
+      host = value;
+
+    value = getReferenceValue(reference, "port");
+    if (value != null)
+      port = Integer.valueOf(value);
+
+    value = getReferenceValue(reference, "database");
+    if (value != null)
+      database = value;
+
+    value = getReferenceValue(reference, "user");
+    if (value != null)
+      user = value;
+
+    value = getReferenceValue(reference, "password");
+    if (value != null)
+      password = value;
+
+    value = getReferenceValue(reference, "housekeeper");
+    if (value != null)
+      housekeeper = Boolean.valueOf(value);
+
+    value = getReferenceValue(reference, "parsedSqlCacheSize");
+    if (value != null)
+       parsedSqlCacheSize = Integer.valueOf(value);
+
+    value = getReferenceValue(reference, "preparedStatementCacheSize");
+    if (value != null)
+       preparedStatementCacheSize = Integer.valueOf(value);
+
+    value = getReferenceValue(reference, "applicationName");
+    if (value != null)
+      applicationName = value;
+
+    value = getReferenceValue(reference, "clientEncoding");
+    if (value != null)
+      clientEncoding = value;
+  }
+
+  /**
+   * Get reference value
+   * @param reference The reference
+   * @param key The key
+   * @return The value
+   */
+  private String getReferenceValue(Reference reference, String key) {
+    RefAddr refAddr = reference.get(key);
+
+    if (refAddr == null)
+      return null;
+
+    return (String)refAddr.getContent();
   }
 
   /**

--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -56,6 +56,8 @@ public abstract class AbstractDataSource implements CommonDataSource {
   private boolean housekeeper;
   private int parsedSqlCacheSize;
   private int preparedStatementCacheSize;
+  private String applicationName;
+  private String clientEncoding;
 
   /**
    * Constructor
@@ -70,6 +72,8 @@ public abstract class AbstractDataSource implements CommonDataSource {
     this.housekeeper = parseBoolean(PGSettings.HOUSEKEEPER_ENABLED_DEFAULT_DATASOURCE);
     this.parsedSqlCacheSize = Settings.PARSED_SQL_CACHE_SIZE_DEFAULT;
     this.preparedStatementCacheSize = Settings.PREPARED_STATEMENT_CACHE_SIZE_DEFAULT;
+    this.applicationName = null;
+    this.clientEncoding = null;
   }
 
   /**
@@ -247,6 +251,38 @@ public abstract class AbstractDataSource implements CommonDataSource {
   }
 
   /**
+   * Get the application name
+   * @return The value
+   */
+  public String getApplicationName() {
+    return applicationName;
+  }
+
+  /**
+   * Set the application name
+   * @param v The value
+   */
+  public void setApplicationName(String v) {
+    applicationName = v;
+  }
+
+  /**
+   * Get the client encoding
+   * @return The value
+   */
+  public String getClientEncoding() {
+    return clientEncoding;
+  }
+
+  /**
+   * Set the client encoding
+   * @param v The value
+   */
+  public void setClientEncoding(String v) {
+    clientEncoding = v;
+  }
+
+  /**
    * Create a connection
    *
    * @param u
@@ -283,6 +319,10 @@ public abstract class AbstractDataSource implements CommonDataSource {
 
     props.put(Settings.PARSED_SQL_CACHE_SIZE, parsedSqlCacheSize);
     props.put(Settings.PREPARED_STATEMENT_CACHE_SIZE, preparedStatementCacheSize);
+    if (applicationName != null)
+      props.put(Settings.APPLICATION_NAME, applicationName);
+    if (clientEncoding != null)
+      props.put(Settings.CLIENT_ENCODING, clientEncoding);
 
     return ConnectionUtil.createConnection(url, props, housekeeper);
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
@@ -33,6 +33,8 @@ import com.impossibl.postgres.system.NoticeException;
 import static com.impossibl.postgres.jdbc.ErrorUtils.makeSQLException;
 import static com.impossibl.postgres.jdbc.PGSettings.HOUSEKEEPER_ENABLED;
 import static com.impossibl.postgres.jdbc.PGSettings.HOUSEKEEPER_ENABLED_DEFAULT_DRIVER;
+import static com.impossibl.postgres.system.Settings.APPLICATION_NAME;
+import static com.impossibl.postgres.system.Settings.CLIENT_ENCODING;
 import static com.impossibl.postgres.system.Settings.CREDENTIALS_PASSWORD;
 import static com.impossibl.postgres.system.Settings.CREDENTIALS_USERNAME;
 import static com.impossibl.postgres.system.Settings.DATABASE_URL;
@@ -58,6 +60,8 @@ import static java.lang.Boolean.parseBoolean;
 class ConnectionUtil {
   private static final String JDBC_USERNAME_PARAM = "user";
   private static final String JDBC_PASSWORD_PARAM = "password";
+  private static final String JDBC_APPLICATION_NAME_PARAM = "application_name";
+  private static final String JDBC_CLIENT_ENCODING_PARAM = "client_encoding";
   private static Logger log = Logger.getLogger(ConnectionUtil.class.getName());
 
   static class ConnectionSpecifier {
@@ -210,6 +214,10 @@ class ConnectionUtil {
     //Translate JDBC parameters to PostgreSQL parameters
     settings.put(CREDENTIALS_USERNAME, settings.getProperty(JDBC_USERNAME_PARAM, ""));
     settings.put(CREDENTIALS_PASSWORD, settings.getProperty(JDBC_PASSWORD_PARAM, ""));
+    if (settings.getProperty(JDBC_APPLICATION_NAME_PARAM) != null)
+       settings.put(APPLICATION_NAME, settings.getProperty(JDBC_APPLICATION_NAME_PARAM, ""));
+    if (settings.getProperty(JDBC_CLIENT_ENCODING_PARAM) != null)
+       settings.put(CLIENT_ENCODING, settings.getProperty(JDBC_CLIENT_ENCODING_PARAM, ""));
 
     //Create & store URL
     settings.put(DATABASE_URL, "jdbc:pgsql://" + connSpec.getHosts() + "/" + connSpec.getDatabase());

--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatementDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatementDelegator.java
@@ -1648,4 +1648,26 @@ public class PGCallableStatementDelegator extends PGPreparedStatementDelegator i
       throw se;
     }
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || !(o instanceof PGCallableStatementDelegator))
+      return false;
+
+    PGCallableStatementDelegator other = (PGCallableStatementDelegator)o;
+    return delegator.equals(other.delegator);
+  }
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionPoolDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionPoolDataSource.java
@@ -30,6 +30,8 @@ package com.impossibl.postgres.jdbc;
 
 import java.sql.SQLException;
 
+import javax.naming.Reference;
+import javax.naming.Referenceable;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.PooledConnection;
 
@@ -37,7 +39,7 @@ import javax.sql.PooledConnection;
  * ConnectionPoolDataSource implementation
  * @author <a href="mailto:jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
-public class PGConnectionPoolDataSource extends AbstractDataSource implements ConnectionPoolDataSource {
+public class PGConnectionPoolDataSource extends AbstractDataSource implements ConnectionPoolDataSource, Referenceable {
 
   /**
    * Constructor
@@ -60,6 +62,15 @@ public class PGConnectionPoolDataSource extends AbstractDataSource implements Co
   @Override
   public PooledConnection getPooledConnection(String user, String password) throws SQLException {
     return new PGPooledConnection(createConnection(user, password), true, false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected Reference createReference() {
+    return new Reference(getClass().getName(),
+                         PGConnectionPoolDataSourceObjectFactory.class.getName(),
+                         null);
   }
 }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionPoolDataSourceObjectFactory.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionPoolDataSourceObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, impossibl.com
+ * Copyright (c) 2015, impossibl.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,71 +28,38 @@
  */
 package com.impossibl.postgres.jdbc;
 
-import static com.impossibl.postgres.jdbc.Exceptions.UNWRAP_ERROR;
+import java.util.Hashtable;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
+import javax.naming.Context;
+import javax.naming.Name;
 import javax.naming.Reference;
-import javax.naming.Referenceable;
-import javax.sql.DataSource;
+import javax.naming.spi.ObjectFactory;
 
 /**
- * DataSource implementation
+ * An ObjectFactory for PGConnectionPoolDataSource
  * @author <a href="mailto:jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
-public class PGDataSource extends AbstractDataSource implements DataSource, Referenceable {
+public class PGConnectionPoolDataSourceObjectFactory implements ObjectFactory {
 
   /**
    * Constructor
    */
-  public PGDataSource() {
-    super();
+  public PGConnectionPoolDataSourceObjectFactory() {
   }
 
   /**
    * {@inheritDoc}
    */
-  @Override
-  public Connection getConnection() throws SQLException {
-    return getConnection(getUser(), getPassword());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Connection getConnection(String user, String password) throws SQLException {
-    return createConnection(user, password);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    if (!iface.isAssignableFrom(getClass())) {
-      throw UNWRAP_ERROR;
+  public Object getObjectInstance(Object o, Name n, Context ctx, Hashtable env) throws Exception {
+    Reference ref = (Reference)o;
+    String className = ref.getClassName();
+    if (className.equals("com.impossibl.postgres.jdbc.PGConnectionPoolDataSource")) {
+      PGConnectionPoolDataSource ds = new PGConnectionPoolDataSource();
+      ds.init(ref);
+      return ds;
     }
-
-    return iface.cast(this);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
-    return iface.isAssignableFrom(getClass());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  protected Reference createReference() {
-    return new Reference(getClass().getName(),
-                         PGDataSourceObjectFactory.class.getName(),
-                         null);
+    else {
+      return null;
+    }
   }
 }
-

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDataSourceObjectFactory.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDataSourceObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, impossibl.com
+ * Copyright (c) 2015, impossibl.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,71 +28,38 @@
  */
 package com.impossibl.postgres.jdbc;
 
-import static com.impossibl.postgres.jdbc.Exceptions.UNWRAP_ERROR;
+import java.util.Hashtable;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
+import javax.naming.Context;
+import javax.naming.Name;
 import javax.naming.Reference;
-import javax.naming.Referenceable;
-import javax.sql.DataSource;
+import javax.naming.spi.ObjectFactory;
 
 /**
- * DataSource implementation
+ * An ObjectFactory for PGDataSource
  * @author <a href="mailto:jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
-public class PGDataSource extends AbstractDataSource implements DataSource, Referenceable {
+public class PGDataSourceObjectFactory implements ObjectFactory {
 
   /**
    * Constructor
    */
-  public PGDataSource() {
-    super();
+  public PGDataSourceObjectFactory() {
   }
 
   /**
    * {@inheritDoc}
    */
-  @Override
-  public Connection getConnection() throws SQLException {
-    return getConnection(getUser(), getPassword());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Connection getConnection(String user, String password) throws SQLException {
-    return createConnection(user, password);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    if (!iface.isAssignableFrom(getClass())) {
-      throw UNWRAP_ERROR;
+  public Object getObjectInstance(Object o, Name n, Context ctx, Hashtable env) throws Exception {
+    Reference ref = (Reference)o;
+    String className = ref.getClassName();
+    if (className.equals("com.impossibl.postgres.jdbc.PGDataSource")) {
+      PGDataSource ds = new PGDataSource();
+      ds.init(ref);
+      return ds;
     }
-
-    return iface.cast(this);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
-    return iface.isAssignableFrom(getClass());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  protected Reference createReference() {
-    return new Reference(getClass().getName(),
-                         PGDataSourceObjectFactory.class.getName(),
-                         null);
+    else {
+      return null;
+    }
   }
 }
-

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
@@ -1006,4 +1006,26 @@ public class PGPooledConnectionDelegator implements PGConnection {
                                      "08003");
     }
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || !(o instanceof PGPooledConnectionDelegator))
+      return false;
+
+    PGPooledConnectionDelegator other = (PGPooledConnectionDelegator)o;
+    return delegator.equals(other.delegator);
+  }
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatementDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatementDelegator.java
@@ -853,4 +853,26 @@ public class PGPreparedStatementDelegator extends PGStatementDelegator implement
       throw se;
     }
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || !(o instanceof PGPreparedStatementDelegator))
+      return false;
+
+    PGPreparedStatementDelegator other = (PGPreparedStatementDelegator)o;
+    return delegator.equals(other.delegator);
+  }
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGStatementDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGStatementDelegator.java
@@ -416,4 +416,26 @@ public class PGStatementDelegator implements Statement {
       throw se;
     }
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || !(o instanceof PGStatementDelegator))
+      return false;
+
+    PGStatementDelegator other = (PGStatementDelegator)o;
+    return delegator.equals(other.delegator);
+  }
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/PGXAConnection.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/PGXAConnection.java
@@ -321,7 +321,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
       // except if the transaction is in abort-only state and the
       // backed refuses to process new queries. Hopefully not a problem
       // in practice.
-      try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT gid FROM pg_prepared_xacts")) {
+      try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT gid FROM pg_prepared_xacts where database = current_database()")) {
         List<Xid> l = new ArrayList<Xid>();
         while (rs.next()) {
           Xid recoveredXid = RecoveredXid.stringToXid(rs.getString(1));

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/PGXAConnectionDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/PGXAConnectionDelegator.java
@@ -103,4 +103,26 @@ public class PGXAConnectionDelegator extends PGPooledConnectionDelegator {
     }
     super.setAutoCommit(autoCommit);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || !(o instanceof PGXAConnectionDelegator))
+      return false;
+
+    PGXAConnectionDelegator other = (PGXAConnectionDelegator)o;
+    return owner.equals(other.owner);
+  }
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/PGXADataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/PGXADataSource.java
@@ -32,6 +32,8 @@ import com.impossibl.postgres.jdbc.AbstractDataSource;
 
 import java.sql.SQLException;
 
+import javax.naming.Reference;
+import javax.naming.Referenceable;
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
 
@@ -39,7 +41,7 @@ import javax.sql.XADataSource;
  * XADataSource implementation
  * @author <a href="mailto:jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
-public class PGXADataSource extends AbstractDataSource implements XADataSource {
+public class PGXADataSource extends AbstractDataSource implements XADataSource, Referenceable {
 
   /**
    * Constructor
@@ -62,6 +64,15 @@ public class PGXADataSource extends AbstractDataSource implements XADataSource {
   @Override
   public XAConnection getXAConnection(String user, String password) throws SQLException {
     return new PGXAConnection(createConnection(user, password));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected Reference createReference() {
+    return new Reference(getClass().getName(),
+                         PGXADataSourceObjectFactory.class.getName(),
+                         null);
   }
 }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/PGXADataSourceObjectFactory.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/PGXADataSourceObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, impossibl.com
+ * Copyright (c) 2015, impossibl.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,73 +26,40 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.impossibl.postgres.jdbc;
+package com.impossibl.postgres.jdbc.xa;
 
-import static com.impossibl.postgres.jdbc.Exceptions.UNWRAP_ERROR;
+import java.util.Hashtable;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
+import javax.naming.Context;
+import javax.naming.Name;
 import javax.naming.Reference;
-import javax.naming.Referenceable;
-import javax.sql.DataSource;
+import javax.naming.spi.ObjectFactory;
 
 /**
- * DataSource implementation
+ * An ObjectFactory for PGXADataSource
  * @author <a href="mailto:jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
-public class PGDataSource extends AbstractDataSource implements DataSource, Referenceable {
+public class PGXADataSourceObjectFactory implements ObjectFactory {
 
   /**
    * Constructor
    */
-  public PGDataSource() {
-    super();
+  public PGXADataSourceObjectFactory() {
   }
 
   /**
    * {@inheritDoc}
    */
-  @Override
-  public Connection getConnection() throws SQLException {
-    return getConnection(getUser(), getPassword());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public Connection getConnection(String user, String password) throws SQLException {
-    return createConnection(user, password);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    if (!iface.isAssignableFrom(getClass())) {
-      throw UNWRAP_ERROR;
+  public Object getObjectInstance(Object o, Name n, Context ctx, Hashtable env) throws Exception {
+    Reference ref = (Reference)o;
+    String className = ref.getClassName();
+    if (className.equals("com.impossibl.postgres.jdbc.xa.PGXADataSource")) {
+      PGXADataSource ds = new PGXADataSource();
+      ds.init(ref);
+      return ds;
     }
-
-    return iface.cast(this);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
-    return iface.isAssignableFrom(getClass());
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  protected Reference createReference() {
-    return new Reference(getClass().getName(),
-                         PGDataSourceObjectFactory.class.getName(),
-                         null);
+    else {
+      return null;
+    }
   }
 }
-

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
@@ -205,8 +205,8 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
 
     Map<String, Object> params = new HashMap<String, Object>();
 
-    params.put(APPLICATION_NAME, "pgjdbc app");
-    params.put(CLIENT_ENCODING, "UTF8");
+    params.put(APPLICATION_NAME, context.getSetting(APPLICATION_NAME, "pgjdbc app"));
+    params.put(CLIENT_ENCODING, context.getSetting(CLIENT_ENCODING, "UTF8"));
     params.put(DATABASE, context.getSetting(DATABASE, ""));
     params.put(CREDENTIALS_USERNAME, context.getSetting(CREDENTIALS_USERNAME, ""));
 

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
@@ -62,6 +62,7 @@ import java.io.InterruptedIOException;
 import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -1058,7 +1059,7 @@ public class ProtocolImpl implements Protocol {
           rowsAffected = Long.parseLong(parts[2]);
         }
         else {
-          throw new IOException("error parsing command tag");
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
         }
 
         break;
@@ -1070,7 +1071,7 @@ public class ProtocolImpl implements Protocol {
           rowsAffected = null;
         }
         else {
-          throw new IOException("error parsing command tag");
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
         }
 
         break;
@@ -1084,7 +1085,7 @@ public class ProtocolImpl implements Protocol {
           rowsAffected = Long.parseLong(parts[1]);
         }
         else {
-          throw new IOException("error parsing command tag");
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
         }
 
         break;
@@ -1098,7 +1099,7 @@ public class ProtocolImpl implements Protocol {
           rowsAffected = Long.parseLong(parts[1]);
         }
         else {
-          throw new IOException("error parsing command tag");
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
         }
 
         break;
@@ -1119,7 +1120,7 @@ public class ProtocolImpl implements Protocol {
           rowsAffected = 0L;
         }
         else {
-          throw new IOException("error parsing command tag");
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
         }
 
         break;
@@ -1127,10 +1128,37 @@ public class ProtocolImpl implements Protocol {
       case "TRUNCATE":
         break;
 
+      case "PREPARE":
+        if (parts.length == 2) {
+          // Nothing to parse but accepted
+        }
+        else {
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
+        }
+        break;
+
+      case "COMMIT":
+        if (parts.length == 1 || parts.length == 2) {
+          // Nothing to parse but accepted
+        }
+        else {
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
+        }
+        break;
+
+      case "ROLLBACK":
+        if (parts.length == 1 || parts.length == 2) {
+          // Nothing to parse but accepted
+        }
+        else {
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
+        }
+        break;
+
       default:
 
         if (parts.length != 1)
-          throw new IOException("error parsing command tag");
+          throw new IOException("error parsing command tag: " + command + " (" + Arrays.toString(parts) + ")");
 
         rowsAffected = 0L;
     }


### PR DESCRIPTION
- PooledConnection equality
- Receive fixes for multiple connections enlisted in the same transaction
- Support application name and client encoding in settings
- Netty 4.0.26
- Support javax.naming.Referenceable for legacy "EE" systems
- Perform recovery only on the specified database
