### PR TITLE
Allow Binary and Text Encoder/Decoders to be extended

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,19 @@
 	</configuration>
       </plugin>
       <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-source-plugin</artifactId>
+    <executions>
+      <execution>
+        <id>attach-sources</id>
+        <goals>
+          <goal>jar</goal>
+		  <goal>test-jar</goal>
+        </goals>
+      </execution>
+    </executions>
+      </plugin>
+      <plugin>
 	<groupId>org.codehaus.mojo</groupId>
 	<artifactId>build-helper-maven-plugin</artifactId>
 	<version>1.9.1</version>

--- a/src/main/java/com/impossibl/postgres/system/procs/BinaryDecoder.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/BinaryDecoder.java
@@ -37,7 +37,7 @@ import io.netty.buffer.ByteBuf;
 
 public abstract class BinaryDecoder implements Type.Codec.Decoder {
 
-  abstract Object decode(Type type, Short typeLength, Integer typeModifier, ByteBuf buffer, Context context) throws IOException;
+  protected abstract Object decode(Type type, Short typeLength, Integer typeModifier, ByteBuf buffer, Context context) throws IOException;
 
   @Override
   public Object decode(Type type, Short typeLength, Integer typeModifier, Object buffer, Context context) throws IOException {

--- a/src/main/java/com/impossibl/postgres/system/procs/BinaryEncoder.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/BinaryEncoder.java
@@ -38,7 +38,7 @@ import io.netty.buffer.ByteBuf;
 
 public abstract class BinaryEncoder implements Type.Codec.Encoder {
 
-  abstract void encode(Type type, ByteBuf buffer, Object val, Context context) throws IOException;
+  protected abstract void encode(Type type, ByteBuf buffer, Object val, Context context) throws IOException;
 
   @Override
   public void encode(Type type, Object buffer, Object value, Context context) throws IOException {

--- a/src/main/java/com/impossibl/postgres/system/procs/Dates.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Dates.java
@@ -204,6 +204,7 @@ public class Dates extends SimpleProcProvider {
     }
 
     @Override
+    protected
     Object decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException {
 
       Map<String, Object> pieces = new HashMap<>();
@@ -228,6 +229,7 @@ public class Dates extends SimpleProcProvider {
     }
 
     @Override
+    protected
     void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
 
       String strVal = context.getDateFormatter().getPrinter().format((Instant) val);

--- a/src/main/java/com/impossibl/postgres/system/procs/TextDecoder.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/TextDecoder.java
@@ -37,7 +37,7 @@ import io.netty.buffer.ByteBuf;
 
 public abstract class TextDecoder implements Type.Codec.Decoder {
 
-  abstract Object decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException;
+  protected abstract Object decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException;
 
   @Override
   public Object decode(Type type, Short typeLength, Integer typeModifier, Object buffer, Context context) throws IOException {

--- a/src/main/java/com/impossibl/postgres/system/procs/TextEncoder.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/TextEncoder.java
@@ -37,7 +37,7 @@ import io.netty.buffer.ByteBuf;
 
 public abstract class TextEncoder implements Type.Codec.Encoder {
 
-  abstract void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException;
+  protected abstract void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException;
 
   @Override
   public void encode(Type type, Object buffer, Object value, Context context) throws IOException {

--- a/src/main/java/com/impossibl/postgres/system/procs/Tids.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Tids.java
@@ -58,6 +58,7 @@ public class Tids extends SimpleProcProvider {
     }
 
     @Override
+    protected
     Object decode(Type type, Short typeLength, Integer typeModifier, ByteBuf buffer, Context context) throws IOException {
 
       int length = buffer.readInt();
@@ -89,6 +90,7 @@ public class Tids extends SimpleProcProvider {
     }
 
     @Override
+    protected
     void encode(Type type, ByteBuf buffer, Object val, Context context) throws IOException {
 
       if (val == null) {
@@ -126,6 +128,7 @@ public class Tids extends SimpleProcProvider {
     }
 
     @Override
+    protected
     Tid decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException {
 
       String[] items = buffer.subSequence(1, buffer.length() - 1).toString().split(",");
@@ -151,6 +154,7 @@ public class Tids extends SimpleProcProvider {
     }
 
     @Override
+    protected
     void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
 
       Tid tid = (Tid) val;

--- a/src/main/java/com/impossibl/postgres/system/procs/TimesWithTZ.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/TimesWithTZ.java
@@ -145,6 +145,7 @@ public class TimesWithTZ extends SettingSelectProcProvider {
     }
 
     @Override
+    protected
     Object decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException {
 
       Map<String, Object> pieces = new HashMap<>();
@@ -169,6 +170,7 @@ public class TimesWithTZ extends SettingSelectProcProvider {
     }
 
     @Override
+    protected
     void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
 
       String strVal = context.getTimeFormatter().getPrinter().format((Instant) val);

--- a/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
@@ -135,6 +135,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
     }
 
     @Override
+    protected
     Object decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException {
 
       Map<String, Object> pieces = new HashMap<>();
@@ -159,6 +160,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
     }
 
     @Override
+    protected
     void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
 
       String strVal = context.getTimeFormatter().getPrinter().format((Instant) val);

--- a/src/main/java/com/impossibl/postgres/system/procs/Timestamps.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Timestamps.java
@@ -190,6 +190,7 @@ public class Timestamps extends SettingSelectProcProvider {
     }
 
     @Override
+    protected
     Object decode(Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Context context) throws IOException {
 
       Map<String, Object> pieces = new HashMap<>();
@@ -220,6 +221,7 @@ public class Timestamps extends SettingSelectProcProvider {
     }
 
     @Override
+    protected
     void encode(Type type, StringBuilder buffer, Object val, Context context) throws IOException {
 
       String strVal = context.getTimestampFormatter().getPrinter().format((Instant) val);


### PR DESCRIPTION
Changed visibility on BinaryEncoder++ to protected from package visible so it's possible to reuse these in other projects needing to extend codecs.

Added generating source jars to maven pom.xml to make it easier to use as dependencies in development
