### PR TITLE
Strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ The 'clientEncoding' parameter specifies the client encoding for the database se
 The 'networkTimeout' parameter specifies the default timeout in milliseconds for the connections.
 A value of 0 indicates that there isnt a timeout for database operations.
 
+	strictMode          (boolean)  false
+
+The 'strictMode' parameter specifies if the JDBC driver should follow behavior assumed by
+certain frameworks, and test suites. See
+[http://github.com/impossibl/pgjdbc-ng/wiki/StrictMode](http://github.com/impossibl/pgjdbc-ng/wiki/StrictMode "pgjdbc-ng strictMode")
+for additional details.
+
 ## License
 
 pgjdbc-ng is released under the 3 clause BSD license.

--- a/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
+++ b/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
@@ -91,4 +91,15 @@ public interface PGConnection extends Connection {
    */
   void removeNotificationListener(PGNotificationListener listener);
 
+  /**
+   * Set strict mode
+   * @param v The value
+   */
+  void setStrictMode(boolean v);
+
+  /**
+   * Is strict mode
+   * @return The value
+   */
+  boolean isStrictMode();
 }

--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -63,6 +63,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
   private String applicationName;
   private String clientEncoding;
   private int networkTimeout;
+  private boolean strictMode;
 
   /**
    * Constructor
@@ -80,6 +81,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
     this.applicationName = null;
     this.clientEncoding = null;
     this.networkTimeout = Settings.NETWORK_TIMEOUT_DEFAULT;
+    this.strictMode = Settings.STRICT_MODE_DEFAULT;
   }
 
   /**
@@ -168,6 +170,9 @@ public abstract class AbstractDataSource implements CommonDataSource {
     if (networkTimeout != 0)
       ref.add(new StringRefAddr("networkTimeout", Integer.toString(networkTimeout)));
 
+    if (strictMode != Settings.STRICT_MODE_DEFAULT)
+      ref.add(new StringRefAddr("strictMode", Boolean.toString(strictMode)));
+
     return ref;
   }
 
@@ -221,6 +226,10 @@ public abstract class AbstractDataSource implements CommonDataSource {
     value = getReferenceValue(reference, "networkTimeout");
     if (value != null)
        networkTimeout = Integer.valueOf(value);
+
+    value = getReferenceValue(reference, "strictMode");
+    if (value != null)
+      strictMode = Boolean.valueOf(value);
   }
 
   /**
@@ -420,6 +429,22 @@ public abstract class AbstractDataSource implements CommonDataSource {
   }
 
   /**
+   * Get the strict mode
+   * @return The value
+   */
+  public boolean getStrictMode() {
+    return strictMode;
+  }
+
+  /**
+   * Set the strict mode
+   * @param v The value
+   */
+  public void setStrictMode(boolean v) {
+    strictMode = v;
+  }
+
+  /**
    * Create a connection
    *
    * @param u
@@ -461,6 +486,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
     if (clientEncoding != null)
       props.put(Settings.CLIENT_ENCODING, clientEncoding);
     props.put(Settings.NETWORK_TIMEOUT, Integer.toString(networkTimeout));
+    props.put(Settings.STRICT_MODE, Boolean.toString(strictMode));
 
     return ConnectionUtil.createConnection(url, props, housekeeper);
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -586,6 +586,9 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
 
     Class<?> targetType = mapGetType(type, map, connection);
 
+    if (connection.isStrictMode() && InputStream.class.equals(targetType))
+      targetType = byte[].class;
+
     return coerce(get(parameterIndex), type, targetType, map, connection);
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -76,8 +76,10 @@ import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -102,6 +104,7 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
   List<ParameterMode> allParameterModes;
   List<String> outParameterNames;
   List<Type> outParameterTypes;
+  Map<Integer, Integer> outParameterSQLTypes;
   List<Object> outParameterValues;
   Map<String, Class<?>> typeMap;
   Boolean nullFlag;
@@ -119,6 +122,7 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
     allParameterModes = new ArrayList<>(nCopies(parameterCount, (ParameterMode) null));
     outParameterNames = new ArrayList<>();
     outParameterTypes = new ArrayList<>();
+    outParameterSQLTypes = new HashMap<>();
     outParameterValues = new ArrayList<>();
 
     if (hasAssign) {
@@ -335,6 +339,8 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
     outParameterNames.addAll(nCopies(needed, (String) null));
     outParameterTypes.addAll(nCopies(needed, (Type) null));
     outParameterValues.addAll(nCopies(needed, (Object) null));
+
+    outParameterSQLTypes.put(Integer.valueOf(parameterIndex), Integer.valueOf(sqlType));
   }
 
   @Override
@@ -586,8 +592,16 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
 
     Class<?> targetType = mapGetType(type, map, connection);
 
-    if (connection.isStrictMode() && InputStream.class.equals(targetType))
-      targetType = byte[].class;
+    if (connection.isStrictMode()) {
+      if (InputStream.class.equals(targetType)) {
+        targetType = byte[].class;
+      }
+      else if (Double.class.equals(targetType)) {
+        Integer sqlType = outParameterSQLTypes.get(Integer.valueOf(parameterIndex));
+        if (sqlType != null && Types.REAL == sqlType.intValue())
+          targetType = Float.class;
+      }
+    }
 
     return coerce(get(parameterIndex), type, targetType, map, connection);
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -76,6 +76,8 @@ import static com.impossibl.postgres.system.Settings.PARSED_SQL_CACHE_SIZE;
 import static com.impossibl.postgres.system.Settings.PARSED_SQL_CACHE_SIZE_DEFAULT;
 import static com.impossibl.postgres.system.Settings.PREPARED_STATEMENT_CACHE_SIZE;
 import static com.impossibl.postgres.system.Settings.PREPARED_STATEMENT_CACHE_SIZE_DEFAULT;
+import static com.impossibl.postgres.system.Settings.STRICT_MODE;
+import static com.impossibl.postgres.system.Settings.STRICT_MODE_DEFAULT;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -167,6 +169,7 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
   }
 
 
+  boolean strict;
   long statementId = 0L;
   long portalId = 0L;
   int savepointId;
@@ -184,6 +187,7 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
   PGConnectionImpl(SocketAddress address, Properties settings, Housekeeper.Ref housekeeper) throws IOException, NoticeException {
     super(address, settings, Collections.<String, Class<?>>emptyMap());
 
+    this.strict = getSetting(STRICT_MODE, STRICT_MODE_DEFAULT);
     this.networkTimeout = getSetting(NETWORK_TIMEOUT, NETWORK_TIMEOUT_DEFAULT);
     this.activeStatements = new ArrayList<>();
 
@@ -612,6 +616,20 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
     QueryCommand.ResultBatch resultBatch = executeForFirstResultBatch(sql, checkTxn, params);
 
     return resultBatch.rowsAffected;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public void setStrictMode(boolean v) {
+    strict = v;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public boolean isStrictMode() {
+    return strict;
   }
 
   /**

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -409,8 +409,8 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
       return parsedSql.copy();
     }
     catch (ParseException e) {
-
-      throw new SQLException("Error parsing SQL at position " + e.getErrorOffset() + " (" + sqlText + ")");
+      throw new SQLException("Error parsing SQL at position " + e.getErrorOffset() +
+                             " (" + sqlText + "): " + e.getMessage());
     }
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -1235,7 +1235,7 @@ class PGDatabaseMetaData implements DatabaseMetaData {
     resultFields[15] = new ResultField("CHAR_OCTET_LENGTH", 0, (short)0, registry.loadType("int4"),   (short)0, 0, Format.Binary);
     resultFields[16] = new ResultField("ORDINAL_POSITION",  0, (short)0, registry.loadType("int4"),   (short)0, 0, Format.Binary);
     resultFields[17] = new ResultField("IS_NULLABLE",       0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
-    resultFields[18] = new ResultField("SCOPE_CATLOG",      0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
+    resultFields[18] = new ResultField("SCOPE_CATALOG",     0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
     resultFields[19] = new ResultField("SCOPE_SCHEMA",      0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
     resultFields[20] = new ResultField("SCOPE_TABLE",       0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
     resultFields[21] = new ResultField("SOURCE_DATA_TYPE",  0, (short)0, registry.loadType("int2"),   (short)0, 0, Format.Binary);
@@ -2349,7 +2349,7 @@ class PGDatabaseMetaData implements DatabaseMetaData {
     resultFields[14] = new ResultField("CHAR_OCTET_LENGTH", 0, (short)0, registry.loadType("int4"),   (short)0, 0, Format.Binary);
     resultFields[15] = new ResultField("ORDINAL_POSITION",  0, (short)0, registry.loadType("int4"),   (short)0, 0, Format.Binary);
     resultFields[16] = new ResultField("IS_NULLABLE",       0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
-    resultFields[17] = new ResultField("SCOPE_CATLOG",      0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
+    resultFields[17] = new ResultField("SCOPE_CATALOG",     0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
     resultFields[18] = new ResultField("SCOPE_SCHEMA",      0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
     resultFields[19] = new ResultField("SCOPE_TABLE",       0, (short)0, registry.loadType("text"),   (short)0, 0, Format.Binary);
     resultFields[20] = new ResultField("SOURCE_DATA_TYPE",  0, (short)0, registry.loadType("int2"),   (short)0, 0, Format.Binary);

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
@@ -981,6 +981,20 @@ public class PGPooledConnectionDelegator implements PGConnection {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  public void setStrictMode(boolean v) {
+    delegator.setStrictMode(v);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public boolean isStrictMode() {
+    return delegator.isStrictMode();
+  }
+
   void reset() {
     if (delegator != null) {
       automatic = true;

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -668,7 +668,78 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 
   @Override
   public void setObject(int parameterIndex, Object x) throws SQLException {
-    set(parameterIndex, x, Types.OTHER);
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+    }
+    else if (x instanceof Boolean) {
+      setBoolean(parameterIndex, ((Boolean)x).booleanValue());
+    }
+    else if (x instanceof Byte) {
+      setByte(parameterIndex, ((Byte)x).byteValue());
+    }
+    else if (x instanceof Short) {
+      setShort(parameterIndex, ((Short)x).shortValue());
+    }
+    else if (x instanceof Integer) {
+      setInt(parameterIndex, ((Integer)x).intValue());
+    }
+    else if (x instanceof Long) {
+      setLong(parameterIndex, ((Long)x).longValue());
+    }
+    else if (x instanceof Float) {
+      setFloat(parameterIndex, ((Float)x).floatValue());
+    }
+    else if (x instanceof Double) {
+      setDouble(parameterIndex, ((Double)x).doubleValue());
+    }
+    else if (x instanceof BigDecimal) {
+      setBigDecimal(parameterIndex, (BigDecimal)x);
+    }
+    else if (x instanceof String) {
+      setString(parameterIndex, (String)x);
+    }
+    else if (x instanceof byte[]) {
+      setBytes(parameterIndex, (byte[])x);
+    }
+    else if (x instanceof Date) {
+      setDate(parameterIndex, (Date)x);
+    }
+    else if (x instanceof Time) {
+      setTime(parameterIndex, (Time)x);
+    }
+    else if (x instanceof Timestamp) {
+      setTimestamp(parameterIndex, (Timestamp)x);
+    }
+    else if (x instanceof InputStream) {
+      setBinaryStream(parameterIndex, (InputStream)x);
+    }
+    else if (x instanceof Blob) {
+      setBlob(parameterIndex, (Blob)x);
+    }
+    else if (x instanceof Clob) {
+      setClob(parameterIndex, (Clob)x);
+    }
+    else if (x instanceof Array) {
+      setArray(parameterIndex, (Array)x);
+    }
+    else if (x instanceof URL) {
+      setURL(parameterIndex, (URL)x);
+    }
+    else if (x instanceof SQLXML) {
+      setSQLXML(parameterIndex, (SQLXML)x);
+    }
+    else if (x instanceof RowId) {
+      setRowId(parameterIndex, (RowId)x);
+    }
+    else if (x instanceof Ref) {
+      setRef(parameterIndex, (Ref)x);
+    }
+    else if (x instanceof NClob) {
+      setNClob(parameterIndex, (NClob)x);
+    }
+    else {
+      set(parameterIndex, x, Types.OTHER);
+    }
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -874,6 +874,9 @@ class PGResultSet implements ResultSet {
 
     Class<?> targetType = mapGetType(type, map, statement.connection);
 
+    if (statement.connection.isStrictMode() && InputStream.class.equals(targetType))
+      targetType = byte[].class;
+
     return coerce(get(columnIndex), type, targetType, map, statement.connection);
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGResultSetMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGResultSetMetaData.java
@@ -207,6 +207,11 @@ class PGResultSetMetaData implements ResultSetMetaData {
 
   @Override
   public String getColumnName(int column) throws SQLException {
+    if (connection.isStrictMode()) {
+      String val = get(column).name;
+      if (val != null)
+        return val;
+    }
 
     CompositeType.Attribute attr = getRelAttr(column);
     if (attr == null)

--- a/src/main/java/com/impossibl/postgres/system/Settings.java
+++ b/src/main/java/com/impossibl/postgres/system/Settings.java
@@ -86,4 +86,7 @@ public class Settings {
 
   public static final String NETWORK_TIMEOUT = "networkTimeout";
   public static final int NETWORK_TIMEOUT_DEFAULT = 0;
+
+  public static final String STRICT_MODE = "strictMode";
+  public static final boolean STRICT_MODE_DEFAULT = false;
 }

--- a/src/main/java/com/impossibl/postgres/system/procs/Bytes.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Bytes.java
@@ -120,6 +120,9 @@ public class Bytes extends SimpleProcProvider {
       }
       else {
 
+        if (val instanceof byte[])
+          val = new ByteArrayInputStream((byte[])val);
+
         InputStream in = (InputStream) val;
 
         int totalLength;
@@ -165,6 +168,9 @@ public class Bytes extends SimpleProcProvider {
       int length = 4;
 
       if (val != null) {
+
+        if (val instanceof byte[])
+          val = new ByteArrayInputStream((byte[])val);
 
         InputStream in = (InputStream) val;
 
@@ -278,6 +284,9 @@ public class Bytes extends SimpleProcProvider {
 
     @Override
     public void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
+
+      if (val instanceof byte[])
+        val = new ByteArrayInputStream((byte[])val);
 
       InputStream in = (InputStream) val;
 

--- a/src/test/java/com/impossibl/postgres/jdbc/CallableStatementTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/CallableStatementTest.java
@@ -49,7 +49,6 @@ import java.sql.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -1168,8 +1167,9 @@ public class CallableStatementTest {
     }
   }
 
-  @Ignore
+  @Test
   public void testGetRealAsFloat() throws Throwable {
+    ((PGConnectionImpl)con).setStrictMode(true);
     try {
       Statement stmt = con.createStatement();
       stmt.execute("create temp table r_tab ( max_val float8, min_val float8, null_val float8 )");
@@ -1211,6 +1211,7 @@ public class CallableStatementTest {
       catch (Exception ex) {
         // Expected...
       }
+      ((PGConnectionImpl)con).setStrictMode(false);
     }
   }
 

--- a/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
@@ -61,7 +61,6 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -124,7 +123,7 @@ public class PreparedStatementTest {
     doSetBinaryStream(bais, 10);
   }
 
-  @Ignore
+  @Test
   public void testGetBinaryStream() throws SQLException {
     byte[] buf = new byte[10];
     for (int i = 0; i < buf.length; i++) {
@@ -134,12 +133,14 @@ public class PreparedStatementTest {
     ByteArrayInputStream bais = new ByteArrayInputStream(buf);
     doSetBinaryStream(bais, 10);
 
+    ((PGConnectionImpl)conn).setStrictMode(true);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT bin FROM streamtable");
     assertTrue(rs.next());
     assertTrue(Arrays.equals(buf, (byte[])rs.getObject(1)));
     rs.close();
     stmt.close();
+    ((PGConnectionImpl)conn).setStrictMode(false);
   }
 
   @Test
@@ -807,7 +808,7 @@ public class PreparedStatementTest {
     pstmt.close();
   }
 
-  @Ignore
+  @Test
   public void testSetObjectBinary() throws SQLException {
     byte[] buf = new byte[10];
     for (int i = 0; i < buf.length; i++) {
@@ -820,15 +821,17 @@ public class PreparedStatementTest {
     pstmt.executeUpdate();
     pstmt.close();
 
+    ((PGConnectionImpl)conn).setStrictMode(true);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT bin FROM streamtable");
     assertTrue(rs.next());
     assertTrue(Arrays.equals(buf, (byte[])rs.getObject(1)));
     rs.close();
     stmt.close();
+    ((PGConnectionImpl)conn).setStrictMode(false);
   }
 
-  @Ignore
+  @Test
   public void testSetObjectVarBinary() throws SQLException {
     byte[] buf = new byte[10];
     for (int i = 0; i < buf.length; i++) {
@@ -841,15 +844,17 @@ public class PreparedStatementTest {
     pstmt.executeUpdate();
     pstmt.close();
 
+    ((PGConnectionImpl)conn).setStrictMode(true);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT bin FROM streamtable");
     assertTrue(rs.next());
     assertTrue(Arrays.equals(buf, (byte[])rs.getObject(1)));
     rs.close();
     stmt.close();
+    ((PGConnectionImpl)conn).setStrictMode(false);
   }
 
-  @Ignore
+  @Test
   public void testSetObjectLongVarBinary() throws SQLException {
     byte[] buf = new byte[10];
     for (int i = 0; i < buf.length; i++) {
@@ -862,12 +867,14 @@ public class PreparedStatementTest {
     pstmt.executeUpdate();
     pstmt.close();
 
+    ((PGConnectionImpl)conn).setStrictMode(true);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT bin FROM streamtable");
     assertTrue(rs.next());
     assertTrue(Arrays.equals(buf, (byte[])rs.getObject(1)));
     rs.close();
     stmt.close();
+    ((PGConnectionImpl)conn).setStrictMode(false);
   }
 
   @Test

--- a/src/test/java/com/impossibl/postgres/jdbc/ResultSetMetaDataTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/ResultSetMetaDataTest.java
@@ -46,7 +46,6 @@ import java.sql.Types;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -249,12 +248,35 @@ public class ResultSetMetaDataTest {
     assertEquals("rsmd1", rsmd.getColumnTypeName(1));
   }
 
-  @Ignore
-  public void testAlias() throws Exception {
+  @Test
+  public void testAliasInsensitive() throws Exception {
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT a AS PK FROM rsmd1");
     ResultSetMetaData rsmd = rs.getMetaData();
     assertEquals(1, rsmd.getColumnCount());
+    assertEquals("a", rsmd.getColumnName(1));
+    assertEquals("pk", rsmd.getColumnLabel(1));
+  }
+
+  @Test
+  public void testAliasSensitive() throws Exception {
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT a AS \"PK\" FROM rsmd1");
+    ResultSetMetaData rsmd = rs.getMetaData();
+    assertEquals(1, rsmd.getColumnCount());
+    assertEquals("a", rsmd.getColumnName(1));
+    assertEquals("PK", rsmd.getColumnLabel(1));
+  }
+
+  @Test
+  public void testAliasStrictMode() throws Exception {
+    ((PGConnectionImpl)conn).setStrictMode(true);
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT a AS \"PK\" FROM rsmd1");
+    ResultSetMetaData rsmd = rs.getMetaData();
+    assertEquals(1, rsmd.getColumnCount());
     assertEquals("PK", rsmd.getColumnName(1));
+    assertEquals("PK", rsmd.getColumnLabel(1));
+    ((PGConnectionImpl)conn).setStrictMode(false);
   }
 }


### PR DESCRIPTION
I have been looking at how to deal with the

```
(byte[])rs.getObject(1);
```

based test cases in PreparedStatementTestCase without messing everything up, and maintaining good defaults. I wonder why I added those ;)

Added a "strict mode" - default is false - to force all InputStream's to be converted to byte[] for the getObject(int) calls. Other changes maybe added for this mode in the future.

@kdubb WDYT ?
