### PR TITLE
Pull driver name from JAR manifest (like version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
     </profile>
   </profiles>
 
-  <name>PGJDBC-NG</name>
+  <name>PostgreSQL JDBC - NG</name>
   <url>http://impossibl.github.io/pgjdbc-ng/</url>
   <description>A new JDBC driver for PostgreSQL aimed at supporting the advanced features of JDBC and Postgres.
   </description>

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -178,7 +178,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
 
   @Override
   public String getDriverName() throws SQLException {
-    return "PostgreSQL JDBC - NG";
+    return PGDriver.NAME;
   }
 
   @Override

--- a/src/main/java/com/impossibl/postgres/jdbc/PGDriver.java
+++ b/src/main/java/com/impossibl/postgres/jdbc/PGDriver.java
@@ -59,11 +59,20 @@ import static java.lang.Boolean.parseBoolean;
  * @author <a href="mailto:jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
 public class PGDriver implements Driver, DriverAction {
+
+  /** The name of the driver */
+  public static final String NAME;
+  static {
+    String name = PGDriver.class.getPackage().getImplementationTitle();
+    name = name != null ? name : "DEVELOP"; // Ensure it works when in IDE
+    NAME = name;
+  }
+
   /** The version of the driver */
   public static final Version VERSION;
   static {
     String version = PGDriver.class.getPackage().getImplementationVersion();
-    version = version != null ? version : "0.0.0-DEVELOP";
+    version = version != null ? version : "0.0.0-DEVELOP"; // Ensure it works when in IDE
     VERSION = Version.parse(version);
   }
 


### PR DESCRIPTION
This sets the driver name via `Package.getImplementationTitle` the same way the version is now applied.

This has the side effect of changing the `project.name` to match what the driver name has always been.  AFAIK changing `project.name` has no ramifications on uploads to maven central.