### PR TITLE
fix inconsistent synchronization

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
@@ -89,10 +89,11 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
     }
 
     @Override
-    public void noData() {
+    public synchronized void noData() {
       resultBatch.fields = Collections.emptyList();
       resultBatch.results = null;
       status = Status.Completed;
+      notifyAll();
     }
 
     @Override
@@ -125,10 +126,11 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
     }
 
     @Override
-    public void emptyQuery() {
+    public synchronized void emptyQuery() {
       resultBatch.fields = Collections.emptyList();
       resultBatch.results = null;
       status = Status.Completed;
+      notifyAll();
     }
 
     @Override
@@ -144,9 +146,7 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
       resultBatch.rowsAffected = rowsAffected;
       resultBatch.insertedOid = oid;
 
-      if (maxRows > 0) {
-        notifyAll();
-      }
+      notifyAll();
     }
 
     @Override


### PR DESCRIPTION
fixes  #146

The missing notification can end up with 'infinite wait'

```
 java.lang.Object.wait(Native Method)
 com.impossibl.postgres.protocol.v30.CommandImpl.waitFor(CommandImpl.java:119)
 com.impossibl.postgres.protocol.v30.QueryCommandImpl.execute(QueryCommandImpl.java:173)
 com.impossibl.postgres.protocol.v30.ProtocolImpl.execute(ProtocolImpl.java:369)
 com.impossibl.postgres.system.BasicContext.queryResults(BasicContext.java:437)
 com.impossibl.postgres.system.BasicContext.queryFirstResultString(BasicContext.java:524)
 com.impossibl.postgres.jdbc.PGConnectionImpl.executeForString(PGConnectionImpl.java:519)
 com.impossibl.postgres.jdbc.PGConnectionImpl.isValid(PGConnectionImpl.java:641)
 com.zaxxer.hikari.pool.HikariPool.isConnectionAlive(HikariPool.java:131)
 com.zaxxer.hikari.pool.BaseHikariPool.getConnection(BaseHikariPool.java:208)
 com.zaxxer.hikari.pool.BaseHikariPool.getConnection(BaseHikariPool.java:183)
com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:91)
```
