### PR TITLE
Fix parsing standard conforming strings

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -41,6 +41,7 @@ import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.ServerObjectType;
 import com.impossibl.postgres.system.BasicContext;
 import com.impossibl.postgres.system.NoticeException;
+import com.impossibl.postgres.system.Settings;
 import com.impossibl.postgres.types.ArrayType;
 import com.impossibl.postgres.types.CompositeType;
 import com.impossibl.postgres.types.Type;
@@ -401,13 +402,15 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
   SQLText parseSQL(String sqlText) throws SQLException {
 
     try {
+      final boolean standardConformingStrings = getSetting(Settings.STANDARD_CONFORMING_STRINGS, false);
+
       if (parsedSqlCache == null) {
-        return new SQLText(sqlText);
+        return new SQLText(sqlText, standardConformingStrings);
       }
 
       SQLText parsedSql = parsedSqlCache.get(sqlText);
       if (parsedSql == null) {
-        parsedSql = new SQLText(sqlText);
+        parsedSql = new SQLText(sqlText, standardConformingStrings);
         parsedSqlCache.put(sqlText, parsedSql);
       }
 

--- a/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
@@ -304,13 +304,13 @@ public class PreparedStatementTest {
   @Test
   public void testSingleQuotes() throws SQLException {
     String[] testStrings = new String[] {"bare ? question mark", "quoted \\' single quote", "doubled '' single quote", "octal \\060 constant", "escaped \\? question mark",
-      "double \\\\ backslash", "double \" quote", };
+      "double \\\\ backslash", "double \" quote", "backslash \\\\\\' single quote"};
 
     String[] testStringsStdConf = new String[] {"bare ? question mark", "quoted '' single quote", "doubled '' single quote", "octal 0 constant", "escaped ? question mark",
-      "double \\ backslash", "double \" quote", };
+      "double \\ backslash", "double \" quote", "backslash \\'' single quote"};
 
     String[] expected = new String[] {"bare ? question mark", "quoted ' single quote", "doubled ' single quote", "octal 0 constant", "escaped ? question mark",
-      "double \\ backslash", "double \" quote", };
+      "double \\ backslash", "double \" quote", "backslash \\' single quote"};
 
     boolean oldStdStrings = TestUtil.getStandardConformingStrings(conn);
     Statement stmt = conn.createStatement();


### PR DESCRIPTION
It's impossible to unambiguously parse a string when two different ways
of escaping are possible: standard (where a single quote is escaped with
another single quote) and non-standard (where a single quote is escaped
with a backslash). One example of an ambiguous string is `\''`. In order
to parse it correctly parsing code needs to know whether current string
literal is standard-conforming or not.

Fixes #254
