### PR TITLE
squid:S2293 The diamond operator should be used

### DIFF
--- a/src/main/java/com/impossibl/postgres/api/data/Range.java
+++ b/src/main/java/com/impossibl/postgres/api/data/Range.java
@@ -119,11 +119,11 @@ public class Range<T> {
     flags |= upperInc ? Flags.RANGE_UB_INC : 0;
     flags |= upperInc && lower == null ? Flags.RANGE_UB_INF : 0;
     flags |= lower == null && upper == null && !lowerInc && !upperInc ? Flags.RANGE_EMPTY : 0;
-    return new Range<U>(new Flags((byte) flags), new Object[] {lower, upper});
+    return new Range<>(new Flags((byte) flags), new Object[] {lower, upper});
   }
 
   public static Range<?> createEmpty() {
-    return new Range<Object>(new Flags((byte) (Flags.RANGE_EMPTY | Flags.RANGE_LB_NULL | Flags.RANGE_UB_NULL)), new Object[] {});
+    return new Range<>(new Flags((byte) (Flags.RANGE_EMPTY | Flags.RANGE_LB_NULL | Flags.RANGE_UB_NULL)), new Object[] {});
   }
 
   public Range(Flags flags, Object[] values) {

--- a/src/main/java/com/impossibl/postgres/jdbc/PGArray.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGArray.java
@@ -133,7 +133,7 @@ public class PGArray implements Array {
       new ResultField("VALUE", 0, (short)0, elementType, (short)0, 0, Format.Binary)
     };
 
-    List<Object[]> results = new ArrayList<Object[]>(value.length);
+    List<Object[]> results = new ArrayList<>(value.length);
     for (long c = index, end = index + count; c < end; ++c) {
       results.add(new Object[]{c, value[(int) c - 1]});
     }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnection.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnection.java
@@ -64,8 +64,8 @@ public class PGPooledConnection implements PooledConnection {
    * connection.
    */
   public PGPooledConnection(PGConnectionImpl con, boolean autoCommit, boolean isXA) {
-    this.connectionListeners = new ArrayList<ConnectionEventListener>();
-    this.statementListeners = new ArrayList<StatementEventListener>();
+    this.connectionListeners = new ArrayList<>();
+    this.statementListeners = new ArrayList<>();
     this.con = con;
     this.last = null;
     this.autoCommit = autoCommit;

--- a/src/main/java/com/impossibl/postgres/jdbc/ThreadedHousekeeper.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/ThreadedHousekeeper.java
@@ -169,7 +169,7 @@ public class ThreadedHousekeeper implements Housekeeper {
 
   private boolean logLeaks = true;
   private ReferenceQueue<Object> cleanupQueue = new ReferenceQueue<>();
-  private Set<HousekeeperReference<?>> cleanupReferences = new HashSet<HousekeeperReference<?>>();
+  private Set<HousekeeperReference<?>> cleanupReferences = new HashSet<>();
   private AtomicBoolean cleanupThreadEnabled = new AtomicBoolean(true);
   private Thread cleanupThread = new Thread() {
 
@@ -234,7 +234,7 @@ public class ThreadedHousekeeper implements Housekeeper {
 
   @Override
   public synchronized <T> Object add(T referent, CleanupRunnable cleanup) {
-    HousekeeperReference<T> ref = new HousekeeperReference<T>(cleanup, referent, cleanupQueue);
+    HousekeeperReference<T> ref = new HousekeeperReference<>(cleanup, referent, cleanupQueue);
     cleanupReferences.add(ref);
     return cleanup;
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/PGXAConnection.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/PGXAConnection.java
@@ -330,7 +330,7 @@ public class PGXAConnection extends PGPooledConnection implements XAConnection, 
       // backed refuses to process new queries. Hopefully not a problem
       // in practice.
       try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery("SELECT gid FROM pg_prepared_xacts where database = current_database()")) {
-        List<Xid> l = new ArrayList<Xid>();
+        List<Xid> l = new ArrayList<>();
         while (rs.next()) {
           Xid recoveredXid = RecoveredXid.stringToXid(rs.getString(1));
           if (recoveredXid != null)

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolFactoryImpl.java
@@ -203,7 +203,7 @@ public class ProtocolFactoryImpl implements ProtocolFactory {
 
   private void startup(ProtocolImpl protocol, BasicContext context) throws IOException, NoticeException {
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
 
     params.put(APPLICATION_NAME, context.getSetting(APPLICATION_NAME, "pgjdbc app"));
     params.put(CLIENT_ENCODING, context.getSetting(CLIENT_ENCODING, "UTF8"));

--- a/src/main/java/com/impossibl/postgres/system/Version.java
+++ b/src/main/java/com/impossibl/postgres/system/Version.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 public class Version {
 
   private static final Pattern VERSION_SPLIT_PATTERN = Pattern.compile("[^0-9]");
-  private static final HashMap<Version, Version> all = new HashMap<Version, Version>();
+  private static final HashMap<Version, Version> all = new HashMap<>();
 
   private int major;
   private Integer minor;

--- a/src/main/java/com/impossibl/postgres/system/procs/BitMods.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/BitMods.java
@@ -45,7 +45,7 @@ public class BitMods extends SimpleProcProvider {
     @Override
     public Map<String, Object> parse(long mod) {
 
-      Map<String, Object> mods = new HashMap<String, Object>();
+      Map<String, Object> mods = new HashMap<>();
 
       mods.put(LENGTH, (int)mod);
 

--- a/src/main/java/com/impossibl/postgres/system/procs/NumericMods.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/NumericMods.java
@@ -46,7 +46,7 @@ public class NumericMods extends SimpleProcProvider {
     @Override
     public Map<String, Object> parse(long mod) {
 
-      Map<String, Object> mods = new HashMap<String, Object>();
+      Map<String, Object> mods = new HashMap<>();
 
       if (mod > 4) {
         mods.put(PRECISION, (int)((mod - 4) >> 16) & 0xffff);

--- a/src/main/java/com/impossibl/postgres/system/procs/Ranges.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Ranges.java
@@ -81,7 +81,7 @@ public class Ranges extends SimpleProcProvider {
           values[1] = baseType.getBinaryCodec().decoder.decode(baseType, null, null, buffer, context);
         }
 
-        instance = new Range<Object>(flags, values);
+        instance = new Range<>(flags, values);
       }
 
       return instance;

--- a/src/main/java/com/impossibl/postgres/system/procs/Strings.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Strings.java
@@ -187,7 +187,7 @@ public class Strings extends SimpleProcProvider {
     @Override
     public Map<String, Object> parse(long mod) {
 
-      Map<String, Object> mods = new HashMap<String, Object>();
+      Map<String, Object> mods = new HashMap<>();
 
       if (mod > 4) {
         mods.put(LENGTH, (int)(mod - 4));

--- a/src/main/java/com/impossibl/postgres/system/procs/TimeMods.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/TimeMods.java
@@ -45,7 +45,7 @@ public class TimeMods extends SimpleProcProvider {
     @Override
     public Map<String, Object> parse(long mod) {
 
-      Map<String, Object> mods = new HashMap<String, Object>();
+      Map<String, Object> mods = new HashMap<>();
 
       if (mod >= 0)
         mods.put(PRECISION, (int)mod);

--- a/src/main/java/com/impossibl/postgres/system/procs/TimestampMods.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/TimestampMods.java
@@ -45,7 +45,7 @@ public class TimestampMods extends SimpleProcProvider {
     @Override
     public Map<String, Object> parse(long mod) {
 
-      Map<String, Object> mods = new HashMap<String, Object>();
+      Map<String, Object> mods = new HashMap<>();
 
       if (mod >= 0)
         mods.put(PRECISION, (int)mod);

--- a/src/main/java/com/impossibl/postgres/types/Registry.java
+++ b/src/main/java/com/impossibl/postgres/types/Registry.java
@@ -93,7 +93,7 @@ public class Registry {
     kindMap.put('r', RangeType.class);
 
     // Required initial types for bootstrapping
-    oidMap = new TreeMap<Integer, Type>();
+    oidMap = new TreeMap<>();
     oidMap.put(16, new BaseType(16, "bool",     (short) 1,  (byte) 0, Category.Boolean, ',', 0, "bool", procs));
     oidMap.put(17, new BaseType(17, "bytea",    (short) 1,  (byte) 0, Category.User,    ',', 0, "bytea", procs));
     oidMap.put(18, new BaseType(18, "char",     (short) 1,  (byte) 0, Category.String,  ',', 0, "char", procs));
@@ -349,7 +349,7 @@ public class Registry {
 
         Collection<PgAttribute.Row> relRows = pgAttrData.get(pgAttrRow.relationId);
         if (relRows == null) {
-          relRows = new HashSet<PgAttribute.Row>();
+          relRows = new HashSet<>();
           pgAttrData.put(pgAttrRow.relationId, relRows);
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar
rule squid:S2293 The diamond operator should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
Please let me know if you have any questions.
George Kankava
