### PR TITLE
Make `strict-mode` strict again

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -107,13 +107,20 @@ Default: `0`
 
 Enable or disable strict adherence to JDBC specification.
 
+Affected behavior when disabled:
+<ul>
+  <li><code>ResultSetMetaData.getColumnName(int)</code> returns a value equivalent to <code>ResultSetMetaData.getColumnLabel(int)</code>, if a label is available.</li>
+  <li>The <code>Statement.executeBatch(...)</code> family of methods insert an extraneous EXECUTE_FAILED status into <code>BatchUpdateException.getUpdateCounts()</code> even though PostgreSQL stops executing at the first error.</li>
+</ul>
+
+
 Driver Property: `strict-mode`
 
 DataSource: `getStrictMode()`/`setStrictMode(java.lang.Boolean)`
 
 System Property: `pgjdbc.strict-mode`
 
-Default: `false`
+Default: `true`
 
 #### Fetch Size
 

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/BatchResults.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/BatchResults.java
@@ -55,6 +55,11 @@ interface BatchResults {
 class IntegerBatchResults implements BatchResults {
 
   int[] counts = new int[0];
+  boolean strict;
+
+  IntegerBatchResults(boolean strict) {
+    this.strict = strict;
+  }
 
   @Override
   public void setBatchSize(int size) {
@@ -69,8 +74,14 @@ class IntegerBatchResults implements BatchResults {
 
   @Override
   public BatchUpdateException getException(int batchIdx, String message, Exception cause) {
-    int[] counts = Arrays.copyOf(this.counts, batchIdx + 1);
-    counts[batchIdx] = EXECUTE_FAILED;
+    int[] counts;
+    if (strict) {
+      counts = Arrays.copyOf(this.counts, batchIdx);
+    }
+    else {
+      counts = Arrays.copyOf(this.counts, batchIdx + 1);
+      counts[batchIdx] = EXECUTE_FAILED;
+    }
     return new BatchUpdateException(message, null, 0, counts, cause != null ? makeSQLException(cause) : null);
   }
 
@@ -79,6 +90,11 @@ class IntegerBatchResults implements BatchResults {
 class LongBatchResults implements BatchResults {
 
   long[] counts = new long[0];
+  boolean strict;
+
+  LongBatchResults(boolean strict) {
+    this.strict = strict;
+  }
 
   @Override
   public void setBatchSize(int size) {
@@ -93,8 +109,14 @@ class LongBatchResults implements BatchResults {
 
   @Override
   public BatchUpdateException getException(int batchIdx, String message, Exception cause) {
-    long[] counts = Arrays.copyOf(this.counts, batchIdx + 1);
-    counts[batchIdx] = EXECUTE_FAILED;
+    long[] counts;
+    if (strict) {
+      counts = Arrays.copyOf(this.counts, batchIdx);
+    }
+    else {
+      counts = Arrays.copyOf(this.counts, batchIdx + 1);
+      counts[batchIdx] = EXECUTE_FAILED;
+    }
     return new BatchUpdateException(message, null, 0, counts, cause != null ? makeSQLException(cause) : null);
   }
 

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/JDBCSettings.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/JDBCSettings.java
@@ -94,8 +94,20 @@ public class JDBCSettings {
   public static final Setting<Integer> DEFAULT_NETWORK_TIMEOUT = Setting.declare();
 
   @Setting.Info(
-      desc = "Enable or disable strict adherence to JDBC specification.",
-      def = "false",
+      desc = "Enable or disable strict adherence to JDBC specification.\n\n" +
+          "Affected behavior when disabled:\n" +
+          "<ul>\n" +
+          "  <li>" +
+          "<code>ResultSetMetaData.getColumnName(int)</code> returns a value equivalent to " +
+          "<code>ResultSetMetaData.getColumnLabel(int)</code>, if a label is available." +
+          "</li>\n" +
+          "  <li>" +
+          "The <code>Statement.executeBatch(...)</code> family of methods insert an extraneous EXECUTE_FAILED " +
+          "status into <code>BatchUpdateException.getUpdateCounts()</code> even though PostgreSQL stops executing at " +
+          "the first error." +
+          "</li>\n" +
+          "</ul>\n",
+      def = "true",
       name = "strict-mode",
       group = "jdbc",
       alternateNames = "strictMode"

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -412,7 +412,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
   public int[] executeBatch() throws SQLException {
     checkClosed();
 
-    IntegerBatchResults results = new IntegerBatchResults();
+    IntegerBatchResults results = new IntegerBatchResults(connection.isStrictMode());
     executeBatch(results);
     return results.counts;
   }
@@ -421,7 +421,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
   public long[] executeLargeBatch() throws SQLException {
     checkClosed();
 
-    LongBatchResults results = new LongBatchResults();
+    LongBatchResults results = new LongBatchResults(connection.isStrictMode());
     executeBatch(results);
     return results.counts;
   }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGResultSetMetaData.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGResultSetMetaData.java
@@ -267,7 +267,7 @@ class PGResultSetMetaData extends PGMetaData implements ResultSetMetaData {
 
   @Override
   public String getColumnName(int column) throws SQLException {
-    if (connection.isStrictMode()) {
+    if (!connection.isStrictMode()) {
       String val = get(column).getName();
       if (val != null)
         return val;

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
@@ -256,7 +256,7 @@ class PGSimpleStatement extends PGStatement {
   public int[] executeBatch() throws SQLException {
     checkClosed();
 
-    IntegerBatchResults results = new IntegerBatchResults();
+    IntegerBatchResults results = new IntegerBatchResults(connection.isStrictMode());
     executeBatch(results);
     return results.counts;
   }
@@ -265,7 +265,7 @@ class PGSimpleStatement extends PGStatement {
   public long[] executeLargeBatch() throws SQLException {
     checkClosed();
 
-    LongBatchResults results = new LongBatchResults();
+    LongBatchResults results = new LongBatchResults(connection.isStrictMode());
     executeBatch(results);
     return results.counts;
   }

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/ResultSetMetaDataTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/ResultSetMetaDataTest.java
@@ -293,8 +293,21 @@ public class ResultSetMetaDataTest {
   }
 
   @Test
-  public void testAliasStrictMode() throws Exception {
-    (conn.unwrap(PGConnection.class)).setStrictMode(true);
+  public void testAliasInsensitiveNonStrict() throws Exception {
+    ((PGDirectConnection)conn).setStrictMode(false);
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT a AS PK FROM rsmd1");
+    ResultSetMetaData rsmd = rs.getMetaData();
+    assertEquals(1, rsmd.getColumnCount());
+    assertEquals("pk", rsmd.getColumnName(1));
+    assertEquals("pk", rsmd.getColumnLabel(1));
+    rs.close();
+    stmt.close();
+  }
+
+  @Test
+  public void testAliasSensitiveNonStrict() throws Exception {
+    ((PGDirectConnection)conn).setStrictMode(false);
     Statement stmt = conn.createStatement();
     ResultSet rs = stmt.executeQuery("SELECT a AS \"PK\" FROM rsmd1");
     ResultSetMetaData rsmd = rs.getMetaData();


### PR DESCRIPTION
Until now enabling `strict-mode` made the driver _less_ compliant. It’s fixed and `strict-mode` is now on by default.  Also, I’ve documented in the setting what behavior changes and when.

#### getColumnName/getColumnLabel
The only place strict mode was still used was in the discrepency between `ResultSetMetaData`’s `getColumnName` and `getColumnLabel`.  According to the spec `getColumnName` should return the table name (other drivers seem to agree at this point).  We had it reversed, strict mode made it return a column label first (if available) then fell back to the table name. Running in `strict-mode` was  “more compatible” / “less strict”.

I’ve now corrected this case and added full tests for both cases. I’v also enabled `strict-mode` by default. This shouldn’t be an issue because it was disabled before the logic was inverted.

#### BatchUpdateException
Along with fixing the previous case I added back another area I knowing defied the standard with regard to `BatchUpdateException` including and EXECUTION_FAILED flag.  In this case we were just “non-compliant” and included the flag. Since the spec is clear about this I re-instated the compliant behavior and stopped adding the flags when in `strict-mode` and add the flag when `strict-mode` is disabled. This change _does_ represent a reversal as, per default, it is now compliant.