### PR TITLE
Housekeeper warning fixes

### DIFF
--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -315,15 +315,7 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
   void checkTransaction() throws SQLException {
 
     if (!autoCommit && protocol.getTransactionStatus() == Idle) {
-      try {
-        query(getBeginText());
-      }
-      catch (IOException e) {
-        throw new SQLException(e);
-      }
-      catch (NoticeException e) {
-        throw makeSQLException(e.getNotice());
-      }
+      execute(getBeginText(), false);
     }
 
   }

--- a/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGConnectionImpl.java
@@ -468,6 +468,10 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
     }
     catch (IOException e) {
 
+      if (!protocol.isConnected()) {
+        close();
+      }
+
       throw new SQLException(e);
     }
 
@@ -494,25 +498,31 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
     }
     catch (BlockingReadTimeoutException e) {
 
-      close();
+      internalClose();
 
       throw new SQLTimeoutException(e);
     }
     catch (InterruptedIOException e) {
 
-      close();
+      internalClose();
 
       throw CLOSED_CONNECTION;
     }
     catch (IOException e) {
 
-      throw new SQLException(e);
+      if (!protocol.isConnected()) {
+        internalClose();
+      }
 
+      throw new SQLException(e);
     }
     catch (NoticeException e) {
 
-      throw makeSQLException(e.getNotice());
+      if (!protocol.isConnected()) {
+        internalClose();
+      }
 
+      throw makeSQLException(e.getNotice());
     }
 
   }
@@ -540,25 +550,31 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
     }
     catch (BlockingReadTimeoutException e) {
 
-      close();
+      internalClose();
 
       throw new SQLTimeoutException(e);
     }
     catch (InterruptedIOException e) {
 
-      close();
+      internalClose();
 
       throw CLOSED_CONNECTION;
     }
     catch (IOException e) {
 
-      throw new SQLException(e);
+      if (!protocol.isConnected()) {
+        internalClose();
+      }
 
+      throw new SQLException(e);
     }
     catch (NoticeException e) {
 
-      throw makeSQLException(e.getNotice());
+      if (!protocol.isConnected()) {
+        internalClose();
+      }
 
+      throw makeSQLException(e.getNotice());
     }
 
   }
@@ -576,25 +592,31 @@ public class PGConnectionImpl extends BasicContext implements PGConnection {
     }
     catch (BlockingReadTimeoutException e) {
 
-      close();
+      internalClose();
 
       throw new SQLTimeoutException(e);
     }
     catch (InterruptedIOException e) {
 
-      close();
+      internalClose();
 
       throw CLOSED_CONNECTION;
     }
     catch (IOException e) {
 
-      throw new SQLException(e);
+      if (!protocol.isConnected()) {
+        internalClose();
+      }
 
+      throw new SQLException(e);
     }
     catch (NoticeException e) {
 
-      throw makeSQLException(e.getNotice());
+      if (!protocol.isConnected()) {
+        internalClose();
+      }
 
+      throw makeSQLException(e.getNotice());
     }
 
   }


### PR DESCRIPTION
Hopefully these changes fix the last of the invalid warnings from the housekeeper.

Essentially the issue was that whenever the database connection was disconnected without explicitly calling `close`, via exception or other random networking/server event , the connection was left in an odd _not open_ but _not closed_ state.
