### PR TITLE
Fix IllformedLocaleException connecting to DB with a Norwegian locale

### DIFF
--- a/.travis/travis-install-dependencies
+++ b/.travis/travis-install-dependencies
@@ -34,7 +34,7 @@ sudo tail /var/log/postgresql/postgresql-${PGVERSION}-main.log
 
 # Setup postgres' users and databases
 sudo -u postgres psql -c "CREATE USER pgjdbc WITH PASSWORD 'test';"
-sudo -u postgres psql -c 'CREATE DATABASE test WITH OWNER pgjdbc;'
+sudo -u postgres psql -c 'CREATE DATABASE test WITH OWNER pgjdbc LC_COLLATE 'Norwegian Bokmål' LC_CTYPE 'Norwegian Bokmål' ;'
 
 # Install hstore extension if >= 9.1
 if [ "${PGVERSION}" != '8.4' -a "${PGVERSION}" != '9.0' ]

--- a/.travis/travis-install-dependencies
+++ b/.travis/travis-install-dependencies
@@ -34,7 +34,7 @@ sudo tail /var/log/postgresql/postgresql-${PGVERSION}-main.log
 
 # Setup postgres' users and databases
 sudo -u postgres psql -c "CREATE USER pgjdbc WITH PASSWORD 'test';"
-sudo -u postgres psql -c "CREATE DATABASE test WITH OWNER pgjdbc LC_COLLATE 'Norwegian Bokmål' LC_CTYPE 'Norwegian Bokmål' ;"
+sudo -u postgres psql -c 'CREATE DATABASE test WITH OWNER pgjdbc;'
 
 # Install hstore extension if >= 9.1
 if [ "${PGVERSION}" != '8.4' -a "${PGVERSION}" != '9.0' ]

--- a/.travis/travis-install-dependencies
+++ b/.travis/travis-install-dependencies
@@ -34,7 +34,7 @@ sudo tail /var/log/postgresql/postgresql-${PGVERSION}-main.log
 
 # Setup postgres' users and databases
 sudo -u postgres psql -c "CREATE USER pgjdbc WITH PASSWORD 'test';"
-sudo -u postgres psql -c 'CREATE DATABASE test WITH OWNER pgjdbc LC_COLLATE 'Norwegian Bokmål' LC_CTYPE 'Norwegian Bokmål' ;'
+sudo -u postgres psql -c "CREATE DATABASE test WITH OWNER pgjdbc LC_COLLATE 'Norwegian Bokmål' LC_CTYPE 'Norwegian Bokmål' ;"
 
 # Install hstore extension if >= 9.1
 if [ "${PGVERSION}" != '8.4' -a "${PGVERSION}" != '9.0' ]

--- a/src/main/java/com/impossibl/postgres/utils/Locales.java
+++ b/src/main/java/com/impossibl/postgres/utils/Locales.java
@@ -208,6 +208,7 @@ public class Locales {
     LOCALES.put("Yakut_Russia", "sah_RU");
     LOCALES.put("Yi_China", "ii_CN");
     LOCALES.put("Yoruba_Nigeria", "yo_NG");
+    LOCALES.put("Norwegian Nynorsk_Norway", "nn_NO");
   }
 
   private Locales() {
@@ -215,6 +216,9 @@ public class Locales {
   }
 
   public static String getJavaCompatibleLocale(String windowsLocale) {
+    if (windowsLocale.startsWith("Norwegian Bokm")) {
+      return "nb_NO";
+    }
     return LOCALES.get(windowsLocale);
   }
 


### PR DESCRIPTION
Since version 0.7.1 we were unable to connect to a PostgreSQL cluster if created with Norwegian Nynorsk or Bokmål locales. 

`java.util.IllformedLocaleException: Invalid subtag: Norwegian Bokm?l [at index 0]
  at java.util.Locale$Builder.setLanguageTag(Unknown Source)
  at com.impossibl.postgres.system.BasicContext.loadLocale(BasicContext:299)
  at com.impossibl.postgres.system.BasicContext.init(BasicContext:273)
...
`

In the LOCALES lookup table (com.impossibl.postgres.utils.Locales) the two Norwegian locales (Nynorsk and Bokmål) are missing. 

The fix required to support Nynorsk locale is straightforward, but things get complicated with Bokmål. Unluckily, it's the only known locale with a non-ascii name, so the query in BasicContext.loadLocale returns a wrongly encoded locale name and a table lookup is not possible. A prefix match is the only solution we found.

