### PR TITLE
Fixed Netty version range for pgjdbc OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
             <!-- do not import ourself -->
             <Import-Package>
               !com.impossibl.postgres*,
-              io.netty.*;version="[4.0,4.1)",
+              io.netty.*;version="[4.1,5)",
               *
             </Import-Package>
           </instructions>


### PR DESCRIPTION
Actually the project is based on Netty 4.1.x, the Netty Version range in maven-bundle-plugin configuration is wrong. It can't be installed in a OSGi container in this way. I guess this must be fixed, with a quick new release if possible.