### PR TITLE
Please add support for SSLParameters

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
@@ -67,9 +67,9 @@ import javax.security.auth.callback.CallbackHandler;
 public class SSLEngineFactory {
 
 
-  private static final String TRUST_MANAGER_FACTORY_TYPE = "PKIX";
-  private static final String SSL_PROTOCOL = "TLS";
-  private static final String KEY_STORE_TYPE = "JKS";
+  private static final String TRUST_MANAGER_FACTORY_TYPE = TrustManagerFactory.getDefaultAlgorithm();
+  private static final String SSLCONTEXT_PROTOCOL = "TLS";
+  private static final String KEY_STORE_TYPE = KeyStore.getDefaultType();
   private static final String SSL_DIR_NAME = "postgresql";
   private static final String CERTIFICATE_FACTORY_TYPE = "X.509";
 
@@ -191,7 +191,7 @@ public class SSLEngineFactory {
 
     SSLContext sslContext;
     try {
-      sslContext = SSLContext.getInstance(SSL_PROTOCOL);
+      sslContext = SSLContext.getInstance(SSLCONTEXT_PROTOCOL);
     }
     catch (NoSuchAlgorithmException e) {
       throw new IOException("ssl context not available", e);

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
@@ -61,6 +61,7 @@ import javax.naming.ldap.Rdn;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
@@ -122,6 +123,10 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
           // Attach the actual handler
 
           SSLEngine sslEngine = SSLEngineFactory.create(sslMode, context);
+          SSLParameters sslParameters = context.getSetting("sslParameters", SSLParameters.class);
+          if (sslParameters != null) {
+              sslEngine.setSSLParameters(sslParameters);
+          }
 
           final SslHandler sslHandler = new SslHandler(sslEngine);
 


### PR DESCRIPTION
Here is a patch that allows connections to set an [`SSLParameters`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLParameters.html) instance, which can be used to choose the SSL/TLS protocol and the cipher suites (amongst other settings).

``` java

Class.forName("com.impossibl.postgres.jdbc.PGDriver");
String url = "jdbc:pgsql://.../...?ssl.mode=VerifyFull";
Properties props = new Properties();
SSLParameters sslParameters = new SSLParameters();
sslParameters.setProtocols(new String[] { "TLSv1.1" });
//sslParameters.setCipherSuites(new String[] { ... });
props.setProperty("user", "...");
props.setProperty("password", "...");
props.put("sslParameters", sslParameters);
Connection conn = DriverManager.getConnection(url, props);
Statement stmt = conn.createStatement();
// The sslinfo extension (from contrib) need to be install on the DB for these functions to work.
ResultSet rs = stmt.executeQuery("SELECT ssl_version() || ' - ' || ssl_cipher()");
if (rs.next()) {
    System.out.println("SSL/TLS version and ciphers: "
            + rs.getString(1));
}
conn.close();
```

I've also renamed the `SSL_PROTOCOL` constant into `SSLCONTEXT_PROTOCOL` in the `SSLEngineFactory`. The [`SSLContext` protocol isn't necessarily the protocol that's going to be used for the connection](http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSE_Protocols).

Since Java 7, they can also be used to implement host name verification directly (at least according the LDAPS and HTTPS conventions). Of course, that would be redundant with the existing host name verification mechanism, but it also checks for names in the subject alternative names. There is currently no support for the more generic [RFC 6125](https://tools.ietf.org/html/rfc6125) here in Java, but "HTTPS" is probably close enough, and could also generally be applied to PostgreSQL connections: `sslParameters.setEndpointIdentificationAlgorithm("HTTPS")`.
