### PR TITLE
Use JVM default trust store by default

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
@@ -67,9 +67,9 @@ import javax.security.auth.callback.CallbackHandler;
 public class SSLEngineFactory {
 
 
-  private static final String TRUST_MANAGER_FACTORY_TYPE = "PKIX";
-  private static final String SSL_PROTOCOL = "TLS";
-  private static final String KEY_STORE_TYPE = "JKS";
+  private static final String TRUST_MANAGER_FACTORY_TYPE = TrustManagerFactory.getDefaultAlgorithm();
+  private static final String SSLCONTEXT_PROTOCOL = "TLS";
+  private static final String KEY_STORE_TYPE = KeyStore.getDefaultType();
   private static final String SSL_DIR_NAME = "postgresql";
   private static final String CERTIFICATE_FACTORY_TYPE = "X.509";
 
@@ -191,7 +191,7 @@ public class SSLEngineFactory {
 
     SSLContext sslContext;
     try {
-      sslContext = SSLContext.getInstance(SSL_PROTOCOL);
+      sslContext = SSLContext.getInstance(SSLCONTEXT_PROTOCOL);
     }
     catch (NoSuchAlgorithmException e) {
       throw new IOException("ssl context not available", e);

--- a/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
@@ -30,7 +30,6 @@ package com.impossibl.postgres.protocol.ssl;
 
 import com.impossibl.postgres.system.Context;
 import com.impossibl.postgres.utils.Factory;
-import com.impossibl.postgres.utils.Paths;
 
 import static com.impossibl.postgres.system.Settings.SSL_CERT_FILE;
 import static com.impossibl.postgres.system.Settings.SSL_CERT_FILE_DEFAULT;
@@ -39,9 +38,7 @@ import static com.impossibl.postgres.system.Settings.SSL_KEY_FILE_DEFAULT;
 import static com.impossibl.postgres.system.Settings.SSL_PASSWORD_CALLBACK;
 import static com.impossibl.postgres.system.Settings.SSL_PASSWORD_CALLBACK_DEFAULT;
 import static com.impossibl.postgres.system.Settings.SSL_ROOT_CERT_FILE;
-import static com.impossibl.postgres.system.Settings.SSL_ROOT_CERT_FILE_DEFAULT;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -70,13 +67,10 @@ public class SSLEngineFactory {
   private static final String TRUST_MANAGER_FACTORY_TYPE = TrustManagerFactory.getDefaultAlgorithm();
   private static final String SSLCONTEXT_PROTOCOL = "TLS";
   private static final String KEY_STORE_TYPE = KeyStore.getDefaultType();
-  private static final String SSL_DIR_NAME = "postgresql";
   private static final String CERTIFICATE_FACTORY_TYPE = "X.509";
 
 
   public static SSLEngine create(SSLMode sslMode, Context context) throws IOException {
-
-    String sslDir = Paths.getHome(SSL_DIR_NAME);
 
     /*
      * Load client's certificate and key file paths
@@ -145,40 +139,41 @@ public class SSLEngineFactory {
        */
 
       String sslRootCertFile = context.getSetting(SSL_ROOT_CERT_FILE, String.class);
-      if (sslRootCertFile == null) {
-        sslRootCertFile = sslDir + File.separator + SSL_ROOT_CERT_FILE_DEFAULT;
-      }
+      if (sslRootCertFile != null) {
 
-      try (FileInputStream sslRootCertInputStream = new FileInputStream(sslRootCertFile)) {
+        try (FileInputStream sslRootCertInputStream = new FileInputStream(sslRootCertFile)) {
 
-        try {
+          try {
 
-          CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_FACTORY_TYPE);
+            CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_FACTORY_TYPE);
 
-          Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(sslRootCertInputStream);
+            Collection<? extends Certificate> certificates = certificateFactory.generateCertificates(sslRootCertInputStream);
 
-          keyStore.load(null, null);
+            keyStore.load(null, null);
 
-          Iterator<? extends Certificate> certificatesIter = certificates.iterator();
-          for (int i = 0; certificatesIter.hasNext(); ++i) {
-            keyStore.setCertificateEntry("cert" + i, certificatesIter.next());
+            Iterator<? extends Certificate> certificatesIter = certificates.iterator();
+            for (int i = 0; certificatesIter.hasNext(); ++i) {
+              keyStore.setCertificateEntry("cert" + i, certificatesIter.next());
+            }
+
+            trustManagerFactory.init(keyStore);
+          }
+          catch (GeneralSecurityException e) {
+            throw new IOException("loading SSL root certificate failed", e);
           }
 
-          trustManagerFactory.init(keyStore);
         }
-        catch (GeneralSecurityException e) {
-          throw new IOException("loading SSL root certificate failed", e);
+        catch (FileNotFoundException e) {
+          throw new IOException("cannot not open SSL root certificate file " + sslRootCertFile, e);
+        }
+        catch (IOException e1) {
+          // Ignore...
         }
 
+        trustManagers = trustManagerFactory.getTrustManagers();
+      } else {
+        trustManagers = null;
       }
-      catch (FileNotFoundException e) {
-        throw new IOException("cannot not open SSL root certificate file " + sslRootCertFile, e);
-      }
-      catch (IOException e1) {
-        // Ignore...
-      }
-
-      trustManagers = trustManagerFactory.getTrustManagers();
     }
     else {
 

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
@@ -61,6 +61,7 @@ import javax.naming.ldap.Rdn;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
@@ -122,6 +123,10 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
           // Attach the actual handler
 
           SSLEngine sslEngine = SSLEngineFactory.create(sslMode, context);
+          SSLParameters sslParameters = context.getSetting("sslParameters", SSLParameters.class);
+          if (sslParameters != null) {
+              sslEngine.setSSLParameters(sslParameters);
+          }
 
           final SslHandler sslHandler = new SslHandler(sslEngine);
 

--- a/src/main/java/com/impossibl/postgres/system/Settings.java
+++ b/src/main/java/com/impossibl/postgres/system/Settings.java
@@ -82,7 +82,6 @@ public class Settings {
   public static final String SSL_PASSWORD_CALLBACK_DEFAULT = ConsolePasswordCallbackHandler.class.getName();
 
   public static final String SSL_ROOT_CERT_FILE = "ssl.root.cert.file";
-  public static final String SSL_ROOT_CERT_FILE_DEFAULT = "root.crt";
 
   public static final String NETWORK_TIMEOUT = "networkTimeout";
   public static final int NETWORK_TIMEOUT_DEFAULT = 0;


### PR DESCRIPTION
This is a further development of pull request #170.

Instead of trying to load a `root.crt` file by default (which would be very specific to PostgreSQL), this would use the JVM default trust store when no CA bundle file is specified. In a Java context, this probably makes more sense.

(Similarly, it would also make sense to be able to pass an `SSLContext` parameter to initialise a possible client certificate, since loading private keys and client certificates from PEM files is less common from a Java point of view. This could be a further development, but that might change the default values some people currently use.)
