### PR TITLE
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/com/impossibl/postgres/datetime/ISODateFormat.java
+++ b/src/main/java/com/impossibl/postgres/datetime/ISODateFormat.java
@@ -129,7 +129,7 @@ public class ISODateFormat implements DateTimeFormat {
       if (year < 1000) {
         // Add leading zeros
         yearString = "" + year;
-        yearString = yearZeros.substring(0, (4 - yearString.length())) + yearString;
+        yearString = yearZeros.substring(0, 4 - yearString.length()) + yearString;
       }
       else {
         yearString = "" + year;
@@ -156,7 +156,7 @@ public class ISODateFormat implements DateTimeFormat {
       timestampBuf.append(dayString);
       timestampBuf.append(" ");
 
-      return (timestampBuf.toString());
+      return timestampBuf.toString();
     }
 
   }

--- a/src/main/java/com/impossibl/postgres/datetime/ISOTimeFormat.java
+++ b/src/main/java/com/impossibl/postgres/datetime/ISOTimeFormat.java
@@ -182,7 +182,7 @@ public class ISOTimeFormat implements DateTimeFormat {
         microsString = Integer.toString(micros);
 
         // Add leading zeros
-        microsString = zeros.substring(0, (6 - microsString.length())) + microsString;
+        microsString = zeros.substring(0, 6 - microsString.length()) + microsString;
 
         // Truncate trailing zeros
         char[] microsChar = new char[microsString.length()];
@@ -212,7 +212,7 @@ public class ISOTimeFormat implements DateTimeFormat {
         timestampBuf.append(zoneOff);
       }
 
-      return (timestampBuf.toString());
+      return timestampBuf.toString();
     }
 
   }

--- a/src/main/java/com/impossibl/postgres/datetime/ISOTimestampFormat.java
+++ b/src/main/java/com/impossibl/postgres/datetime/ISOTimestampFormat.java
@@ -142,7 +142,7 @@ public class ISOTimestampFormat implements DateTimeFormat {
       if (year < 1000) {
         // Add leading zeros
         yearString = "" + year;
-        yearString = yearZeros.substring(0, (4 - yearString.length())) + yearString;
+        yearString = yearZeros.substring(0, 4 - yearString.length()) + yearString;
       }
       else {
         yearString = "" + year;
@@ -184,7 +184,7 @@ public class ISOTimestampFormat implements DateTimeFormat {
         microsString = Integer.toString(micros);
 
         // Add leading zeros
-        microsString = zeros.substring(0, (6 - microsString.length())) + microsString;
+        microsString = zeros.substring(0, 6 - microsString.length()) + microsString;
 
         // Truncate trailing zeros
         char[] microsChar = new char[microsString.length()];
@@ -220,7 +220,7 @@ public class ISOTimestampFormat implements DateTimeFormat {
         timestampBuf.append(zoneOff);
       }
 
-      return (timestampBuf.toString());
+      return timestampBuf.toString();
     }
 
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGBlob.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGBlob.java
@@ -58,7 +58,7 @@ public class PGBlob implements Blob {
       else {
         buffer = lo.read(MAX_BUFFER_SIZE);
         idx = 0;
-        result = (buffer.length > 0);
+        result = buffer.length > 0;
       }
       return result;
     }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGClob.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGClob.java
@@ -69,7 +69,7 @@ public class PGClob implements Clob {
       else {
         buffer = lo.read(MAX_BUFFER_SIZE);
         idx = 0;
-        result = (buffer.length > 0);
+        result = buffer.length > 0;
       }
       return result;
     }

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTypeMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTypeMetaData.java
@@ -212,7 +212,7 @@ class SQLTypeMetaData {
   }
 
   public static int getSQLTypeIndex(int sqlType) {
-    return (((sqlType % 255) + 255) % 255);
+    return (sqlType % 255 + 255) % 255;
   }
 
   private static PrimitiveType[][] sqlToPrimitiveMatrix;

--- a/src/main/java/com/impossibl/postgres/jdbc/xa/Base64.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/xa/Base64.java
@@ -254,19 +254,19 @@ public class Base64 {
 
     switch (numSigBytes) {
       case 3:
-        destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
+        destination[ destOffset     ] = ALPHABET[ inBuff >>> 18        ];
         destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
         destination[ destOffset + 2 ] = ALPHABET[ (inBuff >>>  6) & 0x3f ];
-        destination[ destOffset + 3 ] = ALPHABET[ (inBuff) & 0x3f ];
+        destination[ destOffset + 3 ] = ALPHABET[ inBuff & 0x3f ];
         return destination;
       case 2:
-        destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
+        destination[ destOffset     ] = ALPHABET[ inBuff >>> 18        ];
         destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
         destination[ destOffset + 2 ] = ALPHABET[ (inBuff >>>  6) & 0x3f ];
         destination[ destOffset + 3 ] = EQUALS_SIGN;
         return destination;
       case 1:
-        destination[ destOffset     ] = ALPHABET[ (inBuff >>> 18)        ];
+        destination[ destOffset     ] = ALPHABET[ inBuff >>> 18        ];
         destination[ destOffset + 1 ] = ALPHABET[ (inBuff >>> 12) & 0x3f ];
         destination[ destOffset + 2 ] = EQUALS_SIGN;
         destination[ destOffset + 3 ] = EQUALS_SIGN;
@@ -433,10 +433,10 @@ public class Base64 {
     // Example: DkLE
     else {
       try {
-        int outBuff =   ((DECODABET[source[srcOffset]] & 0xFF) << 18)
-          | ((DECODABET[source[srcOffset + 1]] & 0xFF) << 12)
-          | ((DECODABET[source[srcOffset + 2]] & 0xFF) <<  6)
-          | ((DECODABET[source[srcOffset + 3]] & 0xFF));
+        int outBuff =   (DECODABET[source[srcOffset]] & 0xFF) << 18
+          | (DECODABET[source[srcOffset + 1]] & 0xFF) << 12
+          | (DECODABET[source[srcOffset + 2]] & 0xFF) <<  6
+          | DECODABET[source[srcOffset + 3]] & 0xFF;
 
         destination[destOffset] = (byte)(outBuff >> 16);
         destination[destOffset + 1] = (byte)(outBuff >> 8);

--- a/src/main/java/com/impossibl/postgres/protocol/ssl/OnDemandKeyManager.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ssl/OnDemandKeyManager.java
@@ -138,7 +138,7 @@ public class OnDemandKeyManager extends X509ExtendedKeyManager {
               found = true;
             }
           }
-          return (found ? "user" : null);
+          return found ? "user" : null;
         }
       }
     }
@@ -190,7 +190,7 @@ public class OnDemandKeyManager extends X509ExtendedKeyManager {
   @Override
   public String[] getClientAliases(String keyType, Principal[] issuers) {
     String alias = chooseClientAlias(new String[] {keyType}, issuers, (Socket) null);
-    return (alias == null ? new String[] {} : new String[] {alias});
+    return alias == null ? new String[] {} : new String[] {alias};
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/system/procs/Arrays.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Arrays.java
@@ -78,7 +78,7 @@ public class Arrays extends SimpleProcProvider {
 
       if (length != -1) {
 
-        ArrayType atype = ((ArrayType)type);
+        ArrayType atype = (ArrayType)type;
 
         //
         //Header
@@ -187,7 +187,7 @@ public class Arrays extends SimpleProcProvider {
 
         int writeStart = buffer.writerIndex();
 
-        ArrayType atype = ((ArrayType)type);
+        ArrayType atype = (ArrayType)type;
         Type elementType = atype.getElementType();
 
         //
@@ -345,7 +345,7 @@ public class Arrays extends SimpleProcProvider {
 
       if (length != 0) {
 
-        ArrayType atype = ((ArrayType)type);
+        ArrayType atype = (ArrayType)type;
 
         instance = readArray(buffer, atype.getDelimeter(), type.unwrap(), context);
       }

--- a/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
@@ -308,7 +308,7 @@ public class Numerics extends SimpleProcProvider {
 
           short d1 = (short) (dig / b);
           dig -= d1 * b;
-          putIt |= (d1 > 0);
+          putIt |= d1 > 0;
           if (putIt)
             sb.append((char) (d1 + '0'));
         }

--- a/src/main/java/com/impossibl/postgres/utils/GeometryParsers.java
+++ b/src/main/java/com/impossibl/postgres/utils/GeometryParsers.java
@@ -598,7 +598,7 @@ public enum GeometryParsers {
       case '9':
         // looks like a number
         // eat a number
-        dot = (s.charAt(pos) == '.');
+        dot = s.charAt(pos) == '.';
         ++pos;
         while (pos <= max) {
           char c = s.charAt(pos);

--- a/src/main/java/com/impossibl/postgres/utils/Timer.java
+++ b/src/main/java/com/impossibl/postgres/utils/Timer.java
@@ -38,7 +38,7 @@ public class Timer {
   }
 
   public long getLap() {
-    long lap = (System.currentTimeMillis() - lapStart);
+    long lap = System.currentTimeMillis() - lapStart;
     lapStart = System.currentTimeMillis();
     return lap;
   }
@@ -48,7 +48,7 @@ public class Timer {
   }
 
   public long getTotal() {
-    return (System.currentTimeMillis() - start);
+    return System.currentTimeMillis() - start;
   }
 
   public float getTotalSeconds() {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule 
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava
