### PR TITLE
COPY support

### DIFF
--- a/documentation/src/docs/asciidoc/release-notes/release-notes-0.9.adoc
+++ b/documentation/src/docs/asciidoc/release-notes/release-notes-0.9.adoc
@@ -24,7 +24,7 @@ on GitHub.
 ==== New Features and Improvements
 
 * Batch executions use pipelined requests to increase performance by as much as 70%
-
+* PostgreSQL COPY FROM/TO support
 
 [[release-notes-0.9-pgjdbc-ng-udt]]
 === PGJDBC-NG UDT Generator

--- a/documentation/src/docs/asciidoc/user-guide/extensions.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/extensions.adoc
@@ -70,3 +70,69 @@ JVM, until a `LISTEN` command is issued to the server no notifications will be r
 
 Notification listeners can also be added with a filter on the channel name. This allows individual listeners to
 handle specific notification channels.
+
+[[extensions-copy]]
+=== COPY FROM/TO
+
+{vendorname} provides the capability to bulk load data from an external file, using `COPY <table/spec> FROM STDIN` and
+to bulk save data to an external file, using `COPY <table/spec> TO STDOUT`.
+
+{drivername} supports these commands using two different methods, using <<extensions-copy-std>> or
+<<extensions-copy-ext>>.
+
+[[extensions-copy-std]]
+==== Standard Input & Output
+
+Issuing a relevant command via a `Statement` or `PreparedStatement` will read or write respectively from
+Java's `System.in` or `System.out`.
+
+This method can be useful when redirecting the standard streams from the console or when redirecting the standard
+streams via Java's `System.setIn` or `System.setOut`.
+
+[source,java,options=nowrap]
+.Read from redirected System.in using a Statement
+----
+include::{exdir}/copy/from_system_in.java[]
+----
+<1> Redirect `System.in` to a data stream in `COPY` format
+<2> Issue the `COPY` using a standard `Statement`
+
+[source,java,options=nowrap]
+.Write to redirected System.out using a Statement
+----
+include::{exdir}/copy/to_system_out.java[]
+----
+<1> Redirect `System.out` to a file stream that will receive table data in `COPY` format
+<2> Issue the `COPY` using a standard `Statement`
+
+TIP: Redirecting `System.in` or `System.out` can have unwanted global ramifications. See <<extensions-copy-ext>>
+for a method that does not require global redirection.
+
+[[extensions-copy-ext]]
+==== copyFrom / copyTo
+
+{drivername}'s `PGConnection` provides methods to issue `COPY` commands targeting provided input or output streams.
+Using these methods allows specifying stream without globally redirecting the standard streams like when using
+<<extensions-copy-std>>.
+
+Although, they require access to `PGConnection`, using `copyFrom` & `copyTo` are easy and thread-safe.
+
+[source,java,options=nowrap]
+.Read from a specified stream using copyFrom
+----
+include::{exdir}/copy/from_spec_in.java[]
+----
+<1> Declare a data stream in `COPY` format
+<2> Issue the `COPY` using `PGConnection.copyFrom`
+
+[source,java,options=nowrap]
+.Write to a specified stream using copyTo
+----
+include::{exdir}/copy/to_spec_out.java[]
+----
+<1> Declare a file stream to receive the table data in `COPY` format
+<2> Issue the `COPY` using `PGConnection.copyTo`
+
+WARNING: When using `copyFrom` the SQL command must only be a valid `COPY ... FROM STDIN` command and when using `copyTo`
+the SQL command must only be a valid `COPY ... TO STDOUT`. Any other commands issued will result in an exception begin
+thrown.

--- a/documentation/src/docs/examples/copy/from_spec_in.java
+++ b/documentation/src/docs/examples/copy/from_spec_in.java
@@ -1,0 +1,2 @@
+InputStream tableData = new ByteArrayInputStream("1-1\t1-2\n2-1\t2-2\n3-1\t3-2".getBytes(UTF_8)); // <1>
+connection.unwrap(PGConnection.class).copyFrom("COPY a_table FROM STDIN", tableData); // <2>

--- a/documentation/src/docs/examples/copy/from_system_in.java
+++ b/documentation/src/docs/examples/copy/from_system_in.java
@@ -1,0 +1,4 @@
+System.setIn(new ByteArrayInputStream("1-1\t1-2\n2-1\t2-2\n3-1\t3-2".getBytes(UTF_8))); // <1>
+try (Statement statement = connection.createStatement()) {
+  statement.execute("COPY a_table FROM STDIN"); // <2>
+}

--- a/documentation/src/docs/examples/copy/to_spec_out.java
+++ b/documentation/src/docs/examples/copy/to_spec_out.java
@@ -1,0 +1,2 @@
+OutputStream fileOut = new FileOutputStream("table.txt")); // <1>
+connection.unwrap(PGConnection.class).copyTo("COPY a_table TO STDOUT", fileOut); // <2>

--- a/documentation/src/docs/examples/copy/to_system_out.java
+++ b/documentation/src/docs/examples/copy/to_system_out.java
@@ -1,0 +1,4 @@
+System.setOut(new FileOutputStream("table.txt")); // <1>
+try (Statement statement = connection.createStatement()) {
+  statement.execute("COPY a_table TO STDOUT"); // <2>
+}

--- a/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
@@ -28,6 +28,8 @@
  */
 package com.impossibl.postgres.api.jdbc;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -140,5 +142,9 @@ public interface PGConnection extends Connection {
    * @return Type instance representing the current name to type mapping.
    */
   PGAnyType resolveType(String name) throws SQLException;
+
+
+  void copyIn(String sql, InputStream inputStream) throws SQLException;
+  void copyOut(String sql, OutputStream outputStream) throws SQLException;
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGConnection.java
@@ -144,7 +144,25 @@ public interface PGConnection extends Connection {
   PGAnyType resolveType(String name) throws SQLException;
 
 
-  void copyIn(String sql, InputStream inputStream) throws SQLException;
-  void copyOut(String sql, OutputStream outputStream) throws SQLException;
+  /**
+   * Allows issuing PostgreSQL's COPY command providing an {@link InputStream}
+   * stream to read from, instead of relying on {@link System#in}.
+   *
+   * @param sql SQL text for a valid <code>COPY ... FROM STDIN</code> command.
+   * @param inputStream {@link InputStream} containing data in <code>COPY</code> format.
+   * @throws SQLException If an error occurs during the copy operation or if an alternate command is provided.
+   */
+  void copyFrom(String sql, InputStream inputStream) throws SQLException;
+
+
+  /**
+   * Allows issuing PostgreSQL's COPY command providing an {@link OutputStream}
+   * stream to write to, instead of relying on {@link System#out}.
+   *
+   * @param sql SQL text for a valid <code>COPY ... TO STDOUT</code> command.
+   * @param outputStream {@link OutputStream} to write data in <code>COPY</code> format.
+   * @throws SQLException If an error occurs during the copy operation or if an alternate command is provided.
+   */
+  void copyTo(String sql, OutputStream outputStream) throws SQLException;
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -36,8 +36,8 @@ import com.impossibl.postgres.jdbc.SQLTextTree.ParameterPiece;
 import com.impossibl.postgres.jdbc.SQLTextTree.Processor;
 import com.impossibl.postgres.protocol.FieldFormatRef;
 import com.impossibl.postgres.protocol.Notice;
-import com.impossibl.postgres.protocol.RequestExecutor.CopyInHandler;
-import com.impossibl.postgres.protocol.RequestExecutor.CopyOutHandler;
+import com.impossibl.postgres.protocol.RequestExecutor.CopyFromHandler;
+import com.impossibl.postgres.protocol.RequestExecutor.CopyToHandler;
 import com.impossibl.postgres.protocol.ResultBatch;
 import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.RowData;
@@ -1596,7 +1596,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
   }
 
   @Override
-  public void copyIn(String sql, InputStream inputStream) throws SQLException {
+  public void copyFrom(String sql, InputStream inputStream) throws SQLException {
 
     AtomicReference<Throwable> errorRef = new AtomicReference<>(null);
 
@@ -1604,7 +1604,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
 
       CountDownLatch latch = new CountDownLatch(1);
 
-      getRequestExecutor().copyIn(sql, inputStream, new CopyInHandler() {
+      getRequestExecutor().copyFrom(sql, inputStream, new CopyFromHandler() {
 
         @Override
         public void handleComplete() {
@@ -1643,7 +1643,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
   }
 
   @Override
-  public void copyOut(String sql, OutputStream outputStream) throws SQLException {
+  public void copyTo(String sql, OutputStream outputStream) throws SQLException {
 
     AtomicReference<Throwable> errorRef = new AtomicReference<>(null);
 
@@ -1651,7 +1651,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
 
       CountDownLatch latch = new CountDownLatch(1);
 
-      getRequestExecutor().copyOut(sql, outputStream, new CopyOutHandler() {
+      getRequestExecutor().copyTo(sql, outputStream, new CopyToHandler() {
 
         @Override
         public void handleComplete() {

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
@@ -32,6 +32,8 @@ import com.impossibl.postgres.api.jdbc.PGAnyType;
 import com.impossibl.postgres.api.jdbc.PGConnection;
 import com.impossibl.postgres.api.jdbc.PGNotificationListener;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -148,6 +150,34 @@ public class PGPooledConnectionDelegator implements PGConnection {
     try {
       checkClosed();
       delegator.removeNotificationListener(listener);
+    }
+    catch (SQLException se) {
+      // Nothing to do
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void copyIn(String sql, InputStream inputStream) {
+    try {
+      checkClosed();
+      delegator.copyIn(sql, inputStream);
+    }
+    catch (SQLException se) {
+      // Nothing to do
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void copyOut(String sql, OutputStream outputStream) {
+    try {
+      checkClosed();
+      delegator.copyOut(sql, outputStream);
     }
     catch (SQLException se) {
       // Nothing to do

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPooledConnectionDelegator.java
@@ -160,10 +160,10 @@ public class PGPooledConnectionDelegator implements PGConnection {
    * {@inheritDoc}
    */
   @Override
-  public void copyIn(String sql, InputStream inputStream) {
+  public void copyFrom(String sql, InputStream inputStream) {
     try {
       checkClosed();
-      delegator.copyIn(sql, inputStream);
+      delegator.copyFrom(sql, inputStream);
     }
     catch (SQLException se) {
       // Nothing to do
@@ -174,10 +174,10 @@ public class PGPooledConnectionDelegator implements PGConnection {
    * {@inheritDoc}
    */
   @Override
-  public void copyOut(String sql, OutputStream outputStream) {
+  public void copyTo(String sql, OutputStream outputStream) {
     try {
       checkClosed();
-      delegator.copyOut(sql, outputStream);
+      delegator.copyTo(sql, outputStream);
     }
     catch (SQLException se) {
       // Nothing to do

--- a/driver/src/main/java/com/impossibl/postgres/protocol/CopyFormat.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/CopyFormat.java
@@ -26,75 +26,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-/*-------------------------------------------------------------------------
- *
- * Copyright (c) 2004-2011, PostgreSQL Global Development Group
- *
- *
- *-------------------------------------------------------------------------
- */
 package com.impossibl.postgres.protocol;
 
-import com.impossibl.postgres.system.ServerInfo;
-import com.impossibl.postgres.system.Version;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.SocketAddress;
-import java.util.concurrent.ScheduledExecutorService;
-
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.ChannelFuture;
-
-public interface ServerConnection {
-
-  interface Listener {
-    void parameterStatusChanged(String name, String value);
-    void notificationReceived(int processId, String channelName, String payload);
-    InputStream openStandardInput();
-    OutputStream openStandardOutput();
-    void closed();
-  }
-
-  class KeyData {
-    private int processId;
-    private int secretKey;
-
-    public KeyData(int processId, int secretKey) {
-      this.processId = processId;
-      this.secretKey = secretKey;
-    }
-
-    public int getProcessId() {
-      return processId;
-    }
-
-    public int getSecretKey() {
-      return secretKey;
-    }
-  }
-
-  ServerInfo getServerInfo();
-
-  Version getProtocolVersion();
-
-  KeyData getKeyData();
-
-  ByteBufAllocator getAllocator();
-
-  SocketAddress getRemoteAddress();
-
-  TransactionStatus getTransactionStatus() throws IOException;
-
-  RequestExecutor getRequestExecutor();
-
-  ChannelFuture shutdown();
-
-  ChannelFuture kill();
-
-  boolean isConnected();
-
-  ScheduledExecutorService getIOExecutor();
-
+public enum CopyFormat {
+  Text,
+  Binary;
 }

--- a/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutor.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutor.java
@@ -29,6 +29,8 @@
 package com.impossibl.postgres.protocol;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
@@ -397,5 +399,26 @@ public interface RequestExecutor {
     void handleNotification(int processId, String channelName, String payload) throws IOException;
 
   }
+
+  /*****
+   * Copy In & Out
+   */
+
+  interface CopyInHandler extends SynchronizedHandler {
+
+    void handleComplete() throws IOException;
+
+  }
+
+  void copyIn(String sql, InputStream stream, CopyInHandler handler) throws IOException;
+
+
+  interface CopyOutHandler extends SynchronizedHandler {
+
+    void handleComplete() throws IOException;
+
+  }
+
+  void copyOut(String sql, OutputStream stream, CopyOutHandler handler) throws IOException;
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutor.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutor.java
@@ -401,24 +401,24 @@ public interface RequestExecutor {
   }
 
   /*****
-   * Copy In & Out
+   * Copy In &amp; Out
    */
 
-  interface CopyInHandler extends SynchronizedHandler {
+  interface CopyFromHandler extends SynchronizedHandler {
 
     void handleComplete() throws IOException;
 
   }
 
-  void copyIn(String sql, InputStream stream, CopyInHandler handler) throws IOException;
+  void copyFrom(String sql, InputStream stream, CopyFromHandler handler) throws IOException;
 
 
-  interface CopyOutHandler extends SynchronizedHandler {
+  interface CopyToHandler extends SynchronizedHandler {
 
     void handleComplete() throws IOException;
 
   }
 
-  void copyOut(String sql, OutputStream stream, CopyOutHandler handler) throws IOException;
+  void copyTo(String sql, OutputStream stream, CopyToHandler handler) throws IOException;
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyInRequest.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyInRequest.java
@@ -31,7 +31,7 @@ package com.impossibl.postgres.protocol.v30;
 import com.impossibl.postgres.protocol.CopyFormat;
 import com.impossibl.postgres.protocol.FieldFormat;
 import com.impossibl.postgres.protocol.Notice;
-import com.impossibl.postgres.protocol.RequestExecutor.CopyInHandler;
+import com.impossibl.postgres.protocol.RequestExecutor.CopyFromHandler;
 import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.TransactionStatus;
 import com.impossibl.postgres.protocol.v30.ProtocolHandler.CommandComplete;
@@ -52,10 +52,10 @@ public class CopyInRequest implements ServerRequest {
 
   private String sql;
   private InputStream stream;
-  private CopyInHandler handler;
+  private CopyFromHandler handler;
   private List<Notice> notices;
 
-  CopyInRequest(String sql, InputStream stream, CopyInHandler handler) {
+  CopyInRequest(String sql, InputStream stream, CopyFromHandler handler) {
     this.sql = sql;
     this.stream = stream;
     this.handler = handler;

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyInRequest.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyInRequest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.protocol.v30;
+
+import com.impossibl.postgres.protocol.CopyFormat;
+import com.impossibl.postgres.protocol.FieldFormat;
+import com.impossibl.postgres.protocol.Notice;
+import com.impossibl.postgres.protocol.RequestExecutor.CopyInHandler;
+import com.impossibl.postgres.protocol.ResultField;
+import com.impossibl.postgres.protocol.TransactionStatus;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CommandComplete;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CommandError;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CopyInResponse;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.EmptyQuery;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.ReadyForQuery;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.ReportNotice;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.RowDescription;
+import com.impossibl.postgres.system.NoticeException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CopyInRequest implements ServerRequest {
+
+  private String sql;
+  private InputStream stream;
+  private CopyInHandler handler;
+  private List<Notice> notices;
+
+  CopyInRequest(String sql, InputStream stream, CopyInHandler handler) {
+    this.sql = sql;
+    this.stream = stream;
+    this.handler = handler;
+    this.notices = new ArrayList<>();
+  }
+
+  private class Handler implements CopyInResponse, RowDescription, EmptyQuery, CommandComplete, CommandError, ReportNotice, ReadyForQuery {
+
+    boolean started = false;
+
+    @Override
+    public InputStream copyIn(CopyFormat format, FieldFormat[] columnFormats) {
+      started = true;
+      return stream;
+    }
+
+    @Override
+    public Action rowDescription(ResultField[] fields) {
+      return Action.Resume;
+    }
+
+    @Override
+    public Action emptyQuery() {
+      return Action.Resume;
+    }
+
+    @Override
+    public Action notice(Notice notice) {
+      notices.add(notice);
+      return Action.Resume;
+    }
+
+    @Override
+    public Action commandComplete(String command, Long rowsAffected, Long insertedOid) throws IOException {
+      if (!started) {
+        handler.handleError(new IOException("Command Not Initiated: COPY IN"), notices);
+      }
+      else {
+        handler.handleComplete();
+      }
+      return Action.Resume;
+    }
+
+    @Override
+    public Action error(Notice notice) throws IOException {
+      handler.handleError(new NoticeException(notice), notices);
+      return Action.Resume;
+    }
+
+    @Override
+    public Action readyForQuery(TransactionStatus txnStatus) throws IOException {
+      handler.handleReady(txnStatus);
+      return Action.Complete;
+    }
+
+    @Override
+    public void exception(Throwable cause) throws IOException {
+      handler.handleError(cause, notices);
+    }
+
+  }
+
+  @Override
+  public ProtocolHandler createHandler() {
+    return new Handler();
+  }
+
+  @Override
+  public void execute(ProtocolChannel channel) throws IOException {
+
+    channel
+        .writeQuery(sql)
+        .flush();
+
+  }
+
+}

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyOutRequest.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyOutRequest.java
@@ -31,7 +31,7 @@ package com.impossibl.postgres.protocol.v30;
 import com.impossibl.postgres.protocol.CopyFormat;
 import com.impossibl.postgres.protocol.FieldFormat;
 import com.impossibl.postgres.protocol.Notice;
-import com.impossibl.postgres.protocol.RequestExecutor.CopyOutHandler;
+import com.impossibl.postgres.protocol.RequestExecutor.CopyToHandler;
 import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.TransactionStatus;
 import com.impossibl.postgres.protocol.v30.ProtocolHandler.CommandComplete;
@@ -57,10 +57,10 @@ public class CopyOutRequest implements ServerRequest {
 
   private String sql;
   private OutputStream stream;
-  private CopyOutHandler handler;
+  private CopyToHandler handler;
   private List<Notice> notices;
 
-  CopyOutRequest(String sql, OutputStream stream, CopyOutHandler handler) {
+  CopyOutRequest(String sql, OutputStream stream, CopyToHandler handler) {
     this.sql = sql;
     this.stream = stream;
     this.handler = handler;

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyOutRequest.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/CopyOutRequest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.protocol.v30;
+
+import com.impossibl.postgres.protocol.CopyFormat;
+import com.impossibl.postgres.protocol.FieldFormat;
+import com.impossibl.postgres.protocol.Notice;
+import com.impossibl.postgres.protocol.RequestExecutor.CopyOutHandler;
+import com.impossibl.postgres.protocol.ResultField;
+import com.impossibl.postgres.protocol.TransactionStatus;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CommandComplete;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CommandError;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CopyData;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CopyDone;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CopyFail;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.CopyOutResponse;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.EmptyQuery;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.ReadyForQuery;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.ReportNotice;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.RowDescription;
+import com.impossibl.postgres.system.NoticeException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+
+public class CopyOutRequest implements ServerRequest {
+
+  private String sql;
+  private OutputStream stream;
+  private CopyOutHandler handler;
+  private List<Notice> notices;
+
+  CopyOutRequest(String sql, OutputStream stream, CopyOutHandler handler) {
+    this.sql = sql;
+    this.stream = stream;
+    this.handler = handler;
+    this.notices = new ArrayList<>();
+  }
+
+  private class Handler implements CopyOutResponse, CopyData, CopyDone, CopyFail, RowDescription, EmptyQuery, CommandComplete, CommandError, ReportNotice, ReadyForQuery {
+
+    boolean started = false;
+
+    @Override
+    public ProtocolHandler copyOut(CopyFormat format, FieldFormat[] columnFormats) {
+      started = true;
+      return this;
+    }
+
+    @Override
+    public void copyData(ByteBuf data) throws IOException {
+      data.readBytes(stream, data.readableBytes());
+    }
+
+    @Override
+    public void copyDone() {
+    }
+
+    @Override
+    public void copyFail(String message) {
+      notices.add(new Notice("", "", message));
+    }
+
+    @Override
+    public Action rowDescription(ResultField[] fields) {
+      return Action.Resume;
+    }
+
+    @Override
+    public Action emptyQuery() {
+      return Action.Resume;
+    }
+
+    @Override
+    public Action notice(Notice notice) {
+      notices.add(notice);
+      return Action.Resume;
+    }
+
+    @Override
+    public Action commandComplete(String command, Long rowsAffected, Long insertedOid) throws IOException {
+      if (!started) {
+        handler.handleError(new IOException("Command Not Initiated: COPY OUT"), notices);
+      }
+      else {
+        handler.handleComplete();
+      }
+      return Action.Resume;
+    }
+
+    @Override
+    public Action error(Notice notice) throws IOException {
+      handler.handleError(new NoticeException(notice), notices);
+      return Action.Resume;
+    }
+
+    @Override
+    public Action readyForQuery(TransactionStatus txnStatus) throws IOException {
+      handler.handleReady(txnStatus);
+      return Action.Complete;
+    }
+
+    @Override
+    public void exception(Throwable cause) throws IOException {
+      handler.handleError(cause, notices);
+    }
+
+  }
+
+  @Override
+  public ProtocolHandler createHandler() {
+    return new Handler();
+  }
+
+  @Override
+  public void execute(ProtocolChannel channel) throws IOException {
+
+    channel.writeQuery(sql).flush();
+
+  }
+
+}

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolHandler.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/ProtocolHandler.java
@@ -35,12 +35,15 @@
  */
 package com.impossibl.postgres.protocol.v30;
 
+import com.impossibl.postgres.protocol.CopyFormat;
+import com.impossibl.postgres.protocol.FieldFormat;
 import com.impossibl.postgres.protocol.Notice;
 import com.impossibl.postgres.protocol.ResultField;
 import com.impossibl.postgres.protocol.TransactionStatus;
 import com.impossibl.postgres.protocol.TypeRef;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
@@ -181,6 +184,41 @@ public interface ProtocolHandler {
   interface Notification {
 
     void notification(int processId, String channelName, String payload) throws IOException;
+
+  }
+
+  interface CopyInResponse extends ProtocolHandler {
+
+    InputStream copyIn(CopyFormat format, FieldFormat[] fieldFormats) throws IOException;
+
+  }
+
+  interface CopyOutResponse extends ProtocolHandler {
+
+    ProtocolHandler copyOut(CopyFormat format, FieldFormat[] fieldFormats) throws IOException;
+
+  }
+
+  interface CopyBothResponse extends ProtocolHandler {
+
+    ProtocolHandler copyBoth(CopyFormat format, FieldFormat[] fieldFormats) throws IOException;
+
+  }
+
+  interface CopyData extends ProtocolHandler {
+
+    void copyData(ByteBuf data) throws IOException;
+
+  }
+
+  interface CopyDone extends ProtocolHandler {
+
+    void copyDone() throws IOException;
+  }
+
+  interface CopyFail extends ProtocolHandler {
+
+    void copyFail(String message) throws IOException;
 
   }
 

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnection.java
@@ -50,6 +50,7 @@ import static com.impossibl.postgres.system.SystemSettings.SQL_TRACE_FILE;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -250,6 +251,22 @@ class ServerConnection implements com.impossibl.postgres.protocol.ServerConnecti
       sqlTrace.query("CALL: " + functionId);
     }
     submit(new FunctionCallRequest(functionId, parameterFormats, parameterBuffers, handler));
+  }
+
+  @Override
+  public void copyIn(String sql, InputStream stream, CopyInHandler handler) throws IOException {
+    if (sqlTrace != null) {
+      sqlTrace.query("COPY-IN: " + sql);
+    }
+    submit(new CopyInRequest(sql, stream, handler));
+  }
+
+  @Override
+  public void copyOut(String sql, OutputStream stream, CopyOutHandler handler) throws IOException {
+    if (sqlTrace != null) {
+      sqlTrace.query("COPY-OUT: " + sql);
+    }
+    submit(new CopyOutRequest(sql, stream, handler));
   }
 
   @Override

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnection.java
@@ -254,7 +254,7 @@ class ServerConnection implements com.impossibl.postgres.protocol.ServerConnecti
   }
 
   @Override
-  public void copyIn(String sql, InputStream stream, CopyInHandler handler) throws IOException {
+  public void copyFrom(String sql, InputStream stream, CopyFromHandler handler) throws IOException {
     if (sqlTrace != null) {
       sqlTrace.query("COPY-IN: " + sql);
     }
@@ -262,7 +262,7 @@ class ServerConnection implements com.impossibl.postgres.protocol.ServerConnecti
   }
 
   @Override
-  public void copyOut(String sql, OutputStream stream, CopyOutHandler handler) throws IOException {
+  public void copyTo(String sql, OutputStream stream, CopyToHandler handler) throws IOException {
     if (sqlTrace != null) {
       sqlTrace.query("COPY-OUT: " + sql);
     }

--- a/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -69,6 +69,8 @@ import static com.impossibl.postgres.system.SystemSettings.STANDARD_CONFORMING_S
 import static com.impossibl.postgres.utils.guava.Strings.nullToEmpty;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.SocketAddress;
 import java.nio.charset.Charset;
 import java.text.DecimalFormat;
@@ -128,6 +130,16 @@ public class BasicContext extends AbstractContext {
     }
 
     @Override
+    public InputStream openStandardInput() {
+      return System.in;
+    }
+
+    @Override
+    public OutputStream openStandardOutput() {
+      return System.out;
+    }
+
+    @Override
     public void closed() {
       connectionClosed();
     }
@@ -173,7 +185,6 @@ public class BasicContext extends AbstractContext {
   private ServerConnection serverConnection;
   private ServerConnectionListener serverConnectionListener;
   private Map<String, QueryDescription> utilQueries;
-
 
   public BasicContext(SocketAddress address, Settings settings) throws IOException {
     this.typeMap = new HashMap<>();

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/CopyTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/CopyTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.jdbc;
+
+import com.impossibl.postgres.api.jdbc.PGConnection;
+
+import static com.impossibl.postgres.jdbc.util.Asserts.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CopyTest {
+
+  private Connection con;
+
+  @Before
+  public void setup() throws SQLException {
+    con = TestUtil.openDB();
+    TestUtil.createTable(con, "copytbl", "name text, value int4");
+  }
+
+  @After
+  public void teardown() throws SQLException {
+    TestUtil.dropTable(con, "copytbl");
+    TestUtil.closeDB(con);
+  }
+
+  @Test
+  public void testCopyFromSystemIn() throws SQLException {
+
+    System.setIn(new ByteArrayInputStream("ab\t1\nbc\t20\ncd\t300".getBytes(UTF_8)));
+
+    try (Statement statement = con.createStatement()) {
+
+      statement.executeUpdate("COPY copytbl(name, value) FROM STDIN");
+
+      try (ResultSet rs = statement.executeQuery("SELECT * FROM copytbl")) {
+
+        assertThat(rs.next(), equalTo(true));
+        assertThat(rs.getString(1), equalTo("ab"));
+        assertThat(rs.getInt(2), equalTo(1));
+
+        assertThat(rs.next(), equalTo(true));
+        assertThat(rs.getString(1), equalTo("bc"));
+        assertThat(rs.getInt(2), equalTo(20));
+
+        assertThat(rs.next(), equalTo(true));
+        assertThat(rs.getString(1), equalTo("cd"));
+        assertThat(rs.getInt(2), equalTo(300));
+
+      }
+    }
+
+  }
+
+  @Test
+  public void testCopyFromSpecifiedIn() throws SQLException {
+
+    InputStream in = new ByteArrayInputStream("ab\t1\nbc\t20\ncd\t300".getBytes(UTF_8));
+    con.unwrap(PGConnection.class).copyIn("COPY copytbl FROM STDIN", in);
+
+    try (Statement statement = con.createStatement()) {
+      try (ResultSet rs = statement.executeQuery("SELECT * FROM copytbl")) {
+
+        assertThat(rs.next(), equalTo(true));
+        assertThat(rs.getString(1), equalTo("ab"));
+        assertThat(rs.getInt(2), equalTo(1));
+
+        assertThat(rs.next(), equalTo(true));
+        assertThat(rs.getString(1), equalTo("bc"));
+        assertThat(rs.getInt(2), equalTo(20));
+
+        assertThat(rs.next(), equalTo(true));
+        assertThat(rs.getString(1), equalTo("cd"));
+        assertThat(rs.getInt(2), equalTo(300));
+      }
+    }
+
+  }
+
+  @Test
+  public void testCopyFromSystemOut() throws SQLException, IOException {
+
+    try (Statement statement = con.createStatement()) {
+
+      statement.executeUpdate("INSERT INTO copytbl VALUES ('ab', 1)");
+      statement.executeUpdate("INSERT INTO copytbl VALUES ('bc', 20)");
+      statement.executeUpdate("INSERT INTO copytbl VALUES ('cd', 300)");
+
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      System.setOut(new PrintStream(os));
+
+      statement.executeUpdate("COPY copytbl(name, value) TO STDOUT ");
+
+      os.flush();
+
+      assertThat(os.toByteArray(), equalTo("ab\t1\nbc\t20\ncd\t300\n".getBytes(UTF_8)));
+    }
+
+  }
+
+  @Test
+  public void testCopyFromSpecifiedOut() throws SQLException, IOException {
+
+    try (Statement statement = con.createStatement()) {
+
+      statement.executeUpdate("INSERT INTO copytbl VALUES ('ab', 1)");
+      statement.executeUpdate("INSERT INTO copytbl VALUES ('bc', 20)");
+      statement.executeUpdate("INSERT INTO copytbl VALUES ('cd', 300)");
+
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+      con.unwrap(PGConnection.class).copyOut("COPY copytbl TO STDOUT", os);
+
+      os.flush();
+
+      assertThat(os.toByteArray(), equalTo("ab\t1\nbc\t20\ncd\t300\n".getBytes(UTF_8)));
+    }
+
+  }
+
+  @Test
+  public void testCopyInInvalid() {
+
+    assertThrows(SQLException.class, () -> {
+
+      ByteArrayInputStream is = new ByteArrayInputStream(new byte[0]);
+
+      con.unwrap(PGConnection.class).copyIn("SELECT * FROM copytbl", is);
+    });
+  }
+
+  @Test
+  public void testCopyOutInvalid() {
+
+    assertThrows(SQLException.class, () -> {
+
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+      con.unwrap(PGConnection.class).copyOut("SELECT * FROM copytbl", os);
+    });
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/CopyTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/CopyTest.java
@@ -99,7 +99,7 @@ public class CopyTest {
   public void testCopyFromSpecifiedIn() throws SQLException {
 
     InputStream in = new ByteArrayInputStream("ab\t1\nbc\t20\ncd\t300".getBytes(UTF_8));
-    con.unwrap(PGConnection.class).copyIn("COPY copytbl FROM STDIN", in);
+    con.unwrap(PGConnection.class).copyFrom("COPY copytbl FROM STDIN", in);
 
     try (Statement statement = con.createStatement()) {
       try (ResultSet rs = statement.executeQuery("SELECT * FROM copytbl")) {
@@ -152,7 +152,7 @@ public class CopyTest {
 
       ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-      con.unwrap(PGConnection.class).copyOut("COPY copytbl TO STDOUT", os);
+      con.unwrap(PGConnection.class).copyTo("COPY copytbl TO STDOUT", os);
 
       os.flush();
 
@@ -168,7 +168,7 @@ public class CopyTest {
 
       ByteArrayInputStream is = new ByteArrayInputStream(new byte[0]);
 
-      con.unwrap(PGConnection.class).copyIn("SELECT * FROM copytbl", is);
+      con.unwrap(PGConnection.class).copyFrom("SELECT * FROM copytbl", is);
     });
   }
 
@@ -179,7 +179,7 @@ public class CopyTest {
 
       ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-      con.unwrap(PGConnection.class).copyOut("SELECT * FROM copytbl", os);
+      con.unwrap(PGConnection.class).copyTo("SELECT * FROM copytbl", os);
     });
   }
 


### PR DESCRIPTION
This adds basic PostgreSQL `COPY` support.

Currently there are two methods two invoke `COPY`...

The first method reads from `System.in` or writes to `System.out`, as the commands themselves reference.   Unfortunately this is not thread safe because to redirect `System.in` or `System.out` you need to call `System.setIn` or `System.setOut` accordingly; these have global ramifications.

The alternative, thread safe, method is to use the new `PGConnection.copyIn` and `PGConnection.copyOut` methods which accept InputStream and OutputStream and does not use system globals.

~~These are _basic_ methods that access the copy functionality.  Before this PR is finished an implementation of an "encoding" input stream and "decoding" output stream will be added that handles translating Java objects to/from the correct format for `COPY`.~~ I've scrapped ideas for encoding and decoding streams right now. As I was implementing it, it dawned on my that `TRUNCATE <table>` takes nearly the same path for data out and the new batching provides a performant method for getting Java data in. Encoding and Decoding streams can be implemented on top of the current functionality and even outside the driver, if needed.