### PR TITLE
Use strong references for notification listeners

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -643,6 +643,8 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
 
     shutdown();
 
+    notificationListeners.clear();
+
     if (housekeeper != null) {
       housekeeper.remove(cleanupKey);
       housekeeper.release();


### PR DESCRIPTION
These objects do not need to be tracked by a housekeeper therefore do not need the be referenced weakly.
