### PR TITLE
Delay any parsing until data is requested

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
+          <argLine>-Dio.netty.leakDetection.level=advanced</argLine>
           <excludes>
             <exclude>**/PerformanceTest.java</exclude>
             <exclude>**/GiantBlobTest.java</exclude>

--- a/src/main/java/com/impossibl/postgres/jdbc/LargeObject.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/LargeObject.java
@@ -117,8 +117,7 @@ class LargeObject {
   }
 
   byte[] read(long len) throws SQLException {
-    InputStream data = connection.executeForFirstResultValue("@lo.read", true, InputStream.class, fd, (int) len);
-    try {
+    try (InputStream data = connection.executeForFirstResultValue("@lo.read", true, InputStream.class, fd, (int) len)) {
       return ByteStreams.toByteArray(data);
     }
     catch (IOException e) {

--- a/src/main/java/com/impossibl/postgres/jdbc/PGArray.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGArray.java
@@ -28,6 +28,8 @@
  */
 package com.impossibl.postgres.jdbc;
 
+import com.impossibl.postgres.protocol.DataRow;
+import com.impossibl.postgres.protocol.ParsedDataRow;
 import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.ResultField.Format;
 import com.impossibl.postgres.types.ArrayType;
@@ -133,9 +135,9 @@ public class PGArray implements Array {
       new ResultField("VALUE", 0, (short)0, elementType, (short)0, 0, Format.Binary)
     };
 
-    List<Object[]> results = new ArrayList<>(value.length);
+    List<DataRow> results = new ArrayList<>(value.length);
     for (long c = index, end = index + count; c < end; ++c) {
-      results.add(new Object[]{c, value[(int) c - 1]});
+      results.add(new ParsedDataRow(new Object[]{c, value[(int) c - 1]}));
     }
 
     PGStatement stmt = connection.createStatement();

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -29,6 +29,8 @@
 package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.api.data.ACLItem;
+import com.impossibl.postgres.protocol.DataRow;
+import com.impossibl.postgres.protocol.ParsedDataRow;
 import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.ResultField.Format;
 import com.impossibl.postgres.types.CompositeType;
@@ -114,9 +116,15 @@ class PGDatabaseMetaData implements DatabaseMetaData {
 
   private PGResultSet createResultSet(List<ResultField> resultFields, List<Object[]> results) throws SQLException {
 
+    List<DataRow> dataRows = new ArrayList<>();
+
+    for (Object[] row : results) {
+      dataRows.add(new ParsedDataRow(row));
+    }
+
     PGStatement stmt = connection.createStatement();
     stmt.closeOnCompletion();
-    return stmt.createResultSet(resultFields, results);
+    return stmt.createResultSet(resultFields, dataRows);
   }
 
   private int getMaxNameLength() throws SQLException {

--- a/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -30,6 +30,7 @@ package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.datetime.instants.Instants;
 import com.impossibl.postgres.protocol.BindExecCommand;
+import com.impossibl.postgres.protocol.DataRow;
 import com.impossibl.postgres.protocol.PrepareCommand;
 import com.impossibl.postgres.protocol.QueryCommand;
 import com.impossibl.postgres.protocol.ResultField;
@@ -334,9 +335,9 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
       int[] counts = new int[batchParameterValues.size()];
       Arrays.fill(counts, SUCCESS_NO_INFO);
 
-      List<Object[]> generatedKeys = new ArrayList<>();
+      List<DataRow> generatedKeys = new ArrayList<>();
 
-      BindExecCommand command = connection.getProtocol().createBindExec(null, null, parameterTypes, Collections.emptyList(), resultFields, Object[].class);
+      BindExecCommand command = connection.getProtocol().createBindExec(null, null, parameterTypes, Collections.emptyList(), resultFields);
 
       List<Type> lastParameterTypes = null;
       List<ResultField> lastResultFields = null;
@@ -386,7 +387,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
           }
 
           if (wantsGeneratedKeys) {
-            generatedKeys.add((Object[]) resultBatch.results.get(0));
+            generatedKeys.add(resultBatch.results.get(0));
           }
 
           c++;

--- a/src/main/java/com/impossibl/postgres/protocol/BindExecCommand.java
+++ b/src/main/java/com/impossibl/postgres/protocol/BindExecCommand.java
@@ -34,13 +34,11 @@ import java.util.List;
 
 public interface BindExecCommand extends QueryCommand {
 
-  String getStatementName();
   String getPortalName();
 
   List<Type> getParameterTypes();
   void setParameterTypes(List<Type> parameterTypes);
 
-  List<Object> getParameterValues();
   void setParameterValues(List<Object> values);
 
 }

--- a/src/main/java/com/impossibl/postgres/protocol/DataRow.java
+++ b/src/main/java/com/impossibl/postgres/protocol/DataRow.java
@@ -28,40 +28,12 @@
  */
 package com.impossibl.postgres.protocol;
 
-import java.util.List;
+import java.io.IOException;
 
-public interface QueryCommand extends Command {
+public interface DataRow {
 
-  enum Status {
-    Completed,
-    Suspended
-  }
+  Object getColumn(int columnIndex) throws IOException;
 
-  class ResultBatch {
-    public String command;
-    public Long rowsAffected;
-    public Long insertedOid;
-    public List<ResultField> fields;
-    public List<DataRow> results;
-
-    public void release() {
-      if (results != null) {
-        for (DataRow dataRow : results) {
-          dataRow.release();
-        }
-      }
-    }
-
-  }
-
-  void setQueryTimeout(long timeout);
-
-  void setMaxRows(int maxRows);
-
-  void setMaxFieldLength(int maxFieldLength);
-
-  List<ResultBatch> getResultBatches();
-
-  Status getStatus();
+  void release();
 
 }

--- a/src/main/java/com/impossibl/postgres/protocol/ParsedDataRow.java
+++ b/src/main/java/com/impossibl/postgres/protocol/ParsedDataRow.java
@@ -28,40 +28,23 @@
  */
 package com.impossibl.postgres.protocol;
 
-import java.util.List;
+import java.io.IOException;
 
-public interface QueryCommand extends Command {
+public class ParsedDataRow implements DataRow {
 
-  enum Status {
-    Completed,
-    Suspended
+  private Object[] columns;
+
+  public ParsedDataRow(Object[] columns) {
+    this.columns = columns;
   }
 
-  class ResultBatch {
-    public String command;
-    public Long rowsAffected;
-    public Long insertedOid;
-    public List<ResultField> fields;
-    public List<DataRow> results;
-
-    public void release() {
-      if (results != null) {
-        for (DataRow dataRow : results) {
-          dataRow.release();
-        }
-      }
-    }
-
+  @Override
+  public Object getColumn(int columnIndex) throws IOException {
+    return columns[columnIndex];
   }
 
-  void setQueryTimeout(long timeout);
-
-  void setMaxRows(int maxRows);
-
-  void setMaxFieldLength(int maxFieldLength);
-
-  List<ResultBatch> getResultBatches();
-
-  Status getStatus();
+  @Override
+  public void release() {
+  }
 
 }

--- a/src/main/java/com/impossibl/postgres/protocol/Protocol.java
+++ b/src/main/java/com/impossibl/postgres/protocol/Protocol.java
@@ -44,7 +44,7 @@ public interface Protocol {
   SSLRequestCommand createSSLRequest();
   StartupCommand createStartup(Map<String, Object> parameters);
   PrepareCommand createPrepare(String statementName, String sqlText, List<Type> parameterTypes);
-  BindExecCommand createBindExec(String portalName, String statementName, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields, Class<?> rowType);
+  BindExecCommand createBindExec(String portalName, String statementName, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields);
   QueryCommand createQuery(String sqlText);
   FunctionCallCommand createFunctionCall(String functionName, List<Type> parameterTypes, List<Object> parameterValues);
 

--- a/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
+++ b/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolImpl.java
@@ -62,6 +62,7 @@ import java.io.InterruptedIOException;
 import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -304,8 +305,8 @@ public class ProtocolImpl implements Protocol {
   }
 
   @Override
-  public BindExecCommand createBindExec(String portalName, String statementName, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields, Class<?> rowType) {
-    return new BindExecCommandImpl(portalName, statementName, parameterTypes, parameterValues, resultFields, rowType);
+  public BindExecCommand createBindExec(String portalName, String statementName, List<Type> parameterTypes, List<Object> parameterValues, List<ResultField> resultFields) {
+    return new BindExecCommandImpl(portalName, statementName, parameterTypes, parameterValues, resultFields);
   }
 
   @Override
@@ -924,7 +925,7 @@ public class ProtocolImpl implements Protocol {
 
     int fieldCount = buffer.readUnsignedShort();
 
-    ResultField[] fields = new ResultField[fieldCount];
+    List<ResultField> fields = new ArrayList<>(fieldCount);
 
     for (int c = 0; c < fieldCount; ++c) {
 
@@ -937,12 +938,12 @@ public class ProtocolImpl implements Protocol {
       field.typeModifier = buffer.readInt();
       field.format = ResultField.Format.values()[buffer.readUnsignedShort()];
 
-      fields[c] = field;
+      fields.add(field);
     }
 
     logger.finest("ROW-DESC: " + fieldCount);
 
-    listener.rowDescription(asList(fields));
+    listener.rowDescription(fields);
   }
 
   private void receiveRowData(ByteBuf buffer) throws IOException {


### PR DESCRIPTION
By delaying the parsing the connection is freed up to discover new types that it may not already know about.  This helps cases where new types are created with a connection and when attempting to use them they error/hang the connection.

This is implemented using Netty’s reference counted ByteBuf. The pooled nature of the ByteBuf API makes leaks especially nasty.  During maven builds the Surefire tasks has Netty’s advanced leak detection turned on. Any warnings about leaked buffers should be reported/examined thoroughly.
