### PR TITLE
Fix NPE when binding null as a batch parameter value

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/utils/ByteBufs.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/ByteBufs.java
@@ -58,7 +58,9 @@ public class ByteBufs {
   public static ByteBuf[] retainedDuplicateAll(ByteBuf[] buffers) {
     buffers = buffers.clone();
     for (int c = 0; c < buffers.length; ++c)
-      buffers[c] = buffers[c].retainedDuplicate();
+      if(buffers[c] != null) {
+        buffers[c] = buffers[c].retainedDuplicate();
+      }
     return buffers;
   }
 

--- a/driver/src/main/java/com/impossibl/postgres/utils/ByteBufs.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/ByteBufs.java
@@ -57,10 +57,11 @@ public class ByteBufs {
 
   public static ByteBuf[] retainedDuplicateAll(ByteBuf[] buffers) {
     buffers = buffers.clone();
-    for (int c = 0; c < buffers.length; ++c)
-      if(buffers[c] != null) {
+    for (int c = 0; c < buffers.length; ++c) {
+      if (buffers[c] != null) {
         buffers[c] = buffers[c].retainedDuplicate();
       }
+    }
     return buffers;
   }
 


### PR DESCRIPTION
Hi, congratulations on the new release: I'm very happy this project is
getting attention again. I've tested the new 0.8 version and
encountered an issue when binding `null` in an insert statement. Here's
a Clojure example to reproduce the issue (using clojure.java.jdbc):

```clojure
(jdbc/with-db-connection [conn "jdbc:pgsql://postgres@127.0.0.1:5432/mydb"]¬                             
  (doto conn¬                                                                                           
    (jdbc/execute! "CREATE TABLE IF NOT EXISTS delete_me (col_a int)")¬                                 
    (jdbc/execute! ["INSERT INTO delete_me (col_a) VALUES (?)" nil])))
```
The result:
```
1. Unhandled java.lang.NullPointerException                                                             
   (No message)                                                                                         
                                                                                                        
             ByteBufs.java:   61  com.impossibl.postgres.utils.ByteBufs/retainedDuplicateAll            
  PGPreparedStatement.java:  395  com.impossibl.postgres.jdbc.PGPreparedStatement/addBatch              
                  jdbc.clj: 1026  clojure.java.jdbc/db-do-execute-prepared-statement                    
                  jdbc.clj: 1014  clojure.java.jdbc/db-do-execute-prepared-statement                    
                  jdbc.clj: 1052  clojure.java.jdbc/db-do-prepared                                      
                  jdbc.clj: 1032  clojure.java.jdbc/db-do-prepared                                      
                  jdbc.clj: 1437  clojure.java.jdbc/execute!/execute-helper                             
                  jdbc.clj: 1439  clojure.java.jdbc/execute!                                            
                  jdbc.clj: 1408  clojure.java.jdbc/execute!                                            
                  jdbc.clj: 1429  clojure.java.jdbc/execute!                                            
                  jdbc.clj: 1408  clojure.java.jdbc/execute!                                        
```

This worked fine in earlier versions and I'm guessing we don't need to
create retained duplicates for the `null` values. This change
basically just skips them. Please let me know if you have a different
solution in mind, need further details or have trouble reproducing
this.

Thanks!