### PR TITLE
Multiple platform and locale related test errors running on Windows 7

### DIFF
--- a/src/main/java/com/impossibl/postgres/api/data/Interval.java
+++ b/src/main/java/com/impossibl/postgres/api/data/Interval.java
@@ -37,7 +37,6 @@ import java.util.StringTokenizer;
 import static java.lang.Double.parseDouble;
 import static java.lang.Integer.parseInt;
 import static java.lang.Math.round;
-import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -59,7 +58,6 @@ public class Interval {
     dfs.setDecimalSeparator('.');
     secondsFormat.setDecimalFormatSymbols(dfs);
   }
-
 
   public Interval(int months, int days, long timeMicros) {
     super();
@@ -337,13 +335,13 @@ public class Interval {
     StringBuilder buffer = new StringBuilder();
 
     buffer.
-      append("@ ").
-      append(getYears()).append(" years ").
-      append(getMonths()).append(" months ").
-      append(getDays()).append(" days ").
-      append(getHours()).append(" hours ").
-      append(getMinutes()).append(" minutes ").
-      append(format("%f", getSeconds())).append(" seconds");
+        append("@ ").
+        append(getYears()).append(" years ").
+        append(getMonths()).append(" months ").
+        append(getDays()).append(" days ").
+        append(getHours()).append(" hours ").
+        append(getMinutes()).append(" minutes ").
+        append(secondsFormat.format(getSeconds())).append(" seconds");
 
     return buffer.toString();
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionPoolDataSourceObjectFactory.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionPoolDataSourceObjectFactory.java
@@ -50,7 +50,8 @@ public class PGConnectionPoolDataSourceObjectFactory implements ObjectFactory {
   /**
    * {@inheritDoc}
    */
-  public Object getObjectInstance(Object o, Name n, Context ctx, Hashtable env) throws Exception {
+  @Override
+  public Object getObjectInstance(Object o, Name n, Context ctx, @SuppressWarnings("rawtypes") Hashtable env) throws Exception {
     Reference ref = (Reference)o;
     String className = ref.getClassName();
     if (className.equals("com.impossibl.postgres.jdbc.PGConnectionPoolDataSource")) {

--- a/src/main/java/com/impossibl/postgres/system/procs/Intervals.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Intervals.java
@@ -36,8 +36,8 @@ import com.impossibl.postgres.types.Type;
 import static com.impossibl.postgres.types.PrimitiveType.Interval;
 
 import java.io.IOException;
-
-import static java.lang.String.format;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 
 import io.netty.buffer.ByteBuf;
 
@@ -139,6 +139,14 @@ public class Intervals extends SimpleProcProvider {
 
   static class TxtEncoder extends TextEncoder {
 
+    private static final DecimalFormat secondsFormat;
+    static {
+      secondsFormat = new DecimalFormat("0.00####");
+      DecimalFormatSymbols dfs = secondsFormat.getDecimalFormatSymbols();
+      dfs.setDecimalSeparator('.');
+      secondsFormat.setDecimalFormatSymbols(dfs);
+    }
+
     @Override
     public Class<?> getInputType() {
       return Interval.class;
@@ -161,7 +169,7 @@ public class Intervals extends SimpleProcProvider {
         append(ival.getDays()).append(" days ").
         append(ival.getHours()).append(" hours ").
         append(ival.getMinutes()).append(" minutes ").
-        append(format("%f", ival.getSeconds())).append(" seconds");
+        append(secondsFormat.format(ival.getSeconds())).append(" seconds");
 
     }
 

--- a/src/test/java/com/impossibl/postgres/jdbc/BlobTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/BlobTest.java
@@ -184,17 +184,23 @@ public class BlobTest {
   public void testGetBytesOffsetBlob() throws Exception {
     assertTrue(uploadFileBlob("pom.xml") > 0);
 
+    String eol = String.format("%n");
+
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
     assertTrue(rs.next());
 
     Blob lob = rs.getBlob(1);
-    byte[] data = lob.getBytes(2, 4);
-    assertEquals(data.length, 4);
+    int blobLength = 3 + eol.length();
+    byte[] data = lob.getBytes(2, blobLength);
+    assertEquals(data.length, blobLength);
     assertEquals(data[0], '!');
     assertEquals(data[1], '-');
     assertEquals(data[2], '-');
-    assertEquals(data[3], '\n');
+
+    for (int i = 0; i < eol.length(); i++) {
+      assertEquals(data[3 + i], eol.charAt(i));
+    }
 
     stmt.close();
     rs.close();
@@ -204,17 +210,23 @@ public class BlobTest {
   public void testGetBytesOffsetClob() throws Exception {
     assertTrue(uploadFileClob("pom.xml") > 0);
 
+    String eol = String.format("%n");
+
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT lo FROM testblob");
     assertTrue(rs.next());
 
     Clob lob = rs.getClob(1);
-    String data = lob.getSubString(2, 4);
-    assertEquals(data.length(), 4);
+    int blobLength = 3 + eol.length();
+    String data = lob.getSubString(2, blobLength);
+    assertEquals(data.length(), blobLength);
     assertEquals(data.charAt(0), '!');
     assertEquals(data.charAt(1), '-');
     assertEquals(data.charAt(2), '-');
-    assertEquals(data.charAt(3), '\n');
+
+    for (int i = 0; i < eol.length(); i++) {
+      assertEquals(data.charAt(3 + i), eol.charAt(i));
+    }
 
     stmt.close();
     rs.close();

--- a/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
@@ -378,14 +378,17 @@ public class ConnectionTest {
     }
     con.commit();
 
+    Statement stmt = con.createStatement();
+
     // Get a new connection and kill the first one
     Connection killer = TestUtil.openDB();
-    try (Statement stmt = killer.createStatement()) {
-      stmt.execute("SELECT pg_terminate_backend(" + pid + ")");
+    try (Statement kstmt = killer.createStatement()) {
+      kstmt.execute("SELECT pg_terminate_backend(" + pid + ")");
     }
     killer.close();
 
-    Statement stmt = con.createStatement();
+    Thread.sleep(200);
+
     try {
       stmt.execute("SELECT 1");
       fail("Expected SQLException");

--- a/src/test/java/com/impossibl/postgres/jdbc/IntervalTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/IntervalTest.java
@@ -144,7 +144,7 @@ public class IntervalTest {
     Type type = pgConnectionImpl.getRegistry().loadType("Interval");
     String coercedStringValue = SQLTypeUtils.coerceToString(interval, type, pgConnectionImpl);
 
-    assertEquals("@ 1 years 3 months 0 days 0 hours 0 minutes 0.000000 seconds", coercedStringValue);
+    assertEquals("@ 1 years 3 months 0 days 0 hours 0 minutes 0.00 seconds", coercedStringValue);
   }
 
   @Test(expected = SQLException.class)


### PR DESCRIPTION
Fix for eol error in Blobtest
Fix for decimal separator locale dependency in codectest (decimal separator is always parsed as dot '.' when parsing string, but may have been rendered with comma or other depending on locale.  
Fix for race condition in connectiontest.testKillConnection due to pg_terminate_backend may not complete synchronously.
