### PR TITLE
Fix NPE when BlobOutputStream#close() is called more than once

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/BlobInputStream.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/BlobInputStream.java
@@ -48,6 +48,7 @@ public class BlobInputStream extends InputStream {
 
   @Override
   public int read() throws IOException {
+    checkClosed();
 
     if (pos >= buf.length) {
       readNextRegion();
@@ -58,6 +59,8 @@ public class BlobInputStream extends InputStream {
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
+    checkClosed();
+
     if (b == null) {
       throw new NullPointerException();
     }
@@ -96,6 +99,12 @@ public class BlobInputStream extends InputStream {
     }
     catch (SQLException e) {
       throw new IOException(e);
+    }
+  }
+
+  private void checkClosed() throws IOException {
+    if (lo == null) {
+      throw new IOException("Stream is closed");
     }
   }
 

--- a/src/main/java/com/impossibl/postgres/jdbc/BlobOutputStream.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/BlobOutputStream.java
@@ -50,6 +50,7 @@ public class BlobOutputStream extends OutputStream {
 
   @Override
   public void write(int b) throws IOException {
+    checkClosed();
 
     if (pos >= buf.length) {
       writeNextRegion();
@@ -67,6 +68,7 @@ public class BlobOutputStream extends OutputStream {
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
+    checkClosed();
 
     if (pos > 0) {
       writeNextRegion();
@@ -83,6 +85,10 @@ public class BlobOutputStream extends OutputStream {
 
   @Override
   public void flush() throws IOException {
+    if (lo == null) {
+      return;
+    }
+
     if (pos > 0) {
       writeNextRegion();
     }
@@ -90,6 +96,10 @@ public class BlobOutputStream extends OutputStream {
 
   @Override
   public void close() throws IOException {
+    if (lo == null) {
+      return;
+    }
+
     flush();
     try {
       lo.close();
@@ -114,6 +124,12 @@ public class BlobOutputStream extends OutputStream {
       throw new IOException(e);
     }
 
+  }
+
+  private void checkClosed() throws IOException {
+    if (lo == null) {
+      throw new IOException("Stream is closed");
+    }
   }
 
 }

--- a/src/test/java/com/impossibl/postgres/jdbc/BlobTest.java
+++ b/src/test/java/com/impossibl/postgres/jdbc/BlobTest.java
@@ -1292,4 +1292,46 @@ public class BlobTest {
     conn.commit();
   }
 
+  @Test
+  public void testBlobClose() throws Exception {
+    final Blob blob = conn.createBlob();
+    try {
+      OutputStream blobOutputStream = blob.setBinaryStream(1L);
+      try {
+        java.io.BufferedOutputStream bufferedOutputStream =
+            new java.io.BufferedOutputStream(blobOutputStream);
+        try {
+          bufferedOutputStream.write(100);
+        }
+        finally {
+          bufferedOutputStream.close();
+        }
+      }
+      finally {
+        blobOutputStream.close();
+      }
+    }
+    finally {
+      blob.free();
+    }
+  }
+
+  @Test
+  public void testBlobCloseWithResources() throws Exception {
+    final Blob blob = conn.createBlob();
+    try {
+      OutputStream blobOutputStream = blob.setBinaryStream(1L);
+      try (java.io.BufferedOutputStream bufferedOutputStream =
+               new java.io.BufferedOutputStream(blobOutputStream)) {
+        bufferedOutputStream.write(100);
+      }
+      finally {
+        blobOutputStream.close();
+      }
+    }
+    finally {
+      blob.free();
+    }
+  }
+
 }


### PR DESCRIPTION
This is a rework of #223
