### PR TITLE
Handle null values passed to setters for primitive values 

### DIFF
--- a/src/main/java/com/impossibl/postgres/mapper/MethodPropertySetter.java
+++ b/src/main/java/com/impossibl/postgres/mapper/MethodPropertySetter.java
@@ -40,10 +40,15 @@ import java.lang.reflect.Method;
  */
 public class MethodPropertySetter implements PropertySetter {
 
-  Method method;
+  private boolean primitive;
+  private Method method;
 
   public MethodPropertySetter(Method method) {
     super();
+    Class<?>[] parameterTypes = method.getParameterTypes();
+    assert parameterTypes.length == 1;
+    this.primitive = parameterTypes[0].isPrimitive();
+
     this.method = method;
     this.method.setAccessible(true);
   }
@@ -51,12 +56,13 @@ public class MethodPropertySetter implements PropertySetter {
   @Override
   public void set(Object instance, Object value) {
 
-    try {
-      method.invoke(instance, value);
-    }
-    catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
-      // Ignore mapping errors (they shouldn't happen)
+    if (!primitive || value != null) {
+      try {
+        method.invoke(instance, value);
+      }
+      catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
+        // Ignore mapping errors (they shouldn't happen)
+      }
     }
   }
-
 }


### PR DESCRIPTION
 Method property setter generates (and masks) illegal argument exceptions when called with a null value for a primitive property. This leave the value unchanged,but generates an exception with a full stack trace. 

This Change records whether the argument type of the method is a primitive, and does not invoke the method if the value is null. 