### PR TITLE
Type Fixes

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGAnyType.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGAnyType.java
@@ -41,4 +41,6 @@ public interface PGAnyType extends SQLType  {
     return null;
   }
 
+  Class<?> getJavaType();
+
 }

--- a/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGType.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGType.java
@@ -28,77 +28,89 @@
  */
 package com.impossibl.postgres.api.jdbc;
 
+import com.impossibl.postgres.api.data.ACLItem;
+import com.impossibl.postgres.api.data.CidrAddr;
+import com.impossibl.postgres.api.data.InetAddr;
+import com.impossibl.postgres.api.data.Interval;
+import com.impossibl.postgres.api.data.Path;
+import com.impossibl.postgres.api.data.Tid;
 import com.impossibl.postgres.system.Version;
 import com.impossibl.postgres.types.Type;
+import com.impossibl.postgres.utils.TypeLiteral;
 
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.JDBCType;
+import java.sql.SQLXML;
+import java.sql.Struct;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Map;
 
 public enum PGType implements PGAnyType {
 
   //CHECKSTYLE:OFF: ParenPad|NoWhitespaceBefore
 
-  BOOL                    (  16,  "bool",         JDBCType.BOOLEAN),
+  BOOL                    (  16,  "bool",         Boolean.class,        JDBCType.BOOLEAN),
 
-  BYTES                   (  17,  "bytea",        JDBCType.BINARY),
+  BYTES                   (  17,  "bytea",        InputStream.class,    JDBCType.BINARY),
 
-  INT2                    (  21,  "int2",         JDBCType.SMALLINT),
-  INT4                    (  23,  "int4",         JDBCType.INTEGER),
-  INT8                    (  20,  "int8",         JDBCType.BIGINT),
-  FLOAT4                  ( 700,  "float4",       JDBCType.REAL),
-  FLOAT8                  ( 701,  "float8",       JDBCType.DOUBLE),
-  MONEY                   ( 790,  "money",        JDBCType.DECIMAL),
-  NUMERIC                 (1700,  "numeric",      JDBCType.NUMERIC),
+  INT2                    (  21,  "int2",         Short.class,          JDBCType.SMALLINT),
+  INT4                    (  23,  "int4",         Integer.class,        JDBCType.INTEGER),
+  INT8                    (  20,  "int8",         Long.class,           JDBCType.BIGINT),
+  FLOAT4                  ( 700,  "float4",       Float.class,          JDBCType.REAL),
+  FLOAT8                  ( 701,  "float8",       Double.class,         JDBCType.DOUBLE),
+  MONEY                   ( 790,  "money",        BigDecimal.class,     JDBCType.DECIMAL),
+  NUMERIC                 (1700,  "numeric",      BigDecimal.class,     JDBCType.NUMERIC),
 
-  CHAR                    (  18,  "char",         JDBCType.CHAR),
-  NAME                    (  19,  "name",         JDBCType.VARCHAR),
-  TEXT                    (  25,  "text",         JDBCType.VARCHAR),
-  BPCHAR                  (1042,  "bpchar",       JDBCType.VARCHAR),
-  VARCHAR                 (1043,  "varchar",      JDBCType.VARCHAR),
-  CSTRING                 (2275,  "cstring",      JDBCType.VARCHAR),
+  CHAR                    (  18,  "char",         String.class,         JDBCType.CHAR),
+  NAME                    (  19,  "name",         String.class,         JDBCType.VARCHAR),
+  TEXT                    (  25,  "text",         String.class,         JDBCType.VARCHAR),
+  BPCHAR                  (1042,  "bpchar",       String.class,         JDBCType.VARCHAR),
+  VARCHAR                 (1043,  "varchar",      String.class,         JDBCType.VARCHAR),
+  CSTRING                 (2275,  "cstring",      String.class,         JDBCType.VARCHAR),
 
-  JSON                    ( 114,  "json",         JDBCType.VARCHAR,                   "9.1"),
-  JSONB                   (3802,  "jsonb",        JDBCType.VARCHAR,                   "9.4"),
-  XML                     ( 142,  "xml",          JDBCType.SQLXML),
+  JSON                    ( 114,  "json",         String.class,         JDBCType.VARCHAR, "9.1"),
+  JSONB                   (3802,  "jsonb",        String.class,         JDBCType.VARCHAR, "9.4"),
+  XML                     ( 142,  "xml",          SQLXML.class,         JDBCType.SQLXML),
 
-  DATE                    (1082,  "date",         JDBCType.DATE),
-  TIME                    (1083,  "time",         JDBCType.TIME),
-  TIME_WITH_TIMEZONE      (1266,  "timetz",       JDBCType.TIME_WITH_TIMEZONE),
-  TIMESTAMP               (1114,  "timestamp",    JDBCType.TIMESTAMP),
-  TIMESTAMP_WITH_TIMEZONE (1184,  "timestamptz",  JDBCType.TIMESTAMP_WITH_TIMEZONE),
-  INTERVAL                (1186,  "interval",     JDBCType.OTHER),
-  ABSTIME                 ( 702,  "abstime",      JDBCType.OTHER),
-  RELTIME                 ( 703,  "reltime",      JDBCType.OTHER),
-  TINTERVAL               ( 704,  "tinterval",    JDBCType.OTHER),
+  DATE                    (1082,  "date",         Date.class,           JDBCType.DATE),
+  TIME                    (1083,  "time",         Time.class,           JDBCType.TIME),
+  TIME_WITH_TIMEZONE      (1266,  "timetz",       Time.class,           JDBCType.TIME_WITH_TIMEZONE),
+  TIMESTAMP               (1114,  "timestamp",    Timestamp.class,      JDBCType.TIMESTAMP),
+  TIMESTAMP_WITH_TIMEZONE (1184,  "timestamptz",  Timestamp.class,      JDBCType.TIMESTAMP_WITH_TIMEZONE),
+  INTERVAL                (1186,  "interval",     Interval.class,       JDBCType.OTHER),
 
-  POINT                   ( 600,  "point",        JDBCType.OTHER),
-  LINE_SEGMENT            ( 601,  "lseg",         JDBCType.OTHER),
-  PATH                    ( 602,  "path",         JDBCType.OTHER),
-  BOX                     ( 603,  "box",          JDBCType.OTHER),
-  POLYGON                 ( 604,  "polygon",      JDBCType.OTHER),
-  LINE                    ( 628,  "line",         JDBCType.OTHER),
-  CIRCLE                  ( 718,  "circle",       JDBCType.OTHER),
+  POINT                   ( 600,  "point",        double[].class,       JDBCType.OTHER),
+  LINE_SEGMENT            ( 601,  "lseg",         double[].class,       JDBCType.OTHER),
+  PATH                    ( 602,  "path",         Path.class,           JDBCType.OTHER),
+  BOX                     ( 603,  "box",          double[].class,       JDBCType.OTHER),
+  POLYGON                 ( 604,  "polygon",      double[][].class,     JDBCType.OTHER),
+  LINE                    ( 628,  "line",         double[].class,       JDBCType.OTHER),
+  CIRCLE                  ( 718,  "circle",       double[].class,       JDBCType.OTHER),
 
-  MACADDR                 ( 829,  "macaddr",      JDBCType.OTHER),
-  MACADDR8                ( 774,  "macaddr8",     JDBCType.OTHER,                     "10.0"),
-  CIDR                    ( 650,  "cidr",         JDBCType.OTHER),
-  INET                    ( 869,  "inet",         JDBCType.OTHER),
+  MACADDR                 ( 829,  "macaddr",      byte[].class,         JDBCType.OTHER),
+  MACADDR8                ( 774,  "macaddr8",     byte[].class,         JDBCType.OTHER, "10.0"),
+  CIDR                    ( 650,  "cidr",         CidrAddr.class,       JDBCType.OTHER),
+  INET                    ( 869,  "inet",         InetAddr.class,       JDBCType.OTHER),
 
-  BIT                     (1560,  "bit",          JDBCType.BOOLEAN),
-  VARBIT                  (1562,  "varbit",       JDBCType.VARBINARY),
+  BIT                     (1560,  "bit",          boolean[].class,      JDBCType.BOOLEAN),
+  VARBIT                  (1562,  "varbit",       boolean[].class,      JDBCType.VARBINARY),
 
-  RECORD                  (2249,  "record",       JDBCType.STRUCT),
+  RECORD                  (2249,  "record",       Struct.class,         JDBCType.STRUCT),
 
-  UUID                    (2950,  "uuid",         JDBCType.OTHER),
+  UUID                    (2950,  "uuid",         java.util.UUID.class, JDBCType.OTHER),
 
-  ACL_ITEM                (1033,  "aclitem",      JDBCType.OTHER),
+  ACL_ITEM                (1033,  "aclitem",      ACLItem.class,        JDBCType.OTHER),
 
-  OID                     (  26,  "oid",          JDBCType.INTEGER),
-  TID                     (  27,  "tid",          JDBCType.ROWID),
-  XID                     (  28,  "xid",          JDBCType.OTHER),
-  CID                     (  29,  "cid",          JDBCType.OTHER),
+  OID                     (  26,  "oid",          Integer.class,        JDBCType.INTEGER),
+  TID                     (  27,  "tid",          Tid.class,            JDBCType.ROWID),
+  XID                     (  28,  "xid",          Integer.class,        JDBCType.OTHER),
+  CID                     (  29,  "cid",          Integer.class,        JDBCType.OTHER),
 
-  HSTORE                  (null, "hstore",        JDBCType.OTHER),
-  CITEXT                  (null, "citext",        JDBCType.VARCHAR),
+  HSTORE                  (null, "hstore",        Types.HSTORE,         JDBCType.OTHER),
+  CITEXT                  (null, "citext",        String.class,         JDBCType.VARCHAR),
 
   ;
 
@@ -106,18 +118,20 @@ public enum PGType implements PGAnyType {
 
   private Integer oid;
   private String name;
+  private Class<?> javaType;
   private JDBCType jdbcType;
   private Version requiredVersion;
 
-  PGType(Integer oid, String name, JDBCType jdbcType, String requiredVersion) {
+  PGType(Integer oid, String name, Class<?> javaType, JDBCType jdbcType, String requiredVersion) {
     this.oid = oid;
     this.name = name;
+    this.javaType = javaType;
     this.jdbcType = jdbcType;
     this.requiredVersion = Version.parse(requiredVersion);
   }
 
-  PGType(Integer oid, String name, JDBCType jdbcType) {
-    this(oid, name, jdbcType, "0.0");
+  PGType(Integer oid, String name, Class<?> javaType, JDBCType jdbcType) {
+    this(oid, name, javaType, jdbcType, "0.0");
   }
 
   @Override
@@ -138,6 +152,11 @@ public enum PGType implements PGAnyType {
   @Override
   public Integer getVendorTypeNumber() {
     return oid;
+  }
+
+  @Override
+  public Class<?> getJavaType() {
+    return javaType;
   }
 
   public JDBCType getMappedType() {
@@ -163,6 +182,13 @@ public enum PGType implements PGAnyType {
     }
 
     throw new IllegalArgumentException("PostgreSQL Type:" + oid + " is not a valid PGType value.");
+  }
+
+
+  private static class Types {
+
+    static final Class<Map<String, String>> HSTORE = new TypeLiteral<Map<String, String>>() { }.getRawType();
+
   }
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGResolvedType.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGResolvedType.java
@@ -55,4 +55,9 @@ class PGResolvedType implements PGAnyType {
     return type.getId();
   }
 
+  @Override
+  public Class<?> getJavaType() {
+    return type.getCodec(type.getParameterFormat()).getDecoder().getDefaultClass();
+  }
+
 }

--- a/driver/src/main/java/com/impossibl/postgres/protocol/ResultField.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/ResultField.java
@@ -34,7 +34,7 @@ public class ResultField implements FieldFormatRef {
 
   private String name;
   private int relationId;
-  private int relationAttributeNumber;
+  private short relationAttributeNumber;
   private TypeRef typeRef;
   private short typeLength;
   private int typeModifier;
@@ -68,7 +68,7 @@ public class ResultField implements FieldFormatRef {
     return relationId;
   }
 
-  public int getRelationAttributeNumber() {
+  public short getRelationAttributeNumber() {
     return relationAttributeNumber;
   }
 

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Bytes.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Bytes.java
@@ -254,13 +254,52 @@ public class Bytes extends SimpleProcProvider {
 
   private static final char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
 
-  public static byte[] decodeHex(CharSequence buffer) {
+  public static byte[] decodeHex(CharSequence buffer) throws ConversionException {
+    return decodeHex(buffer, false);
+  }
+
+  public static byte[] decodeHex(CharSequence buffer, boolean ignoreDelimeters) throws ConversionException {
+
+    // count non hex chars
+    int hexChars = 0;
+    for (int i = 0; i < buffer.length(); i++) {
+      char ch = buffer.charAt(i);
+      switch (ch) {
+        case '-':
+        case '_':
+        case ':':
+        case '.':
+        case ',':
+          continue;
+        default:
+          if ((ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F') || (ch >= '0' && ch <= '9'))
+            hexChars++;
+          else if (!ignoreDelimeters)
+            throw new ConversionException("Invalid hex input");
+      }
+    }
+
+    if (hexChars % 2 != 0) {
+      throw new ConversionException("Invalid hex input");
+    }
 
     int length = buffer.length();
-    byte[] data = new byte[length / 2];
+    byte[] data = new byte[hexChars / 2];
 
     for (int i = 0, j = 0; i < length; i += 2, j += 1) {
-      data[j] = (byte) (((Character.digit(buffer.charAt(i), 16) << 4) + Character.digit(buffer.charAt(i + 1), 16)));
+      char ch = buffer.charAt(i);
+      switch (ch) {
+        case '-':
+        case '_':
+        case ':':
+        case '.':
+        case ',':
+          i += 1;
+          ch = buffer.charAt(i);
+        default:
+          char ch2 = buffer.charAt(i + 1);
+          data[j] = (byte) (((Character.digit(ch, 16) << 4) + Character.digit(ch2, 16)));
+      }
     }
 
     return data;

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Int2Vectors.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Int2Vectors.java
@@ -40,7 +40,18 @@ import java.text.ParseException;
 public class Int2Vectors extends SimpleProcProvider {
 
   public Int2Vectors() {
-    super(new TxtEncoder(), new TxtDecoder(), new Arrays.BinEncoder(), new Arrays.BinDecoder(), "int2vector");
+    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "int2vector");
+  }
+
+  static class BinDecoder extends Arrays.BinDecoder {
+
+    public Class<?> getDefaultClass() {
+      return Short[].class;
+    }
+
+  }
+
+  static class BinEncoder extends Arrays.BinEncoder {
   }
 
   static class TxtDecoder extends BaseTextDecoder {
@@ -51,7 +62,8 @@ public class Int2Vectors extends SimpleProcProvider {
     }
 
     @Override
-    protected Object decodeValue(Context context, Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Class<?> targetClass, Object targetContext) throws IOException, ParseException {
+    protected Object decodeValue(Context context, Type type, Short typeLength, Integer typeModifier,
+                                 CharSequence buffer, Class<?> targetClass, Object targetContext) throws IOException, ParseException {
 
       int length = buffer.length();
 

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Int4s.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Int4s.java
@@ -39,7 +39,9 @@ import io.netty.buffer.ByteBuf;
 public class Int4s extends SimpleProcProvider {
 
   public Int4s() {
-    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "int4", "xid", "cid", "regproc", "regtype", "regclass", "regoper");
+    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(),
+        "int4", "xid", "cid", "regproc", "regtype", "regclass", "regoper", "regnamespace", "regrole"
+    );
   }
 
   static class BinDecoder extends NumericBinaryDecoder<Integer> {

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/OidVectors.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/OidVectors.java
@@ -39,7 +39,18 @@ import java.text.ParseException;
 public class OidVectors extends SimpleProcProvider {
 
   public OidVectors() {
-    super(new TxtEncoder(), new TxtDecoder(), new Arrays.BinEncoder(), new Arrays.BinDecoder(), "oidvector");
+    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "oidvector");
+  }
+
+  static class BinDecoder extends Arrays.BinDecoder {
+
+    public Class<?> getDefaultClass() {
+      return Integer[].class;
+    }
+
+  }
+
+  static class BinEncoder extends Arrays.BinEncoder {
   }
 
   static class TxtDecoder extends BaseTextDecoder {

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Records.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Records.java
@@ -44,6 +44,7 @@ import static com.impossibl.postgres.utils.ByteBufs.lengthEncodeBinary;
 import java.io.IOException;
 import java.sql.SQLData;
 import java.sql.SQLException;
+import java.sql.Struct;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,7 +89,7 @@ public class Records extends SimpleProcProvider {
 
   static <Buffer> Object convertOutput(Context context, Type type, Type[] attributeTypes, Buffer[] attributeBuffers, Class<?> targetClass, InputFactory<Buffer> inputFactory, StructFactory<Buffer> structFactory) throws IOException {
 
-    if (targetClass == PGStruct.class) {
+    if (Struct.class.isAssignableFrom(targetClass)) {
       targetClass = lookupCustomType(type, context.getCustomTypeMap(), targetClass);
     }
 
@@ -113,7 +114,7 @@ public class Records extends SimpleProcProvider {
 
       result = data;
     }
-    else if (targetClass == PGStruct.class) {
+    else if (Struct.class.isAssignableFrom(targetClass)) {
       result = structFactory.create(context, type.getQualifiedName().toString(), attributeTypes, attributeBuffers);
     }
     else {

--- a/driver/src/main/java/com/impossibl/postgres/types/Type.java
+++ b/driver/src/main/java/com/impossibl/postgres/types/Type.java
@@ -31,11 +31,11 @@ package com.impossibl.postgres.types;
 import com.impossibl.postgres.protocol.FieldFormat;
 import com.impossibl.postgres.protocol.TypeRef;
 import com.impossibl.postgres.system.Context;
-import com.impossibl.postgres.system.procs.Procs;
 import com.impossibl.postgres.system.tables.PGTypeTable;
 
 import static com.impossibl.postgres.system.SystemSettings.FIELD_FORMAT_PREF;
 import static com.impossibl.postgres.system.SystemSettings.PARAM_FORMAT_PREF;
+import static com.impossibl.postgres.system.procs.Procs.isDefaultDecoder;
 import static com.impossibl.postgres.system.procs.Procs.isDefaultEncoder;
 import static com.impossibl.postgres.utils.guava.Preconditions.checkNotNull;
 
@@ -319,7 +319,7 @@ public abstract class Type implements TypeRef {
   }
 
   public boolean isResultFormatSupported(FieldFormat format) {
-    return !Procs.isDefaultDecoder(getCodec(format).decoder);
+    return !isDefaultDecoder(getCodec(format).decoder);
   }
 
   public FieldFormat getResultFormat() {
@@ -354,6 +354,12 @@ public abstract class Type implements TypeRef {
     modifierParser = registry.getShared().loadModifierParser(source.getModInId());
     preferredParameterFormat = PARAM_FORMAT_PREF.getSystem();
     preferredResultFormat = FIELD_FORMAT_PREF.getSystem();
+
+    if (!isDefaultDecoder(textCodec.getDecoder()) && !isDefaultDecoder(binaryCodec.getDecoder())
+        && textCodec.getDecoder().getDefaultClass() != binaryCodec.getDecoder().getDefaultClass()) {
+      throw new IllegalArgumentException("Non default type decoders must have the same default class");
+    }
+
   }
 
   /**

--- a/driver/src/main/resources/META-INF/services/com.impossibl.postgres.system.procs.ProcProvider
+++ b/driver/src/main/resources/META-INF/services/com.impossibl.postgres.system.procs.ProcProvider
@@ -22,6 +22,7 @@ com.impossibl.postgres.system.procs.Jsons
 com.impossibl.postgres.system.procs.Lines
 com.impossibl.postgres.system.procs.LSegs
 com.impossibl.postgres.system.procs.MacAddrs
+com.impossibl.postgres.system.procs.MacAddr8s
 com.impossibl.postgres.system.procs.Moneys
 com.impossibl.postgres.system.procs.Names
 com.impossibl.postgres.system.procs.NumericMods

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/NetworkTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/NetworkTest.java
@@ -29,7 +29,11 @@
 
 package com.impossibl.postgres.jdbc;
 
-import java.sql.Connection;
+import com.impossibl.postgres.api.jdbc.PGConnection;
+import com.impossibl.postgres.system.Version;
+
+import static com.impossibl.postgres.api.jdbc.PGType.MACADDR8;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,15 +45,22 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 public class NetworkTest {
 
-  private Connection conn;
+  private PGConnection conn;
+  private Version macaddr8Ver = MACADDR8.getRequiredVersion();
 
   @Before
   public void before() throws Exception {
-    conn = TestUtil.openDB();
-    TestUtil.createTable(conn, "mactest", "mac_address macaddr, cidr_mask cidr, mac8_address macaddr8");
+    conn = TestUtil.openDB().unwrap(PGConnection.class);
+    if (conn.isServerMinimumVersion(macaddr8Ver.getMajor(), macaddr8Ver.getMinor())) {
+      TestUtil.createTable(conn, "mactest", "mac_address macaddr, cidr_mask cidr, mac8_address macaddr8");
+    }
+    else {
+      TestUtil.createTable(conn, "mactest", "mac_address macaddr, cidr_mask cidr");
+    }
   }
 
   @After
@@ -104,6 +115,8 @@ public class NetworkTest {
 
   @Test
   public void testMac8StringConversion() throws SQLException {
+    assumeTrue("macaddr8 requires server version " + macaddr8Ver,
+        conn.isServerMinimumVersion(macaddr8Ver.getMajor(), macaddr8Ver.getMinor()));
     try (Statement stmt = conn.createStatement()) {
       int rows = stmt.executeUpdate("INSERT into mactest(mac8_address) VALUES ('08:00:2b:01:02:03:07:08')");
       assertEquals("Number of inserted rows not as expected", 1, rows);
@@ -116,6 +129,8 @@ public class NetworkTest {
 
   @Test
   public void testMac8PreparedStatement() throws SQLException {
+    assumeTrue("macaddr8 requires server version " + macaddr8Ver,
+        conn.isServerMinimumVersion(macaddr8Ver.getMajor(), macaddr8Ver.getMinor()));
     try (PreparedStatement stmt = conn.prepareStatement("INSERT into mactest(mac8_address) VALUES (?)")) {
       stmt.setString(1, "08:00:2b:01:02:03:07:08");
       int rows = stmt.executeUpdate();
@@ -125,6 +140,8 @@ public class NetworkTest {
 
   @Test
   public void testMac8Batch() throws SQLException {
+    assumeTrue("macaddr8 requires server version " + macaddr8Ver,
+        conn.isServerMinimumVersion(macaddr8Ver.getMajor(), macaddr8Ver.getMinor()));
     try (PreparedStatement stmt = conn.prepareStatement("INSERT into mactest(mac8_address) VALUES (CAST (? AS macaddr8))")) {
       stmt.setString(1, "08:00:2b:01:02:03:07:08");
       stmt.addBatch();

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/PGTypeTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/PGTypeTest.java
@@ -88,6 +88,11 @@ public class PGTypeTest {
       public Version getRequiredVersion() {
         return Version.parse("99");
       }
+
+      @Override
+      public Class<?> getJavaType() {
+        return Object.class;
+      }
     };
 
     try (PreparedStatement preparedStatement = conn.prepareStatement("SELECT ?::text")) {


### PR DESCRIPTION
A related set of fixes to the types, adds missing `maccaddr8`, removes deprecated types from `PGType` and adds the default java class it's mapped to.

Finally it enforces that all types implementing both text & binary return the same `defaultClass` property to ensure stability parity between text & binary.