### PR TITLE
squid:CommentedOutCodeLine Sections of code should not be commented out

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGStatementDelegator.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGStatementDelegator.java
@@ -393,7 +393,6 @@ public class PGStatementDelegator implements Statement {
   @Override
   public boolean isWrapperFor(Class<?> iface) throws SQLException {
     try {
-      //checkClosed();
       return delegator.isWrapperFor(iface);
     }
     catch (SQLException se) {
@@ -408,7 +407,6 @@ public class PGStatementDelegator implements Statement {
   @Override
   public <T> T unwrap(Class<T> iface) throws SQLException {
     try {
-      //checkClosed();
       return delegator.unwrap(iface);
     }
     catch (SQLException se) {

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextEscapeFunctions.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextEscapeFunctions.java
@@ -593,13 +593,6 @@ class SQLTextEscapeFunctions {
       return ident("hour");
     else if (SQL_TSI_MINUTE.equalsIgnoreCase(shortType))
       return ident("minute");
-    // See http://archives.postgresql.org/pgsql-jdbc/2006-03/msg00096.php
-    /*
-     * else if (SQL_TSI_MONTH.equalsIgnoreCase(shortType)) return "month"; else
-     * if (SQL_TSI_QUARTER.equalsIgnoreCase(shortType)) return "quarter"; else
-     * if (SQL_TSI_WEEK.equalsIgnoreCase(shortType)) return "week"; else if
-     * (SQL_TSI_YEAR.equalsIgnoreCase(shortType)) return "year";
-     */
     else if (SQL_TSI_FRAC_SECOND.equalsIgnoreCase(shortType))
       throw new SQLException(GT.tr("Interval {0} not yet implemented", "SQL_TSI_FRAC_SECOND"), PSQLState.SYNTAX_ERROR);
     else

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/Base64.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/Base64.java
@@ -414,9 +414,6 @@ public class Base64 {
   private static int decode4to3(byte[] source, int srcOffset, byte[] destination, int destOffset) {
     // Example: Dk==
     if (source[srcOffset + 2] == EQUALS_SIGN) {
-      // Two ways to do the same thing. Don't know which way I like best.
-      //int outBuff =   ( ( DECODABET[ source[ srcOffset    ] ] << 24 ) >>>  6 )
-      //              | ( ( DECODABET[ source[ srcOffset + 1] ] << 24 ) >>> 12 );
       int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
         | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12);
 
@@ -425,10 +422,6 @@ public class Base64 {
     }
     // Example: DkL=
     else if (source[ srcOffset + 3 ] == EQUALS_SIGN) {
-      // Two ways to do the same thing. Don't know which way I like best.
-      //int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] << 24 ) >>>  6 )
-      //              | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
-      //              | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 );
       int outBuff = ((DECODABET[source[srcOffset]] & 0xFF) << 18)
         | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
         | ((DECODABET[source[srcOffset + 2]] & 0xFF) <<  6);
@@ -440,11 +433,6 @@ public class Base64 {
     // Example: DkLE
     else {
       try {
-        // Two ways to do the same thing. Don't know which way I like best.
-        //int outBuff =   ( ( DECODABET[ source[ srcOffset     ] ] << 24 ) >>>  6 )
-        //              | ( ( DECODABET[ source[ srcOffset + 1 ] ] << 24 ) >>> 12 )
-        //              | ( ( DECODABET[ source[ srcOffset + 2 ] ] << 24 ) >>> 18 )
-        //              | ( ( DECODABET[ source[ srcOffset + 3 ] ] << 24 ) >>> 24 );
         int outBuff =   ((DECODABET[source[srcOffset]] & 0xFF) << 18)
           | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
           | ((DECODABET[source[srcOffset + 2]] & 0xFF) <<  6)

--- a/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
@@ -43,8 +43,6 @@ public class Numerics extends SimpleProcProvider {
 
   private static final short NUMERIC_POS =    (short) 0x0000;
   private static final short NUMERIC_NEG =    (short) 0x4000;
-  //private static final short NUMERIC_SHORT =  (short) 0x8000;
-  //private static final short NUMERIC_NAN =    (short) 0xC000;
   private static final short DEC_DIGITS = 4;
 
   public Numerics() {

--- a/src/main/java/com/impossibl/postgres/system/procs/Procs.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Procs.java
@@ -39,56 +39,6 @@ import java.util.ServiceLoader;
 
 public class Procs {
 
-  /*
-   * Master ProcProvider List (Loaded as service through META-INF/services/*.ProcProvider)
-   */
-  /*
-  private static final ProcProvider[] PROVIDERS = {
-    new ACLItems(),
-    new Arrays(),
-    new BitMods(),
-    new Bits(),
-    new Bools(),
-    new Boxes(),
-    new Bytes(),
-    new Cidrs(),
-    new Circles(),
-    new Dates(),
-    new Domains(),
-    new Float4s(),
-    new Float8s(),
-    new HStores(),
-    new Inets(),
-    new Int2s(),
-    new Int4s(),
-    new Int8s(),
-    new Intervals(),
-    new Lines(),
-    new LSegs(),
-    new MacAddrs(),
-    new Moneys(),
-    new Names(),
-    new NumericMods(),
-    new Numerics(),
-    new Oids(),
-    new Paths(),
-    new Points(),
-    new Polygons(),
-    new Ranges(),
-    new Records(),
-    new Strings(),
-    new Tids(),
-    new TimeMods(),
-    new TimestampMods(),
-    new TimestampsWithoutTZ(),
-    new TimestampsWithTZ(),
-    new TimesWithoutTZ(),
-    new TimesWithTZ(),
-    new UUIDs(),
-    new XMLs(),
-  };
-  */
-
   private static final Type.Codec.Decoder[] DEFAULT_DECODERS = {new Unknowns.TxtDecoder(), new Unknowns.BinDecoder()};
   private static final Type.Codec.Encoder[] DEFAULT_ENCODERS = {new Unknowns.TxtEncoder(), new Unknowns.BinEncoder()};
   private static final Modifiers.Parser DEFAULT_MOD_PARSER = new Unknowns.ModParser();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:CommentedOutCodeLine Sections of code should not be commented out.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ACommentedOutCodeLine
Please let me know if you have any questions.
George Kankava
