### PR TITLE
Problem: netty-all doesn't work in OSGi environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
   </parent>
 
   <properties>
+    <netty.version>4.0.42.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Checkstyle configuration -->
     <linkXRef>false</linkXRef>
@@ -65,9 +66,30 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>4.0.42.Final</version>
+      <artifactId>netty-common</artifactId>
+      <version>${netty.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${netty.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
In pgjdbc-ng, Import-Package is defined as:

```
io.netty.*;version="[4.0,4.1)",
```

However, netty-all's MANIFEST.MF does not contain any OSGi
information:

```
Manifest-Version: 1.0
Implementation-Vendor: The Netty Project
Implementation-Title: Netty/All-in-One
Implementation-Version: 4.0.40.Final
Implementation-Vendor-Id: io.netty
Built-By: norman
Build-Jdk: 1.7.0_85
Created-By: Apache Maven 3.3.3
Implementation-URL: http://netty.io/netty-all/
```

When installed, it exports packages without version information:

```
eid@eid> install -s wrap:mvn:io.netty/netty-all/4.0.40.Final
Bundle ID: 61
eid@eid> headers 61

wrap_mvn_io.netty_netty-all_4.0.40.Final (61)
...
Export-Package =
    io.netty.bootstrap;uses:="io.netty.channel,io.netty.util",
...
```

And therefore fails pgjdbc-ng's requirement:

```
Unsatisfied Requirements:
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.bootstrap)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.buffer)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.channel)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.channel.nio)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.channel.socket)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.channel.socket.nio)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.handler.codec)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.handler.ssl)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.util)(version>=4.0.0)(!(version>=4.1.0)))
[pgjdbc-ng [52](R 52.0)] osgi.wiring.package; (&(osgi.wiring.package=io.netty.util.concurrent)(version>=4.0.0)(!(version>=4.1.0)))
```

Solution: use individual netty-\* components

Unlike netty-all, they do have OSGi-compatible manifests that expose package
version information.

This way, manual addition of these dependencies will not be required when Karaf
features or equivalent packages are built off the list of Maven
dependencies.
