### PR TITLE
Fix server connection listener being collected early

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -161,6 +161,7 @@ public class BasicContext extends AbstractContext {
   protected Registry registry;
   protected Map<String, Class<?>> typeMap;
   protected Charset charset;
+  protected Settings settings;
   private TimeZone timeZone;
   private ZoneId timeZoneId;
   private DateTimeFormat dateFormat;
@@ -169,8 +170,8 @@ public class BasicContext extends AbstractContext {
   private NumberFormat integerFormatter;
   private DecimalFormat decimalFormatter;
   private DecimalFormat currencyFormatter;
-  protected Settings settings;
-  protected ServerConnection serverConnection;
+  private ServerConnection serverConnection;
+  private ServerConnectionListener serverConnectionListener;
   private Map<String, QueryDescription> utilQueries;
 
 
@@ -182,7 +183,8 @@ public class BasicContext extends AbstractContext {
     this.dateFormat = new ISODateFormat();
     this.timeFormat = new ISOTimeFormat();
     this.timestampFormat = new ISOTimestampFormat();
-    this.serverConnection = ServerConnectionFactory.getDefault().connect(this, address, new ServerConnectionListener());
+    this.serverConnectionListener = new ServerConnectionListener();
+    this.serverConnection = ServerConnectionFactory.getDefault().connect(this, address, serverConnectionListener);
     this.utilQueries = new HashMap<>();
   }
 
@@ -208,6 +210,10 @@ public class BasicContext extends AbstractContext {
 
   public ByteBufAllocator getAllocator() {
     return serverConnection.getAllocator();
+  }
+
+  protected ServerConnection getServerConnection() {
+    return serverConnection;
   }
 
   @Override

--- a/driver/src/main/java/com/impossibl/postgres/utils/CacheMap.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/CacheMap.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class CacheMap<K, V> extends LinkedHashMap<K, V> {
+
+  private int maxSize;
+  private Consumer<Map.Entry<K, V>> evictionHandler;
+
+  public CacheMap(int maxSize, float loadFactor, boolean accessOrder) {
+    super(maxSize + 1, loadFactor, accessOrder);
+    this.maxSize = maxSize;
+  }
+
+  public CacheMap(int maxSize, float loadFactor, boolean accessOrder, Consumer<Map.Entry<K, V>> evictionHandler) {
+    super(maxSize + 1, loadFactor, accessOrder);
+    this.maxSize = maxSize;
+    this.evictionHandler = evictionHandler;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+    if (size() > maxSize) {
+      if (evictionHandler != null) {
+        evictionHandler.accept(eldest);
+      }
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/LeakTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/LeakTest.java
@@ -28,7 +28,6 @@
  */
 package com.impossibl.postgres.jdbc;
 
-import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -54,14 +53,12 @@ import static org.junit.Assert.assertTrue;
 @RunWith(JUnit4.class)
 public class LeakTest {
 
-  WeakReference<Connection> connRef;
   Connection conn;
   ResourceLeakDetector.Level savedLevel;
 
   @Before
   public void before() throws Exception {
     conn = TestUtil.openDB();
-    connRef = new WeakReference<>(conn);
     savedLevel = ResourceLeakDetector.getLevel();
     ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
     getHousekeeper().setLogLeakedReferences(false);


### PR DESCRIPTION
There was no hard reference to the `ServerConnection.Listener` created in `BasicContext` whic caused it to be collected early.

This adds a hard reference inside `BasicContext` to keep it alive. This caused a failure in LeakTest due to a mix of self references from anonymous classes and weak references; though the exact cause was mysterious.

The anonymous classes were for caching and all moved into a new `CacheMap` class and weak references were used when back connections were required to fix the LeakTest and simplify code.

Fixes #380, although the issue was more serious than the issue assumes.