### PR TITLE
Fixed NullPointerException on getConnection() against server v9.6.5.

### DIFF
--- a/src/main/java/com/impossibl/postgres/system/tables/PgAttribute.java
+++ b/src/main/java/com/impossibl/postgres/system/tables/PgAttribute.java
@@ -191,6 +191,19 @@ public class PgAttribute implements Table<PgAttribute.Row> {
   }
 
   private static final Object[] SQL = {
+          Version.get(9, 6, 5), " select " +
+          "   attrelid as \"relationId\", attname as \"name\", atttypid as \"typeId\", atttypmod as \"typeModifier\", attlen as \"length\", " +
+          "   attnum as \"number\", not attnotnull as \"nullable\", pg_catalog.pg_get_expr(ad.adbin,ad.adrelid) like '%nextval(%' as \"autoIncrement\", " +
+          "   attndims as \"numberOfDimensions\", atthasdef as \"hasDefault\", reltype as \"relationTypeId\" " +
+          " from " +
+          "   pg_catalog.pg_attribute a " +
+          " left join pg_catalog.pg_attrdef ad " +
+          "   on (a.attrelid = ad.adrelid and a.attnum = ad.adnum)" +
+          " left join pg_catalog.pg_class c" +
+          "   on (a.attrelid = c.oid)" +
+          " where " +
+          "   not a.attisdropped" +
+          "     AND (c.relpersistence <> 't' OR c.relpersistence IS NULL)",
     Version.get(9, 0, 0),
     " select " +
       "   attrelid as \"relationId\", attname as \"name\", atttypid as \"typeId\", atttypmod as \"typeModifier\", attlen as \"length\", " +


### PR DESCRIPTION
If server was underload load attributes query contained temporary tables which caused Unknown object OIDxxxxxxxxxxx error from server resulting in NullPointereException being thrown on getConnection() call. This commit adds condition to omit temporary tables in the call.