### PR TITLE
squid:ClassVariableVisibilityCheck Class variable fields should not have public accessibility

### DIFF
--- a/src/main/java/com/impossibl/postgres/api/data/ACLItem.java
+++ b/src/main/java/com/impossibl/postgres/api/data/ACLItem.java
@@ -37,9 +37,9 @@ import java.util.regex.Pattern;
 
 public class ACLItem {
 
-  public String user;
-  public String privileges;
-  public String grantor;
+  private String user;
+  private String privileges;
+  private String grantor;
 
   public ACLItem(String user, String privileges, String grantor) {
     super();
@@ -49,6 +49,30 @@ public class ACLItem {
   }
 
   private ACLItem() {
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getPrivileges() {
+    return privileges;
+  }
+
+  public void setPrivileges(String privileges) {
+    this.privileges = privileges;
+  }
+
+  public String getGrantor() {
+    return grantor;
+  }
+
+  public void setGrantor(String grantor) {
+    this.grantor = grantor;
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/api/data/Tid.java
+++ b/src/main/java/com/impossibl/postgres/api/data/Tid.java
@@ -36,11 +36,27 @@ package com.impossibl.postgres.api.data;
  */
 public class Tid {
 
-  public int block;
-  public short offset;
+  private int block;
+  private short offset;
 
   public Tid(int block, short offset) {
     this.block = block;
+    this.offset = offset;
+  }
+
+  public int getBlock() {
+    return block;
+  }
+
+  public void setBlock(int block) {
+    this.block = block;
+  }
+
+  public short getOffset() {
+    return offset;
+  }
+
+  public void setOffset(short offset) {
     this.offset = offset;
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -1545,14 +1545,14 @@ class PGDatabaseMetaData implements DatabaseMetaData {
         continue;
       }
 
-      for (int i = 0; i < aclItem.privileges.length(); i++) {
+      for (int i = 0; i < aclItem.getPrivileges().length(); i++) {
 
-        char c = aclItem.privileges.charAt(i);
+        char c = aclItem.getPrivileges().charAt(i);
         if (c != '*') {
 
           String sqlpriv;
           String grantable;
-          if (i < aclItem.privileges.length() - 1 && aclItem.privileges.charAt(i + 1) == '*') {
+          if (i < aclItem.getPrivileges().length() - 1 && aclItem.getPrivileges().charAt(i + 1) == '*') {
             grantable = "YES";
           }
           else {
@@ -1606,13 +1606,13 @@ class PGDatabaseMetaData implements DatabaseMetaData {
             privileges.put(sqlpriv, usersWithPermission);
           }
 
-          List<String[]> permissionByGrantor = usersWithPermission.get(aclItem.user);
+          List<String[]> permissionByGrantor = usersWithPermission.get(aclItem.getUser());
           if (permissionByGrantor == null) {
             permissionByGrantor = new ArrayList<>();
-            usersWithPermission.put(aclItem.user, permissionByGrantor);
+            usersWithPermission.put(aclItem.getUser(), permissionByGrantor);
           }
 
-          permissionByGrantor.add(new String[] {aclItem.grantor, grantable});
+          permissionByGrantor.add(new String[] {aclItem.getGrantor(), grantable});
 
         }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/PGRowId.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGRowId.java
@@ -53,8 +53,8 @@ public class PGRowId implements RowId {
   @Override
   public byte[] getBytes() {
     ByteBuf buf = Unpooled.buffer(8);
-    buf.writeInt(tid.block);
-    buf.writeShort(tid.offset);
+    buf.writeInt(tid.getBlock());
+    buf.writeShort(tid.getOffset());
     return buf.array();
   }
 

--- a/src/main/java/com/impossibl/postgres/system/procs/Tids.java
+++ b/src/main/java/com/impossibl/postgres/system/procs/Tids.java
@@ -100,8 +100,8 @@ public class Tids extends SimpleProcProvider {
         Tid tid = (Tid) val;
 
         buffer.writeInt(6);
-        buffer.writeInt(tid.block);
-        buffer.writeShort(tid.offset);
+        buffer.writeInt(tid.getBlock());
+        buffer.writeShort(tid.getOffset());
       }
 
     }
@@ -155,7 +155,7 @@ public class Tids extends SimpleProcProvider {
 
       Tid tid = (Tid) val;
 
-      buffer.append('(').append(tid.block).append(',').append(tid.offset).append(')');
+      buffer.append('(').append(tid.getBlock()).append(',').append(tid.getOffset()).append(')');
     }
 
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:ClassVariableVisibilityCheck Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava
