### PR TITLE
Fix NullPointerException on Windows

### DIFF
--- a/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -287,8 +287,9 @@ public class BasicContext implements Context {
       }
 
       // Check if locale matches a win32 type locale (e.g. "English_United States.1252")
-      if (Locales.getJavaCompatibleLocale(localeSpec.split("\\.")[0]) != null) {
-        localeSpec = Locales.getJavaCompatibleLocale(localeSpec);
+      String windowsLocale = localeSpec.split("\\.")[0];
+      if (Locales.getJavaCompatibleLocale(windowsLocale) != null) {
+        localeSpec = Locales.getJavaCompatibleLocale(windowsLocale);
       }
 
       String[] localeIds = localeSpec.split("_|\\.");


### PR DESCRIPTION
On Windows, I got a NPE after upgrading to 0.7

The cause seems to be a small bug in BasicContext introduced in #287. This fixes the issue for me on Windows 10.