### PR TITLE
Fix race condition for no-data commands that receive a spurious wake up

### DIFF
--- a/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/BindExecCommandImpl.java
@@ -87,7 +87,6 @@ public class BindExecCommandImpl extends CommandImpl implements BindExecCommand 
     public void noData() {
       resultBatch.fields = Collections.emptyList();
       resultBatch.results = null;
-      status = Status.Completed;
     }
 
     @Override


### PR DESCRIPTION
The fix here simply stops setting the command to complete after the `NoData` message from the server.  In `BindExecCommandImpl` this is never correct since we always send more messages after the `Describe` messages in this command.

Not setting the command status to complete causes the `waitFor` to keep waiting in the case of spurious thread wake ups. Previously, the command being marked complete, would cause `waitFor` to exit prematurely if it received a spurious wake up.
