### PR TITLE
MetaData fixes

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDatabaseMetaData.java
@@ -734,8 +734,8 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     List<Object> params = new ArrayList<>();
 
     sql.append(
-        "SELECT NULL AS PROCEDURE_CAT, n.nspname AS PROCEDURE_SCHEM, p.proname AS PROCEDURE_NAME, NULL, NULL, NULL, " +
-        " d.description AS REMARKS, " +  java.sql.DatabaseMetaData.procedureReturnsResult + " AS PROCEDURE_TYPE, p.proname || '_' || p.oid AS SPECIFIC_NAME " +
+        "SELECT NULL AS \"PROCEDURE_CAT\", n.nspname AS \"PROCEDURE_SCHEM\", p.proname AS \"PROCEDURE_NAME\", NULL, NULL, NULL, " +
+        " d.description AS \"REMARKS\", " +  java.sql.DatabaseMetaData.procedureReturnsResult + " AS \"PROCEDURE_TYPE\", p.proname || '_' || p.oid AS \"SPECIFIC_NAME\" " +
         " FROM pg_catalog.pg_namespace n, pg_catalog.pg_proc p " +
         " LEFT JOIN pg_catalog.pg_description d ON (p.oid=d.objoid) " +
         " LEFT JOIN pg_catalog.pg_class c ON (d.classoid=c.oid AND c.relname='pg_proc') " +
@@ -751,7 +751,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
       params.add(procedureNamePattern);
     }
 
-    sql.append(" ORDER BY PROCEDURE_SCHEM, PROCEDURE_NAME, SPECIFIC_NAME");
+    sql.append(" ORDER BY \"PROCEDURE_SCHEM\", \"PROCEDURE_NAME\", \"SPECIFIC_NAME\"");
 
     return execForResultSet(sql.toString(), params);
   }
@@ -780,7 +780,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     resultFields[13] =  new ResultField("COLUMN_DEF",         0, (short)0, reg.loadBaseType("text"), (short)0, 0, FieldFormat.Binary);
     resultFields[14] =  new ResultField("SQL_DATA_TYPE",      0, (short)0, reg.loadBaseType("int4"), (short)0, 0, FieldFormat.Binary);
     resultFields[15] =  new ResultField("SQL_DATETIME_SUB",   0, (short)0, reg.loadBaseType("int4"), (short)0, 0, FieldFormat.Binary);
-    resultFields[16] =  new ResultField("CHAR_OCTECT_LENGTH", 0, (short)0, reg.loadBaseType("int4"), (short)0, 0, FieldFormat.Binary);
+    resultFields[16] =  new ResultField("CHAR_OCTET_LENGTH", 0, (short)0, reg.loadBaseType("int4"), (short)0, 0, FieldFormat.Binary);
     resultFields[17] =  new ResultField("ORDINAL_POSITION",   0, (short)0, reg.loadBaseType("int4"), (short)0, 0, FieldFormat.Binary);
     resultFields[18] =  new ResultField("IS_NULLABLE",        0, (short)0, reg.loadBaseType("text"), (short)0, 0, FieldFormat.Binary);
     resultFields[19] =  new ResultField("SPECIFIC_NAME",      0, (short)0, reg.loadBaseType("text"), (short)0, 0, FieldFormat.Binary);
@@ -885,7 +885,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
           }
 
           row[5] = JDBCTypeMapping.getJDBCTypeCode(argType);
-          row[6] = argType.getCodec(argType.getResultFormat()).getDecoder().getDefaultClass().getName();
+          row[6] = argType.getQualifiedName().toString();
           row[7] = null;
           row[8] = null;
           row[9] = null;
@@ -916,7 +916,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
                 row[3] = columnrs.getString("attname");
                 row[4] = DatabaseMetaData.procedureColumnResult;
                 row[5] = JDBCTypeMapping.getJDBCTypeCode(columnType);
-                row[6] = columnType.getCodec(columnType.getResultFormat()).getDecoder().getDefaultClass().getName();
+                row[6] = columnType.getQualifiedName().toString();
                 row[7] = null;
                 row[8] = null;
                 row[9] = null;
@@ -949,7 +949,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     List<Object> params = new ArrayList<>();
 
     sql.append(
-        "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, c.relname AS TABLE_NAME, " +
+        "SELECT NULL AS \"TABLE_CAT\", n.nspname AS \"TABLE_SCHEM\", c.relname AS \"TABLE_NAME\", " +
         " CASE n.nspname ~ '^pg_' OR n.nspname = 'information_schema' " +
         " WHEN true THEN CASE " +
         " WHEN n.nspname = 'pg_catalog' OR n.nspname = 'information_schema' THEN CASE c.relkind " +
@@ -982,7 +982,9 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
         " END " +
         " ELSE NULL " +
         " END " +
-        " AS TABLE_TYPE, d.description AS REMARKS " +
+        " AS \"TABLE_TYPE\", d.description AS \"REMARKS\", " +
+        " '' as \"TYPE_CAT\", '' as \"TYPE_SCHEM\", '' as \"TYPE_NAME\", " +
+        " '' AS \"SELF_REFERENCING_COL_NAME\", '' AS \"REF_GENERATION\" " +
         " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c " +
         " LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0) " +
         " LEFT JOIN pg_catalog.pg_class dc ON (d.classoid=dc.oid AND dc.relname='pg_class') " +
@@ -1010,7 +1012,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
       sql.append(") ");
     }
 
-    sql.append(" ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ");
+    sql.append(" ORDER BY \"TABLE_TYPE\",\"TABLE_SCHEM\",\"TABLE_NAME\" ");
 
     return execForResultSet(sql.toString(), params);
   }
@@ -1044,7 +1046,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     List<Object> params = new ArrayList<>();
 
     sql.append(
-        "SELECT nspname AS TABLE_SCHEM,  NULL AS TABLE_CATALOG" +
+        "SELECT nspname AS \"TABLE_SCHEM\",  NULL AS \"TABLE_CATALOG\"" +
         " FROM pg_catalog.pg_namespace " +
         " WHERE " +
         " (" +
@@ -1060,7 +1062,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
       params.add(schemaPattern);
     }
 
-    sql.append(" ORDER BY TABLE_SCHEM");
+    sql.append(" ORDER BY \"TABLE_SCHEM\"");
 
     return execForResultSet(sql.toString(), params);
   }
@@ -1654,9 +1656,9 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     List<Object> params = new ArrayList<>();
 
     sql.append(
-        "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, " +
-        "  ct.relname AS TABLE_NAME, a.attname AS COLUMN_NAME, " +
-        "  (i.keys).n AS KEY_SEQ, ci.relname AS PK_NAME " +
+        "SELECT NULL AS \"TABLE_CAT\", n.nspname AS \"TABLE_SCHEM\", " +
+        "  ct.relname AS \"TABLE_NAME\", a.attname AS \"COLUMN_NAME\", " +
+        "  (i.keys).n AS \"KEY_SEQ\", ci.relname AS \"PK_NAME\" " +
         "FROM pg_catalog.pg_class ct " +
         "  JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid) " +
         "  JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid) " +
@@ -1674,7 +1676,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     sql.append(" AND ct.relname = ?");
     params.add(table);
 
-    sql.append(" AND i.indisprimary ORDER BY table_name, pk_name, key_seq");
+    sql.append(" AND i.indisprimary ORDER BY \"TABLE_NAME\", \"PK_NAME\", \"KEY_SEQ\"");
 
     return execForResultSet(sql.toString(), params);
   }
@@ -1684,29 +1686,29 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     List<Object> params = new ArrayList<>();
 
     sql.append(
-        "SELECT NULL::text AS PKTABLE_CAT, pkn.nspname AS PKTABLE_SCHEM, pkc.relname AS PKTABLE_NAME, pka.attname AS PKCOLUMN_NAME, " +
-        "NULL::text AS FKTABLE_CAT, fkn.nspname AS FKTABLE_SCHEM, fkc.relname AS FKTABLE_NAME, fka.attname AS FKCOLUMN_NAME, " +
-        "pos.n AS KEY_SEQ, " +
+        "SELECT NULL::text AS \"PKTABLE_CAT\", pkn.nspname AS \"PKTABLE_SCHEM\", pkc.relname AS \"PKTABLE_NAME\", pka.attname AS \"PKCOLUMN_NAME\", " +
+        "NULL::text AS \"FKTABLE_CAT\", fkn.nspname AS \"FKTABLE_SCHEM\", fkc.relname AS \"FKTABLE_NAME\", fka.attname AS \"FKCOLUMN_NAME\", " +
+        "pos.n AS \"KEY_SEQ\", " +
         "CASE con.confupdtype " +
         " WHEN 'c' THEN " + DatabaseMetaData.importedKeyCascade +
         " WHEN 'd' THEN " + DatabaseMetaData.importedKeySetDefault +
         " WHEN 'n' THEN " + DatabaseMetaData.importedKeySetNull +
         " WHEN 'r' THEN " + DatabaseMetaData.importedKeyRestrict +
         " WHEN 'a' THEN " + DatabaseMetaData.importedKeyNoAction +
-        " ELSE NULL END AS UPDATE_RULE, " +
+        " ELSE NULL END AS \"UPDATE_RULE\", " +
         "CASE con.confdeltype " +
         " WHEN 'c' THEN " + DatabaseMetaData.importedKeyCascade +
         " WHEN 'n' THEN " + DatabaseMetaData.importedKeySetNull +
         " WHEN 'd' THEN " + DatabaseMetaData.importedKeySetDefault +
         " WHEN 'r' THEN " + DatabaseMetaData.importedKeyRestrict +
         " WHEN 'a' THEN " + DatabaseMetaData.importedKeyNoAction +
-        " ELSE NULL END AS DELETE_RULE, " +
-        "con.conname AS FK_NAME, pkic.relname AS PK_NAME, " +
+        " ELSE NULL END AS \"DELETE_RULE\", " +
+        "con.conname AS \"FK_NAME\", pkic.relname AS \"PK_NAME\", " +
         "CASE " +
         " WHEN con.condeferrable AND con.condeferred THEN " + DatabaseMetaData.importedKeyInitiallyDeferred +
         " WHEN con.condeferrable THEN " + DatabaseMetaData.importedKeyInitiallyImmediate +
         " ELSE " + DatabaseMetaData.importedKeyNotDeferrable +
-        " END AS DEFERRABILITY " +
+        " END AS \"DEFERRABILITY\" " +
         " FROM " +
         " pg_catalog.pg_namespace pkn, pg_catalog.pg_class pkc, pg_catalog.pg_attribute pka, " +
         " pg_catalog.pg_namespace fkn, pg_catalog.pg_class fkc, pg_catalog.pg_attribute fka, " +
@@ -1837,18 +1839,18 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     List<Object> params = new ArrayList<>();
 
     sql.append(
-        "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, " +
-        "  ct.relname AS TABLE_NAME, NOT i.indisunique AS NON_UNIQUE, " +
-        "  NULL AS INDEX_QUALIFIER, ci.relname AS INDEX_NAME, " +
+        "SELECT NULL AS \"TABLE_CAT\", n.nspname AS \"TABLE_SCHEM\", " +
+        "  ct.relname AS \"TABLE_NAME\", NOT i.indisunique AS \"NON_UNIQUE\", " +
+        "  NULL AS \"INDEX_QUALIFIER\", ci.relname AS \"INDEX_NAME\", " +
         "  CASE i.indisclustered " +
         "    WHEN true THEN " + java.sql.DatabaseMetaData.tableIndexClustered +
         "    ELSE CASE am.amname " +
         "      WHEN 'hash' THEN " + java.sql.DatabaseMetaData.tableIndexHashed +
         "      ELSE " + java.sql.DatabaseMetaData.tableIndexOther +
         "    END " +
-        "  END AS TYPE, " +
-        "  (i.keys).n AS ORDINAL_POSITION, " +
-        "  pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false) AS COLUMN_NAME, " +
+        "  END AS \"TYPE\", " +
+        "  (i.keys).n AS \"ORDINAL_POSITION\", " +
+        "  pg_catalog.pg_get_indexdef(ci.oid, (i.keys).n, false) AS \"COLUMN_NAME\", " +
         (connection.isServerMinimumVersion(9, 6) ?
         "  CASE am.amname " +
         "    WHEN 'btree' THEN CASE i.indoption[(i.keys).n - 1] & 1 " +
@@ -1856,7 +1858,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
         "      ELSE 'A' " +
         "    END " +
         "    ELSE NULL " +
-        "  END AS ASC_OR_DESC, "
+        "  END AS \"ASC_OR_DESC\", "
         :
         "  CASE am.amcanorder " +
         "    WHEN true THEN CASE i.indoption[(i.keys).n - 1] & 1 " +
@@ -1864,10 +1866,10 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
         "      ELSE 'A' " +
         "    END " +
         "    ELSE NULL " +
-        "  END AS ASC_OR_DESC, ") +
-        "  ci.reltuples AS CARDINALITY, " +
-        "  ci.relpages AS PAGES, " +
-        "  pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS FILTER_CONDITION " +
+        "  END AS \"ASC_OR_DESC\", ") +
+        "  ci.reltuples AS \"CARDINALITY\", " +
+        "  ci.relpages AS \"PAGES\", " +
+        "  pg_catalog.pg_get_expr(i.indpred, i.indrelid) AS \"FILTER_CONDITION\" " +
         "FROM pg_catalog.pg_class ct " +
         "  JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid) " +
         "  JOIN (SELECT i.indexrelid, i.indrelid, i.indoption, " +
@@ -1891,7 +1893,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
     if (unique) {
       sql.append(" AND i.indisunique ");
     }
-    sql.append(" ORDER BY NON_UNIQUE, TYPE, INDEX_NAME, ORDINAL_POSITION ");
+    sql.append(" ORDER BY \"NON_UNIQUE\", \"TYPE\", \"INDEX_NAME\", \"ORDINAL_POSITION\" ");
 
     return execForResultSet(sql.toString(), params);
   }
@@ -2073,10 +2075,10 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
 
     sql.append(
         "SELECT " +
-        " NULL AS TYPE_CAT, n.nspname AS TYPE_SCHEM, t.typname AS TYPE_NAME, NULL AS CLASS_NAME, " +
-        " CASE WHEN t.typtype='c' THEN " + java.sql.Types.STRUCT + " ELSE " + java.sql.Types.DISTINCT + " END AS DATA_TYPE, " +
-        " pg_catalog.obj_description(t.oid, 'pg_type')  AS REMARKS, " +
-        " typbasetype as BASE_TYPE_ID " +
+        " NULL AS \"TYPE_CAT\", n.nspname AS \"TYPE_SCHEM\", t.typname AS \"TYPE_NAME\", NULL AS \"CLASS_NAME\", " +
+        " CASE WHEN t.typtype='c' THEN " + java.sql.Types.STRUCT + " ELSE " + java.sql.Types.DISTINCT + " END AS \"DATA_TYPE\", " +
+        " pg_catalog.obj_description(t.oid, 'pg_type')  AS \"REMARKS\", " +
+        " typbasetype as \"BASE_TYPE_ID\" " +
         "FROM" +
         " pg_catalog.pg_type t, pg_catalog.pg_namespace n " +
         "WHERE" +
@@ -2140,7 +2142,7 @@ class PGDatabaseMetaData extends PGMetaData implements DatabaseMetaData {
       params.add(schemaPattern);
     }
 
-    sql.append(" ORDER BY data_type, type_schem, type_name");
+    sql.append(" ORDER BY \"DATA_TYPE\", \"TYPE_SCHEM\", \"TYPE_NAME\"");
 
     try (PGResultSet rs = execForResultSet(sql.toString(), params)) {
 

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/DatabaseMetaDataTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/DatabaseMetaDataTest.java
@@ -40,6 +40,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.PseudoColumnUsage;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -133,6 +134,9 @@ public class DatabaseMetaDataTest {
     assertNotNull(dbmd);
 
     ResultSet rs = dbmd.getTables(null, null, "metadatates%", new String[] {"TABLE"});
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS",
+        "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "SELF_REFERENCING_COL_NAME", "REF_GENERATION");
+
     assertTrue(rs.next());
     String tableName = rs.getString("TABLE_NAME");
     assertEquals("metadatatest", tableName);
@@ -172,7 +176,9 @@ public class DatabaseMetaDataTest {
     assertNotNull(dbmd);
 
     ResultSet rs = dbmd.getCrossReference(null, "", "vv", null, "", "ww");
-
+    checkResultSetColumnLabels(rs, "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
+        "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE",
+        "FK_NAME", "PK_NAME", "DEFERRABILITY");
     for (int j = 1; rs.next(); j++) {
 
       String pkTableName = rs.getString("PKTABLE_NAME");
@@ -213,6 +219,9 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = conn.getMetaData();
 
     ResultSet rs = dbmd.getImportedKeys(null, "", "fkt1");
+    checkResultSetColumnLabels(rs, "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
+        "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE",
+        "FK_NAME", "PK_NAME", "DEFERRABILITY");
     assertTrue(rs.next());
     assertTrue(rs.getInt("UPDATE_RULE") == DatabaseMetaData.importedKeyRestrict);
     assertTrue(rs.getInt("DELETE_RULE") == DatabaseMetaData.importedKeyCascade);
@@ -238,6 +247,9 @@ public class DatabaseMetaDataTest {
 
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getImportedKeys("", "", "fkt");
+    checkResultSetColumnLabels(rs, "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
+        "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE",
+        "FK_NAME", "PK_NAME", "DEFERRABILITY");
     int j = 0;
     for (; rs.next(); j++) {
       assertTrue("pkt".equals(rs.getString("PKTABLE_NAME")));
@@ -262,6 +274,9 @@ public class DatabaseMetaDataTest {
 
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getImportedKeys("", "", "fkt");
+    checkResultSetColumnLabels(rs, "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
+        "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE",
+        "FK_NAME", "PK_NAME", "DEFERRABILITY");
     int j = 0;
     for (; rs.next(); j++) {
       assertTrue("pkt".equals(rs.getString("PKTABLE_NAME")));
@@ -298,6 +313,9 @@ public class DatabaseMetaDataTest {
     assertNotNull(dbmd);
 
     ResultSet rs = dbmd.getImportedKeys(null, "", "users");
+    checkResultSetColumnLabels(rs, "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME", "PKCOLUMN_NAME",
+        "FKTABLE_CAT", "FKTABLE_SCHEM", "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ", "UPDATE_RULE", "DELETE_RULE",
+        "FK_NAME", "PK_NAME", "DEFERRABILITY");
     int j = 0;
     for (; rs.next(); j++) {
 
@@ -352,6 +370,10 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getColumns(null, null, "pg_class", null);
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
     rs.close();
   }
 
@@ -364,6 +386,10 @@ public class DatabaseMetaDataTest {
 
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "metadatatest", null);
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
 
     assertTrue(rs.next());
     assertEquals("id", rs.getString("COLUMN_NAME"));
@@ -380,6 +406,10 @@ public class DatabaseMetaDataTest {
     rs.close();
 
     rs = dbmd.getColumns(null, null, "metadatatest", "quest");
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
     assertTrue(rs.next());
     assertEquals("quest", rs.getString("COLUMN_NAME"));
     assertEquals(3, rs.getInt("ORDINAL_POSITION"));
@@ -412,6 +442,10 @@ public class DatabaseMetaDataTest {
   public void testSerialColumns() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "sercoltest", null);
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
     int rownum = 0;
     while (rs.next()) {
       assertEquals("sercoltest", rs.getString("TABLE_NAME"));
@@ -513,6 +547,9 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "NON_UNIQUE", "INDEX_QUALIFIER",
+        "INDEX_NAME", "TYPE", "ORDINAL_POSITION", "COLUMN_NAME", "ASC_OR_DESC", "CARDINALITY", "PAGES",
+        "FILTER_CONDITION");
 
     assertTrue(rs.next());
     assertEquals("idx_un_id", rs.getString("INDEX_NAME"));
@@ -560,6 +597,10 @@ public class DatabaseMetaDataTest {
   public void testNotNullDomainColumn() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "domaintable", "");
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
     assertTrue(rs.next());
     assertEquals("id", rs.getString("COLUMN_NAME"));
     assertEquals(Types.DISTINCT, rs.getInt("DATA_TYPE"));
@@ -578,6 +619,9 @@ public class DatabaseMetaDataTest {
 
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "NON_UNIQUE", "INDEX_QUALIFIER",
+        "INDEX_NAME", "TYPE", "ORDINAL_POSITION", "COLUMN_NAME", "ASC_OR_DESC", "CARDINALITY", "PAGES",
+        "FILTER_CONDITION");
 
     assertTrue(rs.next());
     assertEquals("idx_a_d", rs.getString("INDEX_NAME"));
@@ -600,6 +644,9 @@ public class DatabaseMetaDataTest {
 
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getIndexInfo(null, null, "metadatatest", false, false);
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "NON_UNIQUE", "INDEX_QUALIFIER",
+        "INDEX_NAME", "TYPE", "ORDINAL_POSITION", "COLUMN_NAME", "ASC_OR_DESC", "CARDINALITY", "PAGES",
+        "FILTER_CONDITION");
 
     assertTrue(rs.next());
     assertEquals("idx_p_name_id", rs.getString("INDEX_NAME"));
@@ -617,6 +664,7 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getTableTypes();
+    checkResultSetColumnLabels(rs, "TABLE_TYPE");
     rs.close();
   }
 
@@ -649,6 +697,10 @@ public class DatabaseMetaDataTest {
   public void testFuncWithNames() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f2", null);
+    checkResultSetColumnLabels(rs, "PROCEDURE_CAT", "PROCEDURE_SCHEM", "PROCEDURE_NAME", "COLUMN_NAME",
+        "COLUMN_TYPE", "DATA_TYPE", "TYPE_NAME", "PRECISION", "LENGTH", "SCALE", "RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SPECIFIC_NAME");
 
     assertTrue(rs.next());
 
@@ -667,6 +719,10 @@ public class DatabaseMetaDataTest {
   public void testFuncWithDirection() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f3", null);
+    checkResultSetColumnLabels(rs, "PROCEDURE_CAT", "PROCEDURE_SCHEM", "PROCEDURE_NAME", "COLUMN_NAME",
+        "COLUMN_TYPE", "DATA_TYPE", "TYPE_NAME", "PRECISION", "LENGTH", "SCALE", "RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SPECIFIC_NAME");
 
     assertTrue(rs.next());
     assertEquals("a", rs.getString(4));
@@ -690,6 +746,10 @@ public class DatabaseMetaDataTest {
   public void testFuncReturningComposite() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getProcedureColumns(null, null, "f4", null);
+    checkResultSetColumnLabels(rs, "PROCEDURE_CAT", "PROCEDURE_SCHEM", "PROCEDURE_NAME", "COLUMN_NAME",
+        "COLUMN_TYPE", "DATA_TYPE", "TYPE_NAME", "PRECISION", "LENGTH", "SCALE", "RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SPECIFIC_NAME");
 
     assertTrue(rs.next());
     assertEquals("$1", rs.getString(4));
@@ -731,6 +791,8 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getVersionColumns(null, null, "pg_class");
+    checkResultSetColumnLabels(rs, "SCOPE", "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME", "COLUMN_SIZE",
+        "BUFFER_LENGTH", "DECIMAL_DIGITS", "PSEUDO_COLUMN");
     rs.close();
   }
 
@@ -740,6 +802,8 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getBestRowIdentifier(null, null, "pg_type", DatabaseMetaData.bestRowSession, false);
+    checkResultSetColumnLabels(rs, "SCOPE", "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME", "COLUMN_SIZE",
+        "BUFFER_LENGTH", "DECIMAL_DIGITS", "PSEUDO_COLUMN");
     rs.close();
   }
 
@@ -749,6 +813,8 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
     assertNotNull(dbmd);
     ResultSet rs = dbmd.getProcedures(null, null, null);
+    checkResultSetColumnLabels(rs, "PROCEDURE_CAT", "PROCEDURE_SCHEM", "PROCEDURE_NAME", null, null, null,
+        "REMARKS", "PROCEDURE_TYPE", "SPECIFIC_NAME");
     rs.close();
   }
 
@@ -756,6 +822,7 @@ public class DatabaseMetaDataTest {
   public void testCatalogs() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getCatalogs();
+    checkResultSetColumnLabels(rs, "TABLE_CAT");
     assertTrue(rs.next());
     assertEquals(con.getCatalog(), rs.getString(1));
     assertTrue(!rs.next());
@@ -768,6 +835,7 @@ public class DatabaseMetaDataTest {
     assertNotNull(dbmd);
 
     ResultSet rs = dbmd.getSchemas();
+    checkResultSetColumnLabels(rs, "TABLE_SCHEM", "TABLE_CATALOG");
     boolean foundPublic = false;
     boolean foundEmpty = false;
     boolean foundPGCatalog = false;
@@ -796,9 +864,13 @@ public class DatabaseMetaDataTest {
   public void testEscaping() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTables(null, null, "a'", new String[] {"TABLE"});
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS",
+        "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "SELF_REFERENCING_COL_NAME", "REF_GENERATION");
     assertTrue(rs.next());
     rs.close();
     rs = dbmd.getTables(null, null, "a\\\\", new String[] {"TABLE"});
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE", "REMARKS",
+        "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "SELF_REFERENCING_COL_NAME", "REF_GENERATION");
     assertTrue(rs.next());
     rs.close();
 
@@ -834,6 +906,8 @@ public class DatabaseMetaDataTest {
       stmt.execute("create type jdbc.testint8 as (i int8)");
       DatabaseMetaData dbmd = con.getMetaData();
       ResultSet rs = dbmd.getUDTs(null, null, "jdbc.testint8", null);
+      checkResultSetColumnLabels(rs, "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "CLASS_NAME", "DATA_TYPE",
+          "REMARKS", "BASE_TYPE");
       assertTrue(rs.next());
 
       @SuppressWarnings("unused")
@@ -895,6 +969,8 @@ public class DatabaseMetaDataTest {
 
       DatabaseMetaData dbmd = con.getMetaData();
       ResultSet rs = dbmd.getUDTs(null, null, "testint8", null);
+      checkResultSetColumnLabels(rs, "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "CLASS_NAME", "DATA_TYPE",
+          "REMARKS", "BASE_TYPE");
       assertTrue(rs.next());
 
       @SuppressWarnings("unused")
@@ -940,6 +1016,8 @@ public class DatabaseMetaDataTest {
 
       DatabaseMetaData dbmd = con.getMetaData();
       ResultSet rs = dbmd.getUDTs(null, null, "testint8", new int[] {Types.DISTINCT, Types.STRUCT});
+      checkResultSetColumnLabels(rs, "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "CLASS_NAME", "DATA_TYPE",
+          "REMARKS", "BASE_TYPE");
       assertTrue(rs.next());
 
       @SuppressWarnings("unused")
@@ -985,6 +1063,8 @@ public class DatabaseMetaDataTest {
 
       DatabaseMetaData dbmd = con.getMetaData();
       ResultSet rs = dbmd.getUDTs(null, null, "testint8", new int[] {Types.DISTINCT});
+      checkResultSetColumnLabels(rs, "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "CLASS_NAME", "DATA_TYPE",
+          "REMARKS", "BASE_TYPE");
       assertTrue(rs.next());
 
       @SuppressWarnings("unused")
@@ -1029,6 +1109,8 @@ public class DatabaseMetaDataTest {
 
       DatabaseMetaData dbmd = con.getMetaData();
       ResultSet rs = dbmd.getUDTs(null, null, "testint8", null);
+      checkResultSetColumnLabels(rs, "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "CLASS_NAME", "DATA_TYPE",
+          "REMARKS", "BASE_TYPE");
       assertTrue(rs.next());
 
       @SuppressWarnings("unused")
@@ -1068,6 +1150,10 @@ public class DatabaseMetaDataTest {
 
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getAttributes(null, null, "attr_test", null);
+    checkResultSetColumnLabels(rs, "TYPE_CAT", "TYPE_SCHEM", "TYPE_NAME", "ATTR_NAME", "DATA_TYPE",
+        "ATTR_TYPE_NAME", "ATTR_SIZE", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS", "ATTR_DEF",
+        "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE", "SCOPE_CATALOG",
+        "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE");
 
     assertTrue(rs.next());
     assertEquals("public", rs.getString("TYPE_SCHEM"));
@@ -1127,6 +1213,10 @@ public class DatabaseMetaDataTest {
   public void testTypeInfoSigned() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTypeInfo();
+    checkResultSetColumnLabels(rs, "TYPE_NAME", "DATA_TYPE", "PRECISION", "LITERAL_PREFIX", "LITERAL_SUFFIX",
+        "CREATE_PARAMS", "NULLABLE", "CASE_SENSITIVE", "SEARCHABLE", "UNSIGNED_ATTRIBUTE", "FIXED_PREC_SCALE",
+        "AUTO_INCREMENT", "LOCAL_TYPE_NAME", "MINIMUM_SCALE", "MAXIMUM_SCALE", "SQL_DATA_TYPE", "SQL_DATETIME_SUB",
+        "NUM_PREC_RADIX");
     while (rs.next()) {
       if ("int4".equals(rs.getString("TYPE_NAME"))) {
         assertEquals(false, rs.getBoolean("UNSIGNED_ATTRIBUTE"));
@@ -1145,6 +1235,10 @@ public class DatabaseMetaDataTest {
   public void testTypeInfoQuoting() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getTypeInfo();
+    checkResultSetColumnLabels(rs, "TYPE_NAME", "DATA_TYPE", "PRECISION", "LITERAL_PREFIX", "LITERAL_SUFFIX",
+        "CREATE_PARAMS", "NULLABLE", "CASE_SENSITIVE", "SEARCHABLE", "UNSIGNED_ATTRIBUTE", "FIXED_PREC_SCALE",
+        "AUTO_INCREMENT", "LOCAL_TYPE_NAME", "MINIMUM_SCALE", "MAXIMUM_SCALE", "SQL_DATA_TYPE", "SQL_DATETIME_SUB",
+        "NUM_PREC_RADIX");
     while (rs.next()) {
       if ("int4".equals(rs.getString("TYPE_NAME"))) {
         assertNull(rs.getString("LITERAL_PREFIX"));
@@ -1161,6 +1255,10 @@ public class DatabaseMetaDataTest {
   public void testInformationAboutArrayTypes() throws SQLException {
     DatabaseMetaData dbmd = con.getMetaData();
     ResultSet rs = dbmd.getColumns(null, null, "arraytable", "");
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
     assertTrue(rs.next());
     assertEquals("a", rs.getString("COLUMN_NAME"));
     assertEquals(5, rs.getInt("COLUMN_SIZE"));
@@ -1177,6 +1275,7 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
 
     ResultSet rs = dbmd.getClientInfoProperties();
+    checkResultSetColumnLabels(rs, "NAME", "MAX_LEN", "DEFAULT_VALUE", "DESCRIPTION");
 
     assertTrue(rs.next());
     assertEquals("ApplicationName", rs.getString("NAME"));
@@ -1191,6 +1290,10 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
 
     ResultSet rs = dbmd.getColumns("%", "%", "sercoltest", "%");
+    checkResultSetColumnLabels(rs, "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "DATA_TYPE",
+        "TYPE_NAME", "COLUMN_SIZE", "BUFFER_LENGTH", "DECIMAL_DIGITS", "NUM_PREC_RADIX", "NULLABLE", "REMARKS",
+        "COLUMN_DEF", "SQL_DATA_TYPE", "SQL_DATETIME_SUB", "CHAR_OCTET_LENGTH", "ORDINAL_POSITION", "IS_NULLABLE",
+        "SCOPE_CATALOG", "SCOPE_SCHEMA", "SCOPE_TABLE", "SOURCE_DATA_TYPE", "IS_AUTOINCREMENT", "IS_GENERATEDCOLUMN");
     assertTrue(rs.next());
     assertEquals("a", rs.getString("COLUMN_NAME"));
     assertEquals("NO", rs.getString("IS_AUTOINCREMENT"));
@@ -1213,6 +1316,7 @@ public class DatabaseMetaDataTest {
     DatabaseMetaData dbmd = con.getMetaData();
 
     ResultSet rs = dbmd.getSchemas("", "publ%");
+    checkResultSetColumnLabels(rs, "TABLE_SCHEM", "TABLE_CATALOG");
 
     assertTrue(rs.next());
     assertEquals("public", rs.getString("TABLE_SCHEM"));
@@ -1220,6 +1324,18 @@ public class DatabaseMetaDataTest {
     assertTrue(!rs.next());
 
     rs.close();
+  }
+
+  void checkResultSetColumnLabels(ResultSet rs, String... labels) throws SQLException {
+
+    ResultSetMetaData rsmd = rs.getMetaData();
+    assertEquals(labels.length, rsmd.getColumnCount());
+
+    for (int c = 0; c < labels.length; ++c) {
+      if (labels[c] != null) {
+        assertEquals(labels[c], rsmd.getColumnLabel(c + 1));
+      }
+    }
   }
 
 }


### PR DESCRIPTION
The spec defines meta-data result-sets column names to be returned uppercase. This ensures that all our retured columns meet spec. Column label comparisons were added to metadata resultsets to validate the names.

Also, fixes a couple typo in column names and adds some missing columns