### PR TITLE
Changes the URL regular expression to allow the use of any character

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </parent>
 
   <properties>
-    <netty.version>4.1.8.Final</netty.version>
+    <netty.version>4.1.15.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Checkstyle configuration -->
     <linkXRef>false</linkXRef>

--- a/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
@@ -243,7 +243,7 @@ class ConnectionUtil {
    *    3 = parameters            (optional)
    */
   private static final Pattern URL_PATTERN =
-      Pattern.compile("jdbc:pgsql:(?://((?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?(?:,(?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?)*)/)?((?:\\w|-|_)+)(?:[\\?\\&](.*))?");
+      Pattern.compile("jdbc:pgsql:(?://((?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?(?:,(?:[a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(?:\\d+))?)*)/)?(([^?&])+)(?:[\\?\\&](.*))?");
 
   private static final Pattern ADDRESS_PATTERN = Pattern.compile("(?:([a-zA-Z0-9\\-\\.]+|\\[[0-9a-f\\:]+\\])(?:\\:(\\d+))?)");
 


### PR DESCRIPTION
In postgresql, there are no restrictions on the database name if it's enclosed in double quotes; we use dotted notation for some database names, which was not supported by the driver.