### PR TITLE
squid:S2325 private methods that don't access instance data should be static

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -297,7 +297,7 @@ public abstract class AbstractDataSource implements CommonDataSource {
    * @param key The key
    * @return The value
    */
-  private String getReferenceValue(Reference reference, String key) {
+  private static String getReferenceValue(Reference reference, String key) {
     RefAddr refAddr = reference.get(key);
 
     if (refAddr == null)

--- a/src/main/java/com/impossibl/postgres/jdbc/PGBlob.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGBlob.java
@@ -88,7 +88,7 @@ public class PGBlob implements Blob {
     }
   }
 
-  private void checkPosition(long pos) throws SQLException {
+  private static void checkPosition(long pos) throws SQLException {
     if (pos < 1) {
       throw ILLEGAL_ARGUMENT;
     }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -158,7 +158,7 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
     super.parseIfNeeded();
   }
 
-  private Pattern getRegexForParameter(int paramIndex) {
+  private static Pattern getRegexForParameter(int paramIndex) {
 
     Pattern pattern = PARAM_REPLACE_REGEXES.get(paramIndex);
     if (pattern == null) {

--- a/src/main/java/com/impossibl/postgres/jdbc/PGClob.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGClob.java
@@ -104,7 +104,7 @@ public class PGClob implements Clob {
     }
   }
 
-  private void checkPosition(long pos) throws SQLException {
+  private static void checkPosition(long pos) throws SQLException {
     if (pos < 1) {
       throw ILLEGAL_ARGUMENT;
     }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -1531,7 +1531,7 @@ class PGDatabaseMetaData implements DatabaseMetaData {
     return createResultSet(Arrays.asList(fields), results);
   }
 
-  private void mapACLPrivileges(String owner, ACLItem[] aclItems, Map<String, Map<String, List<String[]>>> privileges) {
+  private static void mapACLPrivileges(String owner, ACLItem[] aclItems, Map<String, Map<String, List<String[]>>> privileges) {
 
     if (aclItems == null) {
       // Null is shortcut for owner having full privileges

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
@@ -201,7 +201,7 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
 
   }
 
-  private void startup(ProtocolImpl protocol, BasicContext context) throws IOException, NoticeException {
+  private static void startup(ProtocolImpl protocol, BasicContext context) throws IOException, NoticeException {
 
     Map<String, Object> params = new HashMap<String, Object>();
 
@@ -273,7 +273,7 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
     }
   }
 
-  private IOException translateConnectionException(Exception e) {
+  private static IOException translateConnectionException(Exception e) {
 
     IOException io;
 

--- a/src/main/java/com/impossibl/postgres/system/procs/Arrays.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Arrays.java
@@ -488,7 +488,7 @@ public class Arrays extends SimpleProcProvider {
 
     }
 
-    private boolean needsQuotes(String elemStr, char delim) {
+    private static boolean needsQuotes(String elemStr, char delim) {
 
       if (elemStr.isEmpty())
         return true;

--- a/src/main/java/com/impossibl/postgres/system/procs/Ranges.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Ranges.java
@@ -177,7 +177,7 @@ public class Ranges extends SimpleProcProvider {
       return Range.create(lower, lowerInc, upper, upperInc);
     }
 
-    private int findBound(CharSequence buffer, int start) {
+    private static int findBound(CharSequence buffer, int start) {
 
       boolean string = false;
 
@@ -274,7 +274,7 @@ public class Ranges extends SimpleProcProvider {
 
     }
 
-    private boolean needsQuotes(String elemStr) {
+    private static boolean needsQuotes(String elemStr) {
 
       if (elemStr.isEmpty())
         return true;

--- a/src/main/java/com/impossibl/postgres/system/procs/Records.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Records.java
@@ -368,7 +368,7 @@ public class Records extends SimpleProcProvider {
 
     }
 
-    private boolean needsQuotes(String elemStr, char delim) {
+    private static boolean needsQuotes(String elemStr, char delim) {
 
       if (elemStr.isEmpty())
         return true;

--- a/src/main/java/com/impossibl/postgres/utils/GeometryParsers.java
+++ b/src/main/java/com/impossibl/postgres/utils/GeometryParsers.java
@@ -234,7 +234,7 @@ public enum GeometryParsers {
   /**
    * Returns A,B and C as in Ax+By+C=0 given 2 points
    */
-  private double[] lineConstructPts(double[] pt1, double[] pt2) {
+  private static double[] lineConstructPts(double[] pt1, double[] pt2) {
     double[] lineabc = new double[3];
     if (pt1[0] == pt2[0]) { /* vertical */
       /* use "x = C" */
@@ -327,7 +327,7 @@ public enum GeometryParsers {
     return new Path(pr.p, !pr.isOpen);
   }
 
-  private int pairCount(CharSequence s, char delim) {
+  private static int pairCount(CharSequence s, char delim) {
     int ndelim = 0;
     int max = s.length() - 1;
     int pos = 0;
@@ -445,7 +445,7 @@ public enum GeometryParsers {
     }
   }
 
-  private int findLastDelim(CharSequence s, int pos, char delim) {
+  private static int findLastDelim(CharSequence s, int pos, char delim) {
     int found = -1;
     int max = s.length() - 1;
     while (pos < max) {
@@ -551,7 +551,7 @@ public enum GeometryParsers {
     return pos;
   }
 
-  private int parseExponent(CharSequence s, int pos) {
+  private static int parseExponent(CharSequence s, int pos) {
     int max = s.length() - 1;
     if (pos >= max) {
       return pos;
@@ -621,7 +621,7 @@ public enum GeometryParsers {
     return pos;
   }
 
-  private int consummeSpace(CharSequence s, int pos, boolean checkEOS) {
+  private static int consummeSpace(CharSequence s, int pos, boolean checkEOS) {
     int max = s.length() - 1;
     while (pos <= max && Character.isSpaceChar(s.charAt(pos))) {
       ++pos;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2325 private methods that don't access instance data should be static.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava
