### PR TITLE
SSL for datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,32 @@ certain frameworks, and test suites. See
 [http://github.com/impossibl/pgjdbc-ng/wiki/StrictMode](http://github.com/impossibl/pgjdbc-ng/wiki/StrictMode "pgjdbc-ng strictMode")
 for additional details.
 
+	SSL                 (boolean)  false
+
+Enable SSL for data sources.
+
+	ssl.mode          (String)
+
+The 'ssl.mode' parameter specifies which SSL mode that should be used to connect to the database server.
+Valid values include 'prefer', 'require', 'verify-ca' and 'verify-full'. Data source property is 'SSLMode'.
+
+	ssl.password          (String)
+
+The 'ssl.password' parameter specifies the SSL password. Data source property is 'SSLPassword'.
+
+	ssl.cert.file          (String)
+
+The 'ssl.cert.file' parameter specifies the SSL certificate file as a path. Data source property is 'SSLCertificateFile'.
+
+	ssl.key.file          (String)
+
+The 'ssl.key.file' parameter specifies the SSL key file as a path. Data source property is 'SSLKeyFile'.
+
+	ssl.root.cert.file          (String)
+
+The 'ssl.root.cert.file' parameter specifies the SSL root certificate file as a path. Data source property is 'SSLRootCertificateFile'.
+
+
 ## License
 
 pgjdbc-ng is released under the 3 clause BSD license.

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 	  <excludes>
 	    <exclude>**/PerformanceTest.java</exclude>
 	    <exclude>**/GiantBlobTest.java</exclude>
-	    <exclude>**/SSLTest.java</exclude>
+	    <exclude>**/SSL*.java</exclude>
 	    <exclude>**/ServerDisconnectTest.java</exclude>
 	  </excludes>
 	</configuration>

--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -65,6 +65,13 @@ public abstract class AbstractDataSource implements CommonDataSource {
   private int networkTimeout;
   private boolean strictMode;
 
+  private boolean ssl;
+  private String sslMode;
+  private String sslPassword;
+  private String sslCertificateFile;
+  private String sslKeyFile;
+  private String sslRootCertificateFile;
+
   /**
    * Constructor
    */
@@ -82,6 +89,13 @@ public abstract class AbstractDataSource implements CommonDataSource {
     this.clientEncoding = null;
     this.networkTimeout = Settings.NETWORK_TIMEOUT_DEFAULT;
     this.strictMode = Settings.STRICT_MODE_DEFAULT;
+
+    this.ssl = false;
+    this.sslMode = null;
+    this.sslPassword = null;
+    this.sslCertificateFile = null;
+    this.sslKeyFile = null;
+    this.sslRootCertificateFile = null;
   }
 
   /**
@@ -173,6 +187,25 @@ public abstract class AbstractDataSource implements CommonDataSource {
     if (strictMode != Settings.STRICT_MODE_DEFAULT)
       ref.add(new StringRefAddr("strictMode", Boolean.toString(strictMode)));
 
+    if (ssl) {
+      ref.add(new StringRefAddr("ssl", "true"));
+
+      if (sslMode != null)
+        ref.add(new StringRefAddr("sslMode", sslMode));
+
+      if (sslPassword != null)
+        ref.add(new StringRefAddr("sslPassword", sslPassword));
+
+      if (sslCertificateFile != null)
+        ref.add(new StringRefAddr("sslCertificateFile", sslCertificateFile));
+
+      if (sslKeyFile != null)
+        ref.add(new StringRefAddr("sslKeyFile", sslKeyFile));
+
+      if (sslRootCertificateFile != null)
+        ref.add(new StringRefAddr("sslRootCertificateFile", sslRootCertificateFile));
+    }
+
     return ref;
   }
 
@@ -230,6 +263,32 @@ public abstract class AbstractDataSource implements CommonDataSource {
     value = getReferenceValue(reference, "strictMode");
     if (value != null)
       strictMode = Boolean.valueOf(value);
+
+    value = getReferenceValue(reference, "ssl");
+    if (value != null)
+      ssl = true;
+
+    if (ssl) {
+      value = getReferenceValue(reference, "sslMode");
+      if (value != null)
+        sslMode = value;
+
+      value = getReferenceValue(reference, "sslPassword");
+      if (value != null)
+        sslPassword = value;
+
+      value = getReferenceValue(reference, "sslCertificateFile");
+      if (value != null)
+        sslCertificateFile = value;
+
+      value = getReferenceValue(reference, "sslKeyFile");
+      if (value != null)
+        sslKeyFile = value;
+
+      value = getReferenceValue(reference, "sslRootCertificateFile");
+      if (value != null)
+        sslRootCertificateFile = value;
+    }
   }
 
   /**
@@ -445,6 +504,102 @@ public abstract class AbstractDataSource implements CommonDataSource {
   }
 
   /**
+   * Is SSL enabled
+   * @return The value
+   */
+  public boolean getSSL() {
+    return ssl;
+  }
+
+  /**
+   * Enable/disable SSL
+   * @param v The value
+   */
+  public void setSSL(boolean v) {
+    ssl = v;
+  }
+
+  /**
+   * Get the SSL mode
+   * @return The value
+   */
+  public String getSSLMode() {
+    return sslMode;
+  }
+
+  /**
+   * Set the SSL mode
+   * @param v The value
+   */
+  public void setSSLMode(String v) {
+    sslMode = v;
+  }
+
+  /**
+   * Get the SSL password
+   * @return The value
+   */
+  public String getSSLPassword() {
+    return sslPassword;
+  }
+
+  /**
+   * Set the SSL password
+   * @param v The value
+   */
+  public void setSSLPassword(String v) {
+    sslPassword = v;
+  }
+
+  /**
+   * Get the SSL certificate file
+   * @return The value
+   */
+  public String getSSLCertificateFile() {
+    return sslCertificateFile;
+  }
+
+  /**
+   * Set the SSL certificate file
+   * @param v The value
+   */
+  public void setSSLCertificateFile(String v) {
+    sslCertificateFile = v;
+  }
+
+  /**
+   * Get the SSL key file
+   * @return The value
+   */
+  public String getSSLKeyFile() {
+    return sslKeyFile;
+  }
+
+  /**
+   * Set the SSL key file
+   * @param v The value
+   */
+  public void setSSLKeyFile(String v) {
+    sslKeyFile = v;
+  }
+
+  /**
+   * Get the SSL root certificate file
+   * @return The value
+   */
+  public String getSSLRootCertificateFile() {
+    return sslRootCertificateFile;
+  }
+
+  /**
+   * Set the SSL root certificate file
+   * @param v The value
+   */
+  public void setSSLRootCertificateFile(String v) {
+    sslRootCertificateFile = v;
+  }
+
+  /**
    * Create a connection
    *
    * @param u
@@ -487,6 +642,25 @@ public abstract class AbstractDataSource implements CommonDataSource {
       props.put(Settings.CLIENT_ENCODING, clientEncoding);
     props.put(Settings.NETWORK_TIMEOUT, Integer.toString(networkTimeout));
     props.put(Settings.STRICT_MODE, Boolean.toString(strictMode));
+
+    if (ssl) {
+      if (sslMode != null)
+        props.put(Settings.SSL_MODE, sslMode);
+      else
+        props.put(Settings.SSL_MODE, "Require");
+
+      if (sslPassword != null)
+        props.put(Settings.SSL_PASSWORD, sslPassword);
+
+      if (sslCertificateFile != null)
+        props.put(Settings.SSL_CERT_FILE, sslCertificateFile);
+
+      if (sslKeyFile != null)
+        props.put(Settings.SSL_KEY_FILE, sslKeyFile);
+
+      if (sslRootCertificateFile != null)
+        props.put(Settings.SSL_ROOT_CERT_FILE, sslRootCertificateFile);
+    }
 
     return ConnectionUtil.createConnection(url, props, housekeeper);
   }

--- a/src/main/java/com/impossibl/postgres/protocol/ssl/OnDemandKeyManager.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ssl/OnDemandKeyManager.java
@@ -71,7 +71,7 @@ import javax.security.auth.x500.X500Principal;
  * A Key manager that only loads the keys, if necessary.
  *
  */
-public class OnDemadKeyManager extends X509ExtendedKeyManager {
+public class OnDemandKeyManager extends X509ExtendedKeyManager {
 
   private X509Certificate[] certificates = null;
   private PrivateKey key = null;
@@ -90,7 +90,7 @@ public class OnDemadKeyManager extends X509ExtendedKeyManager {
    * @param cbh
    * @param defaultfile
    */
-  public OnDemadKeyManager(String certfile, String keyfile, CallbackHandler cbh, boolean defaultfile) {
+  public OnDemandKeyManager(String certfile, String keyfile, CallbackHandler cbh, boolean defaultfile) {
     this.certfile = certfile;
     this.keyfileName = keyfile;
     this.cbh = cbh;

--- a/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ssl/SSLEngineFactory.java
@@ -114,7 +114,7 @@ public class SSLEngineFactory {
       ((ContextCallbackHandler) sslPasswordCallback).init(context);
     }
 
-    KeyManager keyManager = new OnDemadKeyManager(sslCertFile, sslKeyFile, sslPasswordCallback, sslFileIsDefault);
+    KeyManager keyManager = new OnDemandKeyManager(sslCertFile, sslKeyFile, sslPasswordCallback, sslFileIsDefault);
 
     /*
      * Initialize Trust Managers

--- a/src/test/java/com/impossibl/postgres/jdbc/SSLDataSourceTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/SSLDataSourceTest.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright (c) 2015, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/*-------------------------------------------------------------------------
+ *
+ * Copyright (c) 2004-2011, PostgreSQL Global Development Group
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+package com.impossibl.postgres.jdbc;
+
+import java.io.FileInputStream;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import javax.sql.DataSource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+
+@RunWith(Parameterized.class)
+public class SSLDataSourceTest {
+
+  protected String certdir;
+  protected String db;
+  protected String sslmode;
+  protected boolean goodclient;
+  protected boolean goodserver;
+  protected String prefix;
+  protected Object[] expected;
+
+  public SSLDataSourceTest(String name, String certdir, String db, String sslmode, boolean goodclient, boolean goodserver, String prefix, Object[] expected) {
+    this.certdir = certdir;
+    this.db = db;
+    this.sslmode = sslmode;
+    this.goodclient = goodclient;
+    this.goodserver = goodserver;
+    this.prefix = prefix;
+    this.expected = expected;
+  }
+
+  @Test
+  public void testConnection() throws Throwable {
+    driver(makeDataSource(), expected);
+  }
+
+  private DataSource makeDataSource() {
+    PGDataSource ds = new PGDataSource();
+    ds.setHost("localhost");
+    ds.setPort(Integer.valueOf(TestUtil.getPort()));
+
+    if ("sslhostnossl".equals(db)) {
+      ds.setDatabase("hostnossldb");
+    }
+    else if ("sslhostgh".equals(db)) {
+      ds.setDatabase("hostdb");
+    }
+    else if ("sslhostbh".equals(db)) {
+      ds.setHost("127.0.0.1");
+      ds.setDatabase("hostdb");
+    }
+    else if ("sslhostsslgh".equals(db)) {
+      ds.setDatabase("hostssldb");
+    }
+    else if ("sslhostsslbh".equals(db)) {
+      ds.setHost("127.0.0.1");
+      ds.setDatabase("hostssldb");
+    }
+    else if ("sslhostsslcertgh".equals(db)) {
+      ds.setDatabase("hostsslcertdb");
+    }
+    else if ("sslhostsslcertbh".equals(db)) {
+      ds.setHost("127.0.0.1");
+      ds.setDatabase("hostsslcertdb");
+    }
+    else if ("sslcertgh".equals(db)) {
+      ds.setDatabase("certdb");
+    }
+    else if ("sslcertbh".equals(db)) {
+      ds.setHost("127.0.0.1");
+      ds.setDatabase("certdb");
+    }
+
+    ds.setUser(TestUtil.getUser());
+    ds.setPassword(TestUtil.getPassword());
+    ds.setNetworkTimeout(10000);
+
+    ds.setSSL(true);
+    ds.setSSLMode(sslmode);
+    ds.setSSLPassword("sslpwd");
+    ds.setSSLCertificateFile(certdir + "/" + prefix + (goodclient ? "goodclient.crt" : "badclient.crt"));
+    ds.setSSLKeyFile(certdir + "/" + prefix + (goodclient ? "goodclient.pk8" : "badclient.pk8"));
+    ds.setSSLRootCertificateFile(certdir + "/" + prefix + (goodserver ? "goodroot.crt" : "badroot.crt"));
+
+    return ds;
+  }
+
+  /**
+   * Tries to connect to the database.
+   *
+   * @param ds
+   *          DataSource instance
+   * @param expected
+   *          Expected values. the first element is a String holding the
+   *          expected message of PSQLException or null, if no exception is
+   *          expected, the second indicates weather ssl is to be used (Boolean)
+   * @throws SQLException
+   */
+  protected void driver(DataSource ds, Object[] expected) throws SQLException {
+    String exmsg = (String) expected[0];
+    try {
+      try (Connection conn = ds.getConnection()) {
+        if (exmsg != null) {
+          fail("Exception did not occur: " + exmsg);
+        }
+        try (Statement stmt = conn.createStatement()) {
+          try (ResultSet rs = stmt.executeQuery("select ssl_is_used()")) {
+            assertTrue(rs.next());
+            assertEquals("ssl_is_used: ", ((Boolean) expected[1]).booleanValue(), rs.getBoolean(1));
+          }
+        }
+      }
+    }
+    catch (SQLException ex) {
+      if (exmsg == null) { // no exception is excepted
+        fail("Exception thrown: " + ex.getMessage());
+      }
+      else {
+        assertTrue("expected: " + exmsg + " actual: " + ex.getMessage(), ex.getMessage().matches(exmsg));
+        return;
+      }
+    }
+  }
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> suite() throws Exception {
+
+    Collection<Object[]> data = new ArrayList<>();
+
+    Properties prop = new Properties();
+    prop.load(new FileInputStream("src/test/resources/ssltest.properties"));
+    add(data, prop, "ssloff");
+    add(data, prop, "sslhostnossl");
+
+    String[] hostmode = {"sslhost", "sslhostssl", "sslhostsslcert", "sslcert"};
+    String[] certmode = {"gh", "bh"};
+
+    for (int i = 0; i < hostmode.length; i++) {
+      for (int j = 0; j < certmode.length; j++) {
+        add(data, prop, hostmode[i] + certmode[j]);
+      }
+    }
+
+    return data;
+  }
+
+  private static void add(Collection<Object[]> data, Properties prop, String param) {
+
+    if (prop.getProperty(param, "").equals("")) {
+      System.out.println("Skipping " + param + ".");
+    }
+    else {
+      data.addAll(testData(prop, param));
+    }
+
+  }
+
+  private static Collection<Object[]> testData(Properties prop, String param) {
+    String certdir = prop.getProperty("certdir");
+    String sprefix = prop.getProperty(param + "prefix");
+    String[] csslmode = {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"};
+
+    Map<String, Object[]> expected = expectedmap.get(param);
+    if (expected == null) {
+      expected = defaultexpected;
+    }
+
+    Collection<Object[]> data = new ArrayList<>();
+
+    for (int i = 0; i < csslmode.length; i++) {
+      data.add(new Object[] {param + "-" + csslmode[i] + "GG", certdir, param, csslmode[i], true, true, sprefix, expected.get(csslmode[i] + "GG")});
+      data.add(new Object[] {param + "-" + csslmode[i] + "GB", certdir, param, csslmode[i], true, false, sprefix, expected.get(csslmode[i] + "GB")});
+      data.add(new Object[] {param + "-" + csslmode[i] + "BG", certdir, param, csslmode[i], false, true, sprefix, expected.get(csslmode[i] + "BG")});
+    }
+    return data;
+  }
+
+  static Map<String, Map<String, Object[]>> expectedmap;
+  static TreeMap<String, Object[]> defaultexpected;
+
+  static String PG_HBA_ON = "Connection Error: no pg_hba.conf entry for host .*, user .*, database .*, SSL on(?s-d:.*)";
+  static String PG_HBA_OFF = "Connection Error: no pg_hba.conf entry for host .*, user .*, database .*, SSL off(?s-d:.*)";
+  static String FAILED = "The connection attempt failed.";
+  static String BROKEN = "Connection Error: SSL Error: Received fatal alert: unknown_ca";
+  static String ANY = ".*";
+  static String VALIDATOR = "Connection Error: SSL Error: PKIX path (building|validation) failed:.*";
+  static String HOSTNAME = "Connection Error: SSL Error: The hostname .* could not be verified";
+
+  static {
+    defaultexpected = new TreeMap<>();
+    defaultexpected.put("disableGG", new Object[] {null, Boolean.FALSE});
+    defaultexpected.put("disableGB", new Object[] {null, Boolean.FALSE});
+    defaultexpected.put("disableBG", new Object[] {null, Boolean.FALSE});
+    defaultexpected.put("allowGG", new Object[] {null, Boolean.FALSE});
+    defaultexpected.put("allowGB", new Object[] {null, Boolean.FALSE});
+    defaultexpected.put("allowBG", new Object[] {null, Boolean.FALSE});
+    defaultexpected.put("preferGG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("preferGB", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("preferBG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("requireGG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("requireGB", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("requireBG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("verify-caGG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("verify-caGB", new Object[] {ANY, Boolean.TRUE});
+    defaultexpected.put("verify-caBG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("verify-fullGG", new Object[] {null, Boolean.TRUE});
+    defaultexpected.put("verify-fullGB", new Object[] {ANY, Boolean.TRUE});
+    defaultexpected.put("verify-fullBG", new Object[] {null, Boolean.TRUE});
+
+    expectedmap = new TreeMap<>();
+
+    TreeMap<String, Object[]> work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {null, Boolean.FALSE});
+    work.put("disableGB", new Object[] {null, Boolean.FALSE});
+    work.put("disableBG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGB", new Object[] {null, Boolean.FALSE});
+    work.put("allowBG", new Object[] {null, Boolean.FALSE});
+    work.put("preferGG", new Object[] {null, Boolean.FALSE});
+    work.put("preferGB", new Object[] {null, Boolean.FALSE});
+    work.put("preferBG", new Object[] {null, Boolean.FALSE});
+    work.put("requireGG", new Object[] {ANY, Boolean.TRUE});
+    work.put("requireGB", new Object[] {ANY, Boolean.TRUE});
+    work.put("requireBG", new Object[] {ANY, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {ANY, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {ANY, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {ANY, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {ANY, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {ANY, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {ANY, Boolean.TRUE});
+    expectedmap.put("ssloff", work);
+
+    work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {null, Boolean.FALSE});
+    work.put("disableGB", new Object[] {null, Boolean.FALSE});
+    work.put("disableBG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGB", new Object[] {null, Boolean.FALSE});
+    work.put("allowBG", new Object[] {null, Boolean.FALSE});
+    work.put("preferGG", new Object[] {null, Boolean.FALSE});
+    work.put("preferGB", new Object[] {null, Boolean.FALSE});
+    work.put("preferBG", new Object[] {null, Boolean.FALSE});
+    work.put("requireGG", new Object[] {PG_HBA_ON, Boolean.TRUE});
+    work.put("requireGB", new Object[] {PG_HBA_ON, Boolean.TRUE});
+    work.put("requireBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {PG_HBA_ON, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {PG_HBA_ON, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {BROKEN, Boolean.TRUE});
+    expectedmap.put("sslhostnossl", work);
+
+    work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {null, Boolean.FALSE});
+    work.put("disableGB", new Object[] {null, Boolean.FALSE});
+    work.put("disableBG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGB", new Object[] {null, Boolean.FALSE});
+    work.put("allowBG", new Object[] {null, Boolean.FALSE});
+    work.put("preferGG", new Object[] {null, Boolean.TRUE});
+    work.put("preferGB", new Object[] {null, Boolean.TRUE});
+    work.put("preferBG", new Object[] {null, Boolean.FALSE});
+    work.put("requireGG", new Object[] {null, Boolean.TRUE});
+    work.put("requireGB", new Object[] {null, Boolean.TRUE});
+    work.put("requireBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {BROKEN, Boolean.TRUE});
+    expectedmap.put("sslhostgh", work);
+
+    work = new TreeMap<>(work);
+    work.put("disableGG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableGB", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableBG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.TRUE});
+    work.put("allowGB", new Object[] {null, Boolean.TRUE});
+    work.put("allowBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("preferBG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    expectedmap.put("sslhostsslgh", work);
+
+    work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {null, Boolean.FALSE});
+    work.put("disableGB", new Object[] {null, Boolean.FALSE});
+    work.put("disableBG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.FALSE});
+    work.put("allowGB", new Object[] {null, Boolean.FALSE});
+    work.put("allowBG", new Object[] {null, Boolean.FALSE});
+    work.put("preferGG", new Object[] {null, Boolean.TRUE});
+    work.put("preferGB", new Object[] {null, Boolean.TRUE});
+    work.put("preferBG", new Object[] {null, Boolean.FALSE});
+    work.put("requireGG", new Object[] {null, Boolean.TRUE});
+    work.put("requireGB", new Object[] {null, Boolean.TRUE});
+    work.put("requireBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {HOSTNAME, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {BROKEN, Boolean.TRUE});
+    expectedmap.put("sslhostbh", work);
+
+    work = new TreeMap<>(work);
+    work.put("disableGG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableGB", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableBG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.TRUE});
+    work.put("allowGB", new Object[] {null, Boolean.TRUE});
+    work.put("allowBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("preferBG", new Object[] {PG_HBA_OFF, Boolean.TRUE});
+    expectedmap.put("sslhostsslbh", work);
+
+    work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableGB", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableBG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.TRUE});
+    work.put("allowGB", new Object[] {null, Boolean.TRUE});
+    work.put("allowBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("preferGG", new Object[] {null, Boolean.TRUE});
+    work.put("preferGB", new Object[] {null, Boolean.TRUE});
+    work.put("preferBG", new Object[] {PG_HBA_OFF, Boolean.TRUE});
+    work.put("requireGG", new Object[] {null, Boolean.TRUE});
+    work.put("requireGB", new Object[] {null, Boolean.TRUE});
+    work.put("requireBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {BROKEN, Boolean.TRUE});
+    expectedmap.put("sslhostsslcertgh", work);
+
+    work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableGB", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableBG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.TRUE});
+    work.put("allowGB", new Object[] {null, Boolean.TRUE});
+    work.put("allowBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("preferGG", new Object[] {null, Boolean.TRUE});
+    work.put("preferGB", new Object[] {null, Boolean.TRUE});
+    work.put("preferBG", new Object[] {PG_HBA_OFF, Boolean.TRUE});
+    work.put("requireGG", new Object[] {null, Boolean.TRUE});
+    work.put("requireGB", new Object[] {null, Boolean.TRUE});
+    work.put("requireBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {HOSTNAME, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {BROKEN, Boolean.TRUE});
+    expectedmap.put("sslhostsslcertbh", work);
+
+    work = new TreeMap<>(defaultexpected);
+    work.put("disableGG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableGB", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("disableBG", new Object[] {PG_HBA_OFF, Boolean.FALSE});
+    work.put("allowGG", new Object[] {null, Boolean.TRUE});
+    work.put("allowGB", new Object[] {null, Boolean.TRUE});
+    work.put("allowBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("preferGG", new Object[] {null, Boolean.TRUE});
+    work.put("preferGB", new Object[] {null, Boolean.TRUE});
+    work.put("preferBG", new Object[] {PG_HBA_OFF, Boolean.TRUE});
+    work.put("requireGG", new Object[] {null, Boolean.TRUE});
+    work.put("requireGB", new Object[] {null, Boolean.TRUE});
+    work.put("requireBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-caGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-caGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-caBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {null, Boolean.TRUE});
+    work.put("verify-fullGB", new Object[] {VALIDATOR, Boolean.TRUE});
+    work.put("verify-fullBG", new Object[] {BROKEN, Boolean.TRUE});
+    expectedmap.put("sslcertgh", work);
+
+    work = new TreeMap<>(work);
+    work.put("allowBG", new Object[] {BROKEN, Boolean.TRUE});
+    work.put("preferBG", new Object[] {PG_HBA_OFF, Boolean.TRUE});
+    work.put("verify-fullGG", new Object[] {HOSTNAME, Boolean.TRUE});
+    expectedmap.put("sslcertbh", work);
+  }
+
+}

--- a/src/test/resources/certdir/README
+++ b/src/test/resources/certdir/README
@@ -36,19 +36,19 @@ openssl pkcs8 -topk8 -in badclient.key -out badclient.pk8 -outform DER -v1 PBE-M
 cp goodclient.crt server/root.crt
 cd server
 openssl req -x509 -newkey rsa:1024 -nodes -days 3650 -keyout server.key -out server.crt
-cp server.crt ../goodroot.crt
 #Common name is localhost, no password
+cp server.crt ../goodroot.crt
 
 The subdirectory server contains what should be copied to the PGDATA directory.
 If you do not overwrite the pg_hba.conf then remember to comment out all lines
 starting with "host all".
 
 For the tests the sslinfo module must be installed into every database.
-The ssl=on must be set in postgresql.conf
+The ssl=on and ssl_ca_file='root.crt' must be set in postgresql.conf.
 
 The following command creates the databases and installs the sslinfo module.
 
-for db in hostssldb hostnossldb certdb hostsslcertdb; do
+for db in hostdb hostssldb hostnossldb certdb hostsslcertdb; do
   createdb $db
   psql $db -c "create extension sslinfo"
 done


### PR DESCRIPTION
Here is the initial SSL support for data sources.

It follows the existing functionality for the connection parameters, which can be documented in README.md now.

I'll likely do further changes, but SSLDataSourceTest is passing - although it is a bit hacky in its test setup.

Ideally this will go in after the 0.6 release, but comments are welcome now
