### PR TITLE
Fixing NPE when BlobOutputStream#close() called more than once

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/BlobOutputStream.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/BlobOutputStream.java
@@ -90,6 +90,8 @@ public class BlobOutputStream extends OutputStream {
 
   @Override
   public void close() throws IOException {
+    if (lo == null) return;
+
     flush();
     try {
       lo.close();

--- a/src/test/java/com/impossibl/postgres/jdbc/BlobTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/BlobTest.java
@@ -1292,4 +1292,46 @@ public class BlobTest {
     conn.commit();
   }
 
+  @Test
+  public void testBlobClose() throws Exception {
+    final Blob blob = conn.createBlob();
+    try {
+      OutputStream blobOutputStream = blob.setBinaryStream(1L);
+      try {
+        java.io.BufferedOutputStream bufferedOutputStream =
+          new java.io.BufferedOutputStream(blobOutputStream);
+        try {
+          bufferedOutputStream.write(100);
+        }
+        finally {
+          bufferedOutputStream.close();
+        }
+      }
+      finally {
+        blobOutputStream.close();
+      }
+    }
+    finally {
+      blob.free();
+    }
+  }
+
+  @Test
+  public void testBlobCloseWithResources() throws Exception {
+    final Blob blob = conn.createBlob();
+    try {
+      OutputStream blobOutputStream = blob.setBinaryStream(1L);
+      try (java.io.BufferedOutputStream bufferedOutputStream =
+              new java.io.BufferedOutputStream(blobOutputStream)) {
+        bufferedOutputStream.write(100);
+      }
+      finally {
+        blobOutputStream.close();
+      }
+    }
+    finally {
+      blob.free();
+    }
+  }
+
 }


### PR DESCRIPTION
I encounter a `NullPointerException` when calling `close()` more than once on the output stream returned via java.sql.Blob#setBinaryStream(long)  (created from Connection#createBlob()). Since I wrap the output stream inside a buffered output stream, I end up calling `close()` more than once. This also happens when using Java 7's `try`-with-resources syntax. Please see tests (added in [BlobTest.java](src/test/java/com/impossibl/postgres/jdbc/BlobTest.java)) that mimics my code.
