### PR TITLE
squid:S1125 Literal boolean values should not be used in condition expressions

### DIFF
--- a/src/main/java/com/impossibl/postgres/datetime/instants/AmbiguousInstant.java
+++ b/src/main/java/com/impossibl/postgres/datetime/instants/AmbiguousInstant.java
@@ -164,7 +164,7 @@ public class AmbiguousInstant extends InstantBase {
       return false;
     if (obj instanceof PreciseInstant)
       obj = ((PreciseInstant) obj).ambiguate();
-    else if (obj instanceof AmbiguousInstant == false)
+    else if (!(obj instanceof AmbiguousInstant))
       return false;
     AmbiguousInstant other = (AmbiguousInstant) obj;
     if (micros != other.micros)

--- a/src/main/java/com/impossibl/postgres/datetime/instants/InstantBase.java
+++ b/src/main/java/com/impossibl/postgres/datetime/instants/InstantBase.java
@@ -176,7 +176,7 @@ public abstract class InstantBase implements Instant {
       return true;
     if (obj == null)
       return false;
-    if (obj instanceof InstantBase == false)
+    if (!(obj instanceof InstantBase))
       return false;
     InstantBase other = (InstantBase) obj;
     if (type != other.type)

--- a/src/main/java/com/impossibl/postgres/datetime/instants/PreciseInstant.java
+++ b/src/main/java/com/impossibl/postgres/datetime/instants/PreciseInstant.java
@@ -168,7 +168,7 @@ public class PreciseInstant extends InstantBase {
       return false;
     if (obj instanceof AmbiguousInstant)
       return ambiguate().equals(obj);
-    if (obj instanceof PreciseInstant == false)
+    if (!(obj instanceof PreciseInstant))
       return false;
     PreciseInstant other = (PreciseInstant) obj;
     other = other.switchTo(getZone());

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
@@ -214,7 +214,7 @@ public class SQLText {
         }
       }
 
-      if (parents.peek() instanceof StatementNode == false && parents.peek() instanceof MultiStatementNode == false) {
+      if (!(parents.peek() instanceof StatementNode) && !(parents.peek() instanceof MultiStatementNode)) {
         throw new IllegalArgumentException("error parsing SQL");
       }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/SQLTextUtils.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/SQLTextUtils.java
@@ -242,7 +242,7 @@ class SQLTextUtils {
       return false;
     }
 
-    if (sqlText.getFirstStatement().getFirstNode().toString().equalsIgnoreCase("SELECT") == false) {
+    if (!sqlText.getFirstStatement().getFirstNode().toString().equalsIgnoreCase("SELECT")) {
       return false;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1125 Literal boolean values should not be used in condition expressions.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1125
Please let me know if you have any questions.
George Kankava
