### PR TITLE
multiple code improvements squid:S1905, squid:S1488, squid:EmptyState…

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextEscapeFunctions.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextEscapeFunctions.java
@@ -217,7 +217,7 @@ class SQLTextEscapeFunctions {
    * @return a Method object or null if not found
    */
   public static Method getEscapeMethod(String functionName) {
-    return (Method) functionMap.get(functionName.toLowerCase(Locale.US));
+    return functionMap.get(functionName.toLowerCase(Locale.US));
   }
 
   public static Node invokeEscape(Method method, String name, List<Node> args) throws SQLException {

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTypeUtils.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTypeUtils.java
@@ -85,10 +85,7 @@ class SQLTypeUtils {
   }
 
   public static Class<?> mapSetType(Format format, Type sourceType) {
-
-    Class<?> targetType = sourceType.getJavaType(format, null);
-
-    return targetType;
+    return sourceType.getJavaType(format, null);
   }
 
   public static Class<?> mapGetType(Type sourceType, Map<String, Class<?>> typeMap, Context context) {

--- a/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
@@ -171,7 +171,7 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
       notifyAll();
     }
 
-  };
+  }
 
 
   private String statementName;

--- a/src/main/java/com/impossibl/postgres/protocol/v30/QueryCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/QueryCommandImpl.java
@@ -120,7 +120,7 @@ public class QueryCommandImpl extends CommandImpl implements QueryCommand {
       notifyAll();
     }
 
-  };
+  }
 
 
 

--- a/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -419,16 +419,15 @@ public class BasicContext implements Context {
     return new PreparedQuery(null, prepare.getDescribedParameterTypes(), prepare.getDescribedResultFields());
   }
 
+  @SuppressWarnings("unchecked")
   public <T> List<T> queryResults(String queryTxt, Class<T> rowType, Object... params) throws IOException, NoticeException {
 
     QueryCommand.ResultBatch resultBatch = queryBatch(queryTxt, rowType, params);
 
-    @SuppressWarnings("unchecked")
-    List<T> res = (List<T>) resultBatch.results;
-
-    return res;
+    return (List<T>) resultBatch.results;
   }
 
+  @SuppressWarnings("unchecked")
   public List<Object> queryResults(String queryTxt) throws IOException, NoticeException {
 
     QueryCommand.ResultBatch resultBatch;
@@ -464,10 +463,7 @@ public class BasicContext implements Context {
       return Collections.emptyList();
     }
 
-    @SuppressWarnings("unchecked")
-    List<Object> results = (List<Object>) resultBatch.results;
-
-    return results;
+    return (List<Object>) resultBatch.results;
   }
 
   public void query(String queryTxt) throws IOException, NoticeException {

--- a/src/main/java/com/impossibl/postgres/utils/ByteBufs.java
+++ b/src/main/java/com/impossibl/postgres/utils/ByteBufs.java
@@ -39,9 +39,7 @@ public class ByteBufs {
     byte[] bytes = new byte[buffer.bytesBefore((byte) 0) + 1];
     buffer.readBytes(bytes);
 
-    String res = new String(bytes, 0, bytes.length - 1, charset);
-
-    return res;
+    return new String(bytes, 0, bytes.length - 1, charset);
   }
 
   public static void writeCString(ByteBuf buffer, String val, Charset charset) {

--- a/src/main/java/com/impossibl/postgres/utils/guava/Strings.java
+++ b/src/main/java/com/impossibl/postgres/utils/guava/Strings.java
@@ -170,8 +170,7 @@ public class Strings {
     final long longSize = (long) len * (long) count;
     final int size = (int) longSize;
     if (size != longSize) {
-      throw new ArrayIndexOutOfBoundsException("Required array size too large: "
-          + String.valueOf(longSize));
+      throw new ArrayIndexOutOfBoundsException("Required array size too large: " + longSize);
     }
 
     final char[] array = new char[size];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1905 Redundant casts should not be used,
squid:S1488 Local Variables should not be declared and then immediately returned or thrown,
squid:EmptyStatementUsageCheck Empty statements should be removed.
You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1905
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AEmptyStatementUsageCheck
Please let me know if you have any questions.
George Kankava
