### PR TITLE
JUnit 5 based declarative JDBC test framework

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -34,6 +34,7 @@ import com.impossibl.postgres.api.jdbc.PGNotificationListener;
 import com.impossibl.postgres.jdbc.Housekeeper.CleanupRunnable;
 import com.impossibl.postgres.jdbc.SQLTextTree.ParameterPiece;
 import com.impossibl.postgres.jdbc.SQLTextTree.Processor;
+import com.impossibl.postgres.protocol.FieldFormat;
 import com.impossibl.postgres.protocol.FieldFormatRef;
 import com.impossibl.postgres.protocol.ResultBatch;
 import com.impossibl.postgres.protocol.ResultField;
@@ -1648,10 +1649,12 @@ class StatementDescription {
 
   Type[] parameterTypes;
   ResultField[] resultFields;
+  FieldFormat[] resultFieldFormats;
 
   StatementDescription(Type[] parameterTypes, ResultField[] resultFields) {
     this.parameterTypes = parameterTypes;
     this.resultFields = resultFields;
+    this.resultFieldFormats = Arrays.stream(resultFields).map(ResultField::getFormat).toArray(FieldFormat[]::new);
   }
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -88,6 +88,7 @@ import static com.impossibl.postgres.jdbc.SQLTextUtils.prependCursorDeclaration;
 import static com.impossibl.postgres.protocol.TransactionStatus.Idle;
 import static com.impossibl.postgres.system.Empty.EMPTY_TYPES;
 import static com.impossibl.postgres.system.SystemSettings.DATABASE_URL;
+import static com.impossibl.postgres.system.SystemSettings.FIELD_FORMAT_PREF;
 import static com.impossibl.postgres.system.SystemSettings.PROTO;
 import static com.impossibl.postgres.system.SystemSettings.SERVER;
 import static com.impossibl.postgres.system.SystemSettings.STANDARD_CONFORMING_STRINGS;
@@ -1022,7 +1023,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
 
       cursorName = "cursor" + getNextStatementName();
 
-      if (!prependCursorDeclaration(sqlText, cursorName, resultSetType, resultSetHoldability, autoCommit)) {
+      if (!prependCursorDeclaration(sqlText, cursorName, resultSetType, resultSetHoldability, autoCommit, getSetting(FIELD_FORMAT_PREF))) {
 
         cursorName = null;
 
@@ -1136,7 +1137,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
 
       cursorName = "cursor" + getNextStatementName();
 
-      if (!prependCursorDeclaration(sqlText, cursorName, resultSetType, resultSetHoldability, autoCommit)) {
+      if (!prependCursorDeclaration(sqlText, cursorName, resultSetType, resultSetHoldability, autoCommit, getSetting(FIELD_FORMAT_PREF))) {
 
         cursorName = null;
 

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -250,7 +250,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
         return handler;
       });
 
-      return new StatementDescription(result.getDescribedParameterTypes(connection), result.getDescribedResultFields());
+      return new StatementDescription(result.getDescribedParameterTypes(connection), result.getDescribedResultFields(connection));
     });
 
     if (cachedDescription != null) {
@@ -294,16 +294,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 
         warningChain = chainWarnings(warningChain, prep);
 
-        // Results are always described as "Text"... update them to our preferred format.
-        ResultField[] describedResultFields = prep.getDescribedResultFields().clone();
-        for (ResultField describedResultField : describedResultFields) {
-          Type type = connection.getRegistry().resolve(describedResultField.getTypeRef());
-          if (type != null) {
-            describedResultField.setFormat(type.getResultFormat());
-          }
-        }
-
-        return new PreparedStatementDescription(name, prep.getDescribedParameterTypes(connection), describedResultFields);
+        return new PreparedStatementDescription(name, prep.getDescribedParameterTypes(connection), prep.getDescribedResultFields(connection));
       });
 
       if (cachedStatement != null) {
@@ -471,7 +462,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 
             parameterTypes = prep.getDescribedParameterTypes(connection);
             lastParameterTypes = parameterTypes;
-            lastResultFields = prep.getDescribedResultFields();
+            lastResultFields = prep.getDescribedResultFields(connection);
           }
 
           FieldFormat[] parameterFormats = batchParameterFormats.get(batchIdx);

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -330,7 +330,8 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
     }
 
     if (cursorName != null) {
-      res = super.executeDirect("FETCH ABSOLUTE 0 FROM " + cursorName, null, null, resultFields);
+
+      res = super.executeDirect("FETCH ABSOLUTE 0 FROM " + cursorName, null, null, null);
     }
 
     if (wantsGeneratedKeys) {

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -65,7 +65,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -93,7 +92,6 @@ import java.util.List;
 import static java.lang.Integer.toHexString;
 import static java.lang.Long.min;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import io.netty.buffer.ByteBuf;
@@ -652,8 +650,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 
   @Override
   public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-
-    set(parameterIndex, x, JDBCType.BINARY);
+    set(parameterIndex, x, JDBCType.LONGVARBINARY);
   }
 
   @Override
@@ -667,7 +664,7 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
       throw new SQLException("Invalid length");
     }
 
-    set(parameterIndex, x, (long) length, JDBCType.BINARY);
+    set(parameterIndex, x, (long) length, JDBCType.LONGVARBINARY);
   }
 
   @Override
@@ -681,58 +678,95 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
       throw new SQLException("Invalid length");
     }
 
-    set(parameterIndex, x, length, JDBCType.BINARY);
+    set(parameterIndex, x, length, JDBCType.LONGVARBINARY);
   }
 
   @Override
   @Deprecated
   public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
 
-    InputStreamReader reader = new InputStreamReader(x, UTF_8);
+    if (length < 0) {
+      throw new SQLException("Invalid length");
+    }
 
-    setCharacterStream(parameterIndex, reader, length);
+    if (x == null  && length != 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    set(parameterIndex, x, (long) length, JDBCType.LONGNVARCHAR);
   }
 
   @Override
   public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-    setAsciiStream(parameterIndex, x, (long) -1);
+
+    Reader reader = x != null ? new InputStreamReader(x, US_ASCII) : null;
+
+    set(parameterIndex, reader, JDBCType.LONGNVARCHAR);
   }
 
   @Override
   public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-    setAsciiStream(parameterIndex, x, (long) length);
+
+    if (length < 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    if (x == null  && length != 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    Reader reader = x != null ? new InputStreamReader(x, US_ASCII) : null;
+
+    set(parameterIndex, reader, (long) length, JDBCType.LONGNVARCHAR);
   }
 
   @Override
   public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
 
-    InputStreamReader reader = new InputStreamReader(x, US_ASCII);
+    if (length < 0) {
+      throw new SQLException("Invalid length");
+    }
 
-    setCharacterStream(parameterIndex, reader, length);
+    if (x == null  && length != 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    Reader reader = x != null ? new InputStreamReader(x, US_ASCII) : null;
+
+    set(parameterIndex, reader, length, JDBCType.LONGNVARCHAR);
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-    setCharacterStream(parameterIndex, reader, (long) -1);
+    set(parameterIndex, reader, JDBCType.LONGNVARCHAR);
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
-    setCharacterStream(parameterIndex, reader, (long) length);
+
+    if (length < 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    if (reader == null  && length != 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    set(parameterIndex, reader, (long) length, JDBCType.LONGNVARCHAR);
   }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
 
-    StringWriter writer = new StringWriter();
-    try {
-      CharStreams.copy(reader, writer);
-    }
-    catch (IOException e) {
-      throw new SQLException(e);
+    if (length < 0) {
+      throw new SQLException("Invalid length");
     }
 
-    set(parameterIndex, writer.toString(), JDBCType.VARCHAR);
+    if (reader == null  && length != 0) {
+      throw new SQLException("Invalid length");
+    }
+
+    set(parameterIndex, reader, JDBCType.VARCHAR);
   }
 
   @Override

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGSimpleStatement.java
@@ -37,6 +37,7 @@ import static com.impossibl.postgres.jdbc.Exceptions.NO_RESULT_COUNT_AVAILABLE;
 import static com.impossibl.postgres.jdbc.Exceptions.NO_RESULT_SET_AVAILABLE;
 import static com.impossibl.postgres.jdbc.SQLTextUtils.appendReturningClause;
 import static com.impossibl.postgres.jdbc.SQLTextUtils.prependCursorDeclaration;
+import static com.impossibl.postgres.system.SystemSettings.FIELD_FORMAT_PREF;
 
 import java.sql.BatchUpdateException;
 import java.sql.ResultSet;
@@ -67,7 +68,7 @@ class PGSimpleStatement extends PGStatement {
 
       cursorName = "cursor" + name;
 
-      if (!prependCursorDeclaration(sqlText, cursorName, resultSetType, resultSetHoldability, connection.autoCommit)) {
+      if (!prependCursorDeclaration(sqlText, cursorName, resultSetType, resultSetHoldability, connection.autoCommit, connection.getSetting(FIELD_FORMAT_PREF))) {
 
         cursorName = name = null;
       }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/SQLTextUtils.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/SQLTextUtils.java
@@ -30,6 +30,7 @@ package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.jdbc.SQLTextTree.GrammarPiece;
 import com.impossibl.postgres.jdbc.SQLTextTree.StatementNode;
+import com.impossibl.postgres.protocol.FieldFormat;
 
 import static com.impossibl.postgres.system.Identifier.quoteIfNeeded;
 
@@ -239,7 +240,7 @@ class SQLTextUtils {
     return true;
   }
 
-  public static boolean prependCursorDeclaration(SQLText sqlText, String cursorName, int resultSetType, int resultSetHoldability, boolean autoCommit) {
+  public static boolean prependCursorDeclaration(SQLText sqlText, String cursorName, int resultSetType, int resultSetHoldability, boolean autoCommit, FieldFormat fieldFormat) {
 
     if (sqlText.getStatementCount() > 1) {
       return false;
@@ -249,7 +250,11 @@ class SQLTextUtils {
       return false;
     }
 
-    String preCursor = "DECLARE " + cursorName + " BINARY ";
+    String preCursor = "DECLARE " + cursorName + " ";
+
+    if (fieldFormat != FieldFormat.Text) {
+      preCursor += "BINARY ";
+    }
 
     if (resultSetType != ResultSet.TYPE_FORWARD_ONLY) {
       preCursor += "SCROLL ";

--- a/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -550,7 +550,7 @@ public class BasicContext extends AbstractContext {
 
     handler.await(INTERNAL_QUERY_TIMEOUT, MILLISECONDS);
 
-    QueryDescription desc = new QueryDescription(name, sql, handler.getDescribedParameterTypes(this), handler.getDescribedResultFields());
+    QueryDescription desc = new QueryDescription(name, sql, handler.getDescribedParameterTypes(this), handler.getDescribedResultFields(this));
     utilQueries.put(name, desc);
   }
 
@@ -570,7 +570,7 @@ public class BasicContext extends AbstractContext {
 
     handler.await(INTERNAL_QUERY_TIMEOUT, MILLISECONDS);
 
-    return new QueryDescription(null, queryTxt, handler.getDescribedParameterTypes(this), handler.getDescribedResultFields());
+    return new QueryDescription(null, queryTxt, handler.getDescribedParameterTypes(this), handler.getDescribedResultFields(this));
   }
 
   public void query(String queryTxt, long timeout) throws IOException {

--- a/driver/src/main/java/com/impossibl/postgres/system/SystemSettings.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/SystemSettings.java
@@ -123,6 +123,32 @@ public class SystemSettings {
   )
   public static final Setting<Integer> MONEY_FRACTIONAL_DIGITS = Setting.declare();
 
+  public enum QueryMode {
+
+    @Setting.Description(
+        "Allow use of simple query protocol when executing parameter-less, non-portaled queries."
+    )
+    AllowSimple,
+
+    @Setting.Description(
+        "Require use of extended query protocol even when executing parameter-less, non-portaled queries."
+    )
+    RequireExtended
+
+  }
+
+  @Setting.Info(
+      desc =
+          "Query execution mode.\n\n" +
+              "Determines what protocols are used to execute queries.\n\n" +
+              "<code>require-extended</code> mode can be used to ensure all queries are executed respecting the " +
+              "<code>field.format</code> preference.",
+      def = "allow-simple",
+      name = "query-mode",
+      group = "system"
+  )
+  public static final Setting<QueryMode> QUERY_MODE = Setting.declare();
+
   @Setting.Info(
       name = "ssl.mode",
       group = "system",

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Bytes.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Bytes.java
@@ -153,11 +153,12 @@ public class Bytes extends SimpleProcProvider {
     protected void encodeValue(Context context, Type type, Object val, Object sourceContext, ByteBuf buffer) throws IOException {
 
       Long specifiedLength = (Long) sourceContext;
-      byte[] value = Bytes.coerceInput(type, val, specifiedLength);
-
-      if (specifiedLength != null && specifiedLength != value.length) {
-        throw new IOException("Invalid binary length");
+      Integer maxLength = context.getSetting(FIELD_LENGTH_MAX);
+      if (specifiedLength != null && maxLength != null && specifiedLength > maxLength) {
+        throw new IOException("Binary data too long");
       }
+
+      byte[] value = Bytes.coerceInput(type, val, specifiedLength);
 
       buffer.writeBytes(value);
     }
@@ -238,11 +239,12 @@ public class Bytes extends SimpleProcProvider {
     protected void encodeValue(Context context, Type type, Object val, Object sourceContext, StringBuilder buffer) throws IOException {
 
       Long specifiedLength = (Long) sourceContext;
-      byte[] value = coerceInput(type, val, specifiedLength);
-
-      if (specifiedLength != null && specifiedLength != value.length) {
-        throw new IOException("Mismatch in length of binary arguments");
+      Integer maxLength = context.getSetting(FIELD_LENGTH_MAX);
+      if (specifiedLength != null && maxLength != null && specifiedLength > maxLength) {
+        throw new IOException("Binary data too long");
       }
+
+      byte[] value = coerceInput(type, val, specifiedLength);
 
       buffer.append("\\x");
 

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/XMLs.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/XMLs.java
@@ -51,10 +51,14 @@ public class XMLs extends SimpleProcProvider {
     super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "xml_");
   }
 
-  static byte[] convertInput(Type type, Object value) throws ConversionException {
+  static byte[] convertInput(Context context, Type type, Object value) throws ConversionException {
 
     if (value instanceof byte[]) {
       return (byte[]) value;
+    }
+
+    if (value instanceof String) {
+      return ((String) value).getBytes(context.getCharset());
     }
 
     if (value instanceof PGSQLXML) {
@@ -101,7 +105,7 @@ public class XMLs extends SimpleProcProvider {
     @Override
     protected void encodeValue(Context context, Type type, Object value, Object sourceContext, ByteBuf buffer) throws IOException {
 
-      value = convertInput(type, value);
+      value = convertInput(context, type, value);
       if (value == null) {
         value = new byte[0];
       }
@@ -132,11 +136,14 @@ public class XMLs extends SimpleProcProvider {
     @Override
     protected void encodeValue(Context context, Type type, Object value, Object sourceContext, StringBuilder buffer) throws IOException {
 
-      if (value instanceof byte[]) {
-        value = new String((byte[]) value, context.getCharset());
+      byte[] bytes = convertInput(context, type, value);
+      if (bytes == null) {
+        bytes = new byte[0];
       }
 
-      super.encodeValue(context, type, value, sourceContext, buffer);
+      String text = new String(bytes, context.getCharset());
+
+      super.encodeValue(context, type, text, sourceContext, buffer);
     }
 
   }

--- a/driver/src/main/java/com/impossibl/postgres/utils/guava/ByteStreams.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/guava/ByteStreams.java
@@ -47,6 +47,7 @@ package com.impossibl.postgres.utils.guava;
 import static com.impossibl.postgres.utils.guava.Preconditions.checkArgument;
 import static com.impossibl.postgres.utils.guava.Preconditions.checkNotNull;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.FilterInputStream;
@@ -68,6 +69,21 @@ public final class ByteStreams {
   private static final int BUF_SIZE = 0x1000; // 4K
 
   private ByteStreams() {
+  }
+
+  /**
+   * Duplicates all bytes from the given input stream.
+   * Does not close stream.
+   *
+   * @param stream the input stream to duplicate
+   * @return the new instance of input stream containing duplicate data
+   * @throws IOException if an I/O error occurs
+   */
+  public static InputStream duplicate(InputStream stream) throws IOException {
+    checkNotNull(stream);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    copy(stream, out);
+    return new ByteArrayInputStream(out.toByteArray());
   }
 
   /**

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/XmlTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/XmlTest.java
@@ -106,15 +106,18 @@ public class XmlTest {
     TestUtil.closeDB(_conn);
   }
 
-//TODO: reconcile against mainstream driver
-//  public void testUpdateRS() throws SQLException {
-//    Statement stmt = _conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
-//    ResultSet rs = stmt.executeQuery("SELECT id, val FROM xmltest");
-//    assertTrue(rs.next());
-//    SQLXML xml = rs.getSQLXML(2);
-//    rs.updateSQLXML(2, xml);
-//    rs.updateRow();
-//  }
+  @Test
+  public void testUpdateRS() throws SQLException {
+    _conn.setAutoCommit(false);
+    Statement stmt = _conn.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
+    ResultSet rs = stmt.executeQuery("SELECT id, val FROM xmltest");
+    assertTrue(rs.next());
+    SQLXML xml = rs.getSQLXML(2);
+    rs.updateSQLXML(2, xml);
+    rs.updateRow();
+    _conn.commit();
+  }
+
   @Test
   public void testDOMParse() throws SQLException {
     Statement stmt = _conn.createStatement();

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/util/BrokenReader.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/util/BrokenReader.java
@@ -36,27 +36,30 @@
 package com.impossibl.postgres.jdbc.util;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 
-public class BrokenInputStream extends InputStream {
+public class BrokenReader extends Reader {
 
-  private InputStream stream;
+  private Reader reader;
   private long numRead;
   private long breakOn;
 
-  public BrokenInputStream(InputStream stream, long breakOn) {
-    this.stream = stream;
+  public BrokenReader(Reader reader, long breakOn) {
+    this.reader = reader;
     this.breakOn = breakOn;
     this.numRead = 0;
   }
 
   @Override
-  public int read() throws IOException {
+  public int read(char[] cbuf, int off, int len) throws IOException {
     if (numRead++ > breakOn) {
       throw new IOException("I was told to break on " + breakOn);
     }
+    return reader.read(cbuf, off, 1);
+  }
 
-    return stream.read();
+  @Override
+  public void close() {
   }
 
 }

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/ConnectionProperty.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/ConnectionProperty.java
@@ -1,0 +1,15 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface ConnectionProperty {
+  String name();
+  String value();
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/ConnectionSetting.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/ConnectionSetting.java
@@ -1,0 +1,16 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface ConnectionSetting {
+  String name();
+  String value();
+  String assignment() default "TO";
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/DBTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/DBTest.java
@@ -1,0 +1,32 @@
+package com.impossibl.postgres.test.annotations;
+
+
+import com.impossibl.postgres.test.extensions.DBProvider;
+import com.impossibl.postgres.test.extensions.ExtensionInstalledCondition;
+import com.impossibl.postgres.test.extensions.RandomProvider;
+import com.impossibl.postgres.test.extensions.SchemaManager;
+import com.impossibl.postgres.test.extensions.UpdateManager;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(DBProvider.class)
+@ExtendWith(SchemaManager.class)
+@ExtendWith(UpdateManager.class)
+@ExtendWith(RandomProvider.class)
+@ExtendWith(ExtensionInstalledCondition.class)
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface DBTest {
+
+  String host() default "localhost";
+  String db() default "test";
+  String user() default "test";
+  String password() default "test";
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Execute.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Execute.java
@@ -1,0 +1,27 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Repeatable(Execute.List.class)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Execute {
+
+  String sql();
+
+
+  @Target({TYPE, METHOD})
+  @Retention(RUNTIME)
+  @interface List {
+
+    Execute[] value();
+
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/ExtensionInstalled.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/ExtensionInstalled.java
@@ -1,0 +1,16 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface ExtensionInstalled {
+
+  String value();
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Insert.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Insert.java
@@ -1,0 +1,30 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Repeatable(Insert.List.class)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Insert {
+
+  String table();
+  String[] columns() default {};
+  String type() default "";
+  String[] values();
+
+
+  @Target({TYPE, METHOD})
+  @Retention(RUNTIME)
+  @interface List {
+
+    Insert[] value();
+
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Prepare.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Prepare.java
@@ -1,0 +1,33 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.sql.ResultSet;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Provides SQL query text for a {@link ResultSet} or {@link java.sql.PreparedStatement}
+ * test parameter
+ */
+@Repeatable(Prepare.List.class)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Prepare {
+
+  String name();
+  String sql();
+  String[] returning() default {};
+
+  @Target({TYPE, METHOD})
+  @Retention(RUNTIME)
+  @interface List {
+
+    Prepare[] value();
+
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Query.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Query.java
@@ -1,0 +1,20 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.sql.ResultSet;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Provides SQL query text for a {@link ResultSet} or {@link java.sql.PreparedStatement}
+ * test parameter.
+ */
+@Target({TYPE, METHOD, PARAMETER})
+@Retention(RUNTIME)
+public @interface Query {
+  String value() default "";
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Random.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Random.java
@@ -1,0 +1,16 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface Random {
+  int size() default 20;
+  int origin() default 0;
+  int bound() default Integer.MAX_VALUE;
+  boolean codepoints() default false;
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Schema.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Schema.java
@@ -1,0 +1,24 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Repeatable(Schema.List.class)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Schema {
+
+  String value();
+
+  @Target({TYPE, METHOD})
+  @Retention(RUNTIME)
+  @interface List {
+    Schema[] value();
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Table.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Table.java
@@ -1,0 +1,25 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Repeatable(Table.List.class)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Table {
+
+  String name();
+  String[] columns();
+
+  @Target({TYPE, METHOD})
+  @Retention(RUNTIME)
+  @interface List {
+    Table[] value();
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/annotations/Type.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/annotations/Type.java
@@ -1,0 +1,25 @@
+package com.impossibl.postgres.test.annotations;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Repeatable(Type.List.class)
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+public @interface Type {
+
+  String name();
+  String[] attributes();
+
+  @Target({TYPE, METHOD})
+  @Retention(RUNTIME)
+  @interface List {
+    Type[] value();
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/extensions/DBProvider.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/extensions/DBProvider.java
@@ -1,0 +1,360 @@
+package com.impossibl.postgres.test.extensions;
+
+import com.impossibl.postgres.test.annotations.ConnectionProperty;
+import com.impossibl.postgres.test.annotations.ConnectionSetting;
+import com.impossibl.postgres.test.annotations.DBTest;
+import com.impossibl.postgres.test.annotations.Prepare;
+import com.impossibl.postgres.test.annotations.Query;
+
+import java.lang.reflect.AnnotatedElement;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+
+public class DBProvider implements ParameterResolver, BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+  private static final Namespace NS = Namespace.create("db");
+  private static final String PREPARED_STATEMENT_KEY_PREFIX = "prepared-statement@";
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    prepareAll(context);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext paramCtx, ExtensionContext extCtx) throws ParameterResolutionException {
+
+    Class<?> paramType = paramCtx.getParameter().getType();
+
+    return (paramType == Connection.class) ||
+        (paramType == Statement.class) ||
+        (paramType == ResultSet.class && paramCtx.isAnnotated(Query.class)) ||
+        (paramType == PreparedStatement.class && paramCtx.isAnnotated(Query.class)) ||
+        (paramType == PreparedStatement.class && isPrepared(extCtx, paramCtx.getParameter().getName()));
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext paramCtx, ExtensionContext extCtx) throws ParameterResolutionException {
+
+    Class<?> paramType = paramCtx.getParameter().getType();
+
+    if (paramType == Connection.class) {
+      try {
+        return open(extCtx);
+      }
+      catch (Exception e) {
+        throw new ParameterResolutionException("Error resolving parameter", e);
+      }
+    }
+
+    if (paramType == Statement.class) {
+      return statement(extCtx);
+    }
+
+    Optional<Query> query = paramCtx.findAnnotation(Query.class);
+
+    if (paramType == PreparedStatement.class) {
+      if (query.isPresent()) {
+        // Try lookup via name (alternative to parameter names)
+        PreparedStatement ps = getPrepared(extCtx, query.get().value());
+        if (ps == null) {
+          // Prepare text provided in @Query
+          ps = prepare(extCtx, query.get().value(), new String[0]);
+        }
+        return ps;
+      }
+      else {
+        // Lookup via parameter name
+        PreparedStatement ps = getPrepared(extCtx, paramCtx.getParameter().getName());
+        if (ps == null) {
+          throw new ParameterResolutionException("No @Query annotation or @Prepare annotation matching parameter: " + paramCtx.getParameter().getName());
+        }
+        return ps;
+      }
+    }
+
+    if (paramType == ResultSet.class) {
+      if (query.isPresent()) {
+        // Try lookup via name (alternative to parameter names)
+        PreparedStatement ps = getPrepared(extCtx, query.get().value());
+        if (ps != null) {
+          return query(extCtx, ps);
+        }
+        // Execute text provided in @Query
+        return query(extCtx, query.get().value());
+      }
+      else {
+        // Lookup vis parameter name
+        PreparedStatement ps = getPrepared(extCtx, paramCtx.getParameter().getName());
+        if (ps == null) {
+          throw new ParameterResolutionException("No @Query annotation or @Prepare annotation matching parameter: " + paramCtx.getParameter().getName());
+        }
+        return query(extCtx, ps);
+      }
+    }
+
+    return null;
+  }
+
+  private static boolean isPrepared(ExtensionContext ctx, String name) {
+    return getPrepared(ctx, name) != null;
+  }
+
+  private static PreparedStatement getPrepared(ExtensionContext ctx, String name) {
+    StatementResource resource = ctx.getStore(NS).get(PREPARED_STATEMENT_KEY_PREFIX + name, StatementResource.class);
+    if (resource == null) return null;
+    return (PreparedStatement) resource.statement;
+  }
+
+  private static void prepareAll(ExtensionContext ctx) {
+
+    enumerateContexts(ctx, (curCtx, element) -> {
+
+      for (Prepare prepare : findRepeatableAnnotations(element, Prepare.class)) {
+        StatementResource statementResource = new StatementResource(prepare(ctx, prepare.sql(), prepare.returning()));
+        ctx.getStore(NS).put(PREPARED_STATEMENT_KEY_PREFIX + prepare.name(), statementResource);
+      }
+
+    });
+
+  }
+
+  private static Statement statement(ExtensionContext ctx) {
+    try {
+      Connection connection = open(ctx);
+      Statement statement = connection.createStatement();
+      statement.closeOnCompletion();
+      return statement;
+    }
+    catch (Exception e) {
+      throw new ParameterResolutionException("Error resolving parameter", e);
+    }
+  }
+
+  private static PreparedStatement prepare(ExtensionContext ctx, String sql, String[] returning) {
+    try {
+      Connection connection = open(ctx);
+      if (returning != null && returning.length != 0) {
+        return connection.prepareStatement(sql, returning);
+      }
+      else {
+        return connection.prepareStatement(sql);
+      }
+    }
+    catch (Exception e) {
+      throw new ParameterResolutionException("Error resolving parameter", e);
+    }
+  }
+
+  private static ResultSet query(ExtensionContext ctx, String sql) {
+    try {
+      Connection connection = open(ctx);
+      Statement statement = connection.createStatement();
+      statement.closeOnCompletion();
+      return track(ctx, statement.executeQuery(sql));
+    }
+    catch (Exception e) {
+      throw new ParameterResolutionException("Error resolving parameter", e);
+    }
+  }
+
+  private static ResultSet query(ExtensionContext ctx, PreparedStatement ps) {
+    try {
+      return track(ctx, ps.executeQuery());
+    }
+    catch (Exception e) {
+      throw new ParameterResolutionException("Error resolving parameter", e);
+    }
+  }
+
+  private static ResultSet track(ExtensionContext ctx, ResultSet resultSet) {
+    ctx.getStore(NS).put(resultSet.toString(), new ResultSetResource(resultSet));
+    return resultSet;
+  }
+
+  private static Optional<ExtensionContext> findContext(ExtensionContext ctx, BiFunction<ExtensionContext, AnnotatedElement, Boolean> predicate) {
+    if (ctx.getElement().isPresent() && predicate.apply(ctx, ctx.getElement().get())) return Optional.of(ctx);
+    if (ctx.getParent().isPresent()) {
+      return findContext(ctx.getParent().get(), predicate);
+    }
+    return Optional.empty();
+  }
+
+  private static void enumerateContexts(ExtensionContext ctx, BiConsumer<ExtensionContext, AnnotatedElement> each) {
+    if (ctx.getElement().isPresent())
+      each.accept(ctx, ctx.getElement().get());
+    if (ctx.getParent().isPresent()) {
+      enumerateContexts(ctx.getParent().get(), each);
+    }
+  }
+
+  private static Properties collectProperties(ExtensionContext ctx) {
+    Properties properties = new Properties();
+    enumerateContexts(ctx, (c, e) -> {
+      for (ConnectionProperty connectionProperty : e.getDeclaredAnnotationsByType(ConnectionProperty.class)) {
+        properties.setProperty(connectionProperty.name(), connectionProperty.value());
+      }
+    });
+    return properties;
+  }
+
+  private static List<ConnectionSetting> collectSettings(ExtensionContext ctx) {
+    List<ConnectionSetting> settings = new ArrayList<>();
+    enumerateContexts(ctx, (c, e) -> settings.addAll(Arrays.asList(e.getDeclaredAnnotationsByType(ConnectionSetting.class))));
+    return settings;
+  }
+
+  static Connection open(ExtensionContext ctx) {
+
+    Optional<ExtensionContext> dbTestCtxOpt =
+        findContext(ctx, (c, e) -> e.isAnnotationPresent(DBTest.class));
+    if (!dbTestCtxOpt.isPresent()) {
+      throw new ExtensionConfigurationException("Unable to fund DBTest annotation");
+    }
+    ExtensionContext dbTestCtx = dbTestCtxOpt.get();
+
+    DBTest dbTest = dbTestCtx.getElement()
+        .orElseThrow(IllegalStateException::new)
+        .getAnnotation(DBTest.class);
+
+    ExtensionContext connectionCtx =
+        findContext(ctx, (c, e) -> e.isAnnotationPresent(ConnectionSetting.class) || e.isAnnotationPresent(ConnectionProperty.class))
+            .orElse(dbTestCtx);
+
+    String url = "jdbc:pgsql://" + dbTest.host() + "/" + dbTest.db();
+
+    Properties properties = collectProperties(connectionCtx);
+    if (properties.getProperty("user") == null) {
+      properties.setProperty("user", dbTest.user());
+    }
+    if (properties.getProperty("password") == null) {
+      properties.setProperty("password", dbTest.password());
+    }
+
+    List<ConnectionSetting> settings = collectSettings(connectionCtx);
+
+    return open(connectionCtx, url, properties, settings);
+  }
+
+  static Connection open(ExtensionContext ctx, String url, Properties properties, List<ConnectionSetting> setttings) {
+
+    String key = "connection@" + ctx.getUniqueId();
+
+    return ctx.getStore(NS).getOrComputeIfAbsent(key, key1 -> {
+
+      try {
+        Connection connection = DriverManager.getConnection(url, properties);
+
+        // Configure any connection settings
+        if (!setttings.isEmpty()) {
+          try(Statement statement = connection.createStatement()) {
+            for (ConnectionSetting setting : setttings) {
+              statement.executeUpdate("SET " + setting.name() + " " + setting.assignment()  + " " + setting.value());
+            }
+          }
+        }
+
+        return new ConnectionResource(connection);
+      }
+      catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }, ConnectionResource.class).connection;
+  }
+
+  private static void close(ExtensionContext ctx) {
+
+    String key = "connection@" + ctx.getUniqueId();
+
+    ConnectionResource connectionResource = ctx.getStore(NS).remove(key, ConnectionResource.class);
+    if (connectionResource == null) return;
+
+    try {
+      connectionResource.connection.close();
+    }
+    catch (SQLException ignored) {
+    }
+  }
+
+  static class ConnectionResource implements Store.CloseableResource {
+
+    Connection connection;
+
+    ConnectionResource(Connection connection) {
+      this.connection = connection;
+    }
+
+    @Override
+    public void close() throws Throwable {
+      connection.close();
+    }
+
+  }
+
+  static class StatementResource implements Store.CloseableResource {
+
+    Statement statement;
+
+    StatementResource(Statement statement) {
+      this.statement = statement;
+    }
+
+    @Override
+    public void close() throws Throwable {
+      statement.close();
+    }
+
+  }
+
+  static class ResultSetResource implements Store.CloseableResource {
+
+    ResultSet resultSet;
+
+    ResultSetResource(ResultSet resultSet) {
+      this.resultSet = resultSet;
+    }
+
+    @Override
+    public void close() throws Throwable {
+      resultSet.close();
+    }
+
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/extensions/ExtensionInstalledCondition.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/extensions/ExtensionInstalledCondition.java
@@ -1,0 +1,42 @@
+package com.impossibl.postgres.test.extensions;
+
+import com.impossibl.postgres.jdbc.TestUtil;
+import com.impossibl.postgres.test.annotations.ExtensionInstalled;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+public class ExtensionInstalledCondition implements ExecutionCondition {
+
+  private static final ConditionEvaluationResult ENABLED =
+      ConditionEvaluationResult.enabled("@ExtensionInstalled not present");
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    Optional<ExtensionInstalled> extensionInstalledOpt =
+        AnnotationSupport.findAnnotation(context.getElement(), ExtensionInstalled.class);
+    if (!extensionInstalledOpt.isPresent()) {
+      return ENABLED;
+    }
+
+    ExtensionInstalled extensionInstalled = extensionInstalledOpt.get();
+
+    try {
+      if (!TestUtil.isExtensionInstalled(DBProvider.open(context), extensionInstalled.value())) {
+        return ConditionEvaluationResult.disabled(extensionInstalled.value() + " is not installed");
+      }
+    }
+    catch (SQLException e) {
+      return ConditionEvaluationResult.disabled("Check for extension " + extensionInstalled.value() + " failed");
+    }
+
+    return ConditionEvaluationResult.enabled(extensionInstalled.value() + " is installed");
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/extensions/RandomProvider.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/extensions/RandomProvider.java
@@ -1,0 +1,117 @@
+package com.impossibl.postgres.test.extensions;
+
+import com.impossibl.postgres.test.annotations.Random;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.stream.IntStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class RandomProvider implements ParameterResolver {
+
+  private static final Namespace NS = Namespace.create("random");
+
+  @Override
+  public boolean supportsParameter(ParameterContext paramCtx, ExtensionContext extensionContext) throws ParameterResolutionException {
+
+    if (!paramCtx.isAnnotated(Random.class)) return false;
+
+    Class<?> paramType = paramCtx.getParameter().getType();
+
+    return paramType == IntStream.class || paramType == InputStream.class || paramType == Reader.class ||
+        paramType == byte[].class ||
+        paramType == Boolean.class || paramType == Boolean.TYPE ||
+        paramType == Integer.class || paramType == Integer.TYPE ||
+        paramType == Long.class || paramType == Long.TYPE ||
+        paramType == Float.class || paramType == Float.TYPE ||
+        paramType == Double.class || paramType == Double.TYPE;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext paramCtx, ExtensionContext extCtx) throws ParameterResolutionException {
+
+    Random randomAnn = paramCtx.findAnnotation(Random.class).orElse(null);
+    if (randomAnn == null) return null;
+
+    java.util.Random random = (java.util.Random) extCtx.getStore(NS)
+        .getOrComputeIfAbsent("provider", key -> new java.util.Random());
+
+    Class<?> paramType = paramCtx.getParameter().getType();
+
+    if (paramType == byte[].class) {
+      int[] values = random.ints(randomAnn.size(), randomAnn.origin(), randomAnn.bound()).toArray();
+      byte[] data = new byte[randomAnn.size()];
+      for (int c=0; c < data.length; ++c) {
+        data[c] = (byte) values[c];
+      }
+      return data;
+    }
+
+    if (paramType == InputStream.class) {
+      if (randomAnn.codepoints()) {
+        int[] values = randomCodePoints(random).limit(randomAnn.size()).toArray();
+        String text = new String(values, 0, values.length);
+        return new ByteArrayInputStream(text.getBytes(UTF_8));
+      }
+      else {
+        int[] values = random.ints(randomAnn.size(), randomAnn.origin(), randomAnn.bound()).toArray();
+        byte[] data = new byte[randomAnn.size()];
+        for (int c=0; c < data.length; ++c) {
+          data[c] = (byte) values[c];
+        }
+        return new ByteArrayInputStream(data);
+      }
+    }
+
+    if (paramType == Reader.class) {
+      int[] values = randomCodePoints(random).limit(randomAnn.size()).toArray();
+      return new StringReader(new String(values, 0, values.length));
+    }
+
+    if (paramType == String.class) {
+      int[] values = randomCodePoints(random).limit(randomAnn.size()).toArray();
+      return new String(values, 0, values.length);
+    }
+
+    if (paramType == Boolean.class || paramType == Boolean.TYPE) {
+      return random.nextBoolean();
+    }
+
+    if (paramType == Integer.class || paramType == Integer.TYPE) {
+      return random.nextInt(randomAnn.bound());
+    }
+
+    if (paramType == Long.class || paramType == Long.TYPE) {
+      return random.nextLong();
+    }
+
+    if (paramType == Float.class || paramType == Float.TYPE) {
+      return random.nextFloat();
+    }
+
+    if (paramType == Double.class || paramType == Double.TYPE) {
+      return random.nextDouble();
+    }
+
+    if (paramType == IntStream.class) {
+      return random.ints(randomAnn.size(), randomAnn.origin(), randomAnn.bound());
+    }
+
+    return null;
+  }
+
+  private IntStream randomCodePoints(java.util.Random random) {
+    return random.ints(0, 0xfffe)
+        .filter(cp -> Character.isDefined(cp) && !Character.isSurrogate((char) cp) && Character.getType(cp) != Character.PRIVATE_USE);
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/extensions/SchemaManager.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/extensions/SchemaManager.java
@@ -1,0 +1,250 @@
+package com.impossibl.postgres.test.extensions;
+
+import com.impossibl.postgres.test.annotations.Schema;
+import com.impossibl.postgres.test.annotations.Table;
+import com.impossibl.postgres.test.annotations.Type;
+import com.impossibl.postgres.test.matchers.ColSnapshot;
+import com.impossibl.postgres.test.matchers.RowSnapshot;
+
+import static com.impossibl.postgres.test.extensions.DBProvider.open;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.reflect.TypeToken;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+
+public class SchemaManager implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
+
+  private static final Namespace NS = Namespace.create("schema");
+
+  private static final TypeToken<ColSnapshot<?>> COL_SNAPSHOT_TYPE = new TypeToken<ColSnapshot<?>>() {};
+  private static final TypeToken<RowSnapshot<?>> ROW_SNAPSHOT_TYPE = new TypeToken<RowSnapshot<?>>() {};
+
+  @Override
+  public boolean supportsParameter(ParameterContext paramCtx, ExtensionContext extCtx) throws ParameterResolutionException {
+    TypeToken<?> paramType = TypeToken.of(paramCtx.getParameter().getParameterizedType());
+    String paramName = paramCtx.getParameter().getName();
+    SchemaTracker tracker = getTracker(extCtx);
+
+    return (COL_SNAPSHOT_TYPE.isSupertypeOf(paramType) || ROW_SNAPSHOT_TYPE.isSupertypeOf(paramType)) && tracker.find(paramName, Table.class) != null;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext paramCtx, ExtensionContext extCtx) throws ParameterResolutionException {
+
+    TypeToken<?> paramType = TypeToken.of(paramCtx.getParameter().getParameterizedType());
+    String paramName = paramCtx.getParameter().getName();
+    SchemaTracker tracker = getTracker(extCtx);
+
+    if (COL_SNAPSHOT_TYPE.isSupertypeOf(paramType)) {
+      Class<?> elementType = paramType.resolveType(paramCtx.getParameter().getType().getTypeParameters()[0]).getRawType();
+      Table table = tracker.find(paramName, Table.class);
+      if (table == null) {
+        throw new ParameterResolutionException("Unable to locate table definition for " + paramName);
+      }
+      String[] columnNames = Arrays.stream(table.columns()).map(col -> col.split(" ")[0]).toArray(String[]::new);
+      return new ColSnapshot<>(DBProvider.open(extCtx), table.name(), columnNames[0], elementType);
+    }
+
+    if (ROW_SNAPSHOT_TYPE.isSupertypeOf(paramType)) {
+      Class<?> elementType = paramType.resolveType(paramCtx.getParameter().getType().getTypeParameters()[0]).getRawType();
+      Table table = tracker.find(paramName, Table.class);
+      if (table == null) {
+        throw new ParameterResolutionException("Unable to locate table definition for " + paramName);
+      }
+      String[] columnNames = Arrays.stream(table.columns()).map(col -> col.split(" ")[0]).toArray(String[]::new);
+      return new RowSnapshot<>(DBProvider.open(extCtx), table.name(), columnNames, elementType);
+    }
+
+    return null;
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    createSchemaObjects(context);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    createSchemaObjects(extensionContext);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) throws Exception {
+    dropSchemaObjects(extensionContext);
+
+    try (Statement statement = open(extensionContext).createStatement()) {
+      getTracker(extensionContext).truncateAllTables(statement);
+    }
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    dropSchemaObjects(context);
+  }
+
+  private static SchemaTracker getTracker(ExtensionContext extCtx) {
+    return extCtx.getRoot().getStore(NS).getOrComputeIfAbsent(SchemaTracker.class);
+  }
+
+  interface SchemaIterator {
+    void apply(Schema schema) throws Exception;
+    void apply(Table table) throws Exception;
+    void apply(Type type) throws Exception;
+  }
+
+  private static void iterateSchemaObjects(ExtensionContext extCtx, SchemaIterator iterator) throws Exception {
+
+    AnnotatedElement element = extCtx.getElement().orElseThrow(IllegalStateException::new);
+
+    for (Schema schema : findRepeatableAnnotations(element, Schema.class)) {
+      iterator.apply(schema);
+    }
+
+    for (Type type : findRepeatableAnnotations(element, Type.class)) {
+      iterator.apply(type);
+    }
+
+    for (Table table : findRepeatableAnnotations(element, Table.class)) {
+      iterator.apply(table);
+    }
+
+  }
+
+  private static void createSchemaObjects(ExtensionContext extCtx) throws Exception {
+
+    SchemaTracker tracker = getTracker(extCtx);
+
+    try (Statement statement = open(extCtx).createStatement()) {
+      iterateSchemaObjects(extCtx, new SchemaIterator() {
+        @Override
+        public void apply(Schema schema) throws Exception {
+          tracker.create(statement, schema);
+        }
+
+        @Override
+        public void apply(Table table) throws Exception {
+          tracker.create(statement, table);
+        }
+
+        @Override
+        public void apply(Type type) throws Exception {
+          tracker.create(statement, type);
+        }
+      });
+    }
+
+  }
+
+  private static void dropSchemaObjects(ExtensionContext extCtx) throws Exception {
+
+    SchemaTracker tracker = getTracker(extCtx);
+
+    try (Statement statement = open(extCtx).createStatement()) {
+      iterateSchemaObjects(extCtx, new SchemaIterator() {
+        @Override
+        public void apply(Schema schema) throws Exception {
+          tracker.drop(statement, schema);
+        }
+
+        @Override
+        public void apply(Table table) throws Exception {
+          tracker.drop(statement, table);
+        }
+
+        @Override
+        public void apply(Type type) throws Exception {
+          tracker.drop(statement, type);
+        }
+      });
+    }
+
+  }
+
+  static class SchemaTracker {
+
+    Map<String, Annotation> objects = new HashMap<>();
+
+    <T extends Annotation> T find(String name, Class<T> annType) {
+      return annType.cast(objects.get(annType.getSimpleName().toUpperCase() + "@" + name));
+    }
+
+    void create(Statement statement, Schema schema) throws SQLException {
+      statement.executeUpdate("DROP SCHEMA IF EXISTS " + schema.value() + "; " +
+          "CREATE SCHEMA " + schema.value() + " ");
+      add(schema);
+    }
+
+    void create(Statement statement, Table table) throws SQLException {
+      statement.executeUpdate("DROP TABLE IF EXISTS " + table.name() + "; " +
+          "CREATE TABLE " + table.name() + " (" + String.join(", ", table.columns()) + ")");
+      add(table);
+    }
+
+    void create(Statement statement, Type type) throws SQLException {
+      statement.executeUpdate("DROP TYPE IF EXISTS " + type.name() + "; " +
+          "CREATE TYPE " + type.name() + " (" + String.join(", ", type.attributes()) + ")");
+      add(type);
+    }
+
+    void drop(Statement statement, Schema schema) throws SQLException {
+      statement.executeUpdate("DROP SCHEMA " + schema.value() + " CASCADE");
+      remove(schema);
+    }
+
+    void drop(Statement statement, Table table) throws SQLException {
+      statement.executeUpdate("DROP TABLE " + table.name() + " CASCADE");
+      remove(table);
+    }
+
+    void drop(Statement statement, Type type) throws SQLException {
+      statement.executeUpdate("DROP TYPE " + type.name() + " CASCADE");
+      remove(type);
+    }
+
+    private void add(Annotation object) {
+      objects.put(typeOf(object) + "@" + nameOf(object), object);
+    }
+
+    private void remove(Annotation object) {
+      objects.remove(typeOf(object) + "@" + nameOf(object));
+    }
+
+    static String typeOf(Annotation annotation) {
+      return annotation.annotationType().getSimpleName().toUpperCase();
+    }
+
+    static String nameOf(Annotation annotation) {
+      if (annotation instanceof Schema) return ((Schema) annotation).value();
+      if (annotation instanceof Table) return ((Table) annotation).name();
+      if (annotation instanceof Type) return ((Type) annotation).name();
+      throw new IllegalStateException("Unsupported schema object type: " + annotation.annotationType().getCanonicalName());
+    }
+
+    void truncateAllTables(Statement statement) throws SQLException {
+      for (Annotation object : objects.values()) {
+        if (object instanceof Table) {
+          statement.executeUpdate("TRUNCATE " + ((Table) object).name());
+        }
+      }
+    }
+  }
+
+}
+

--- a/driver/src/test/java/com/impossibl/postgres/test/extensions/UpdateManager.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/extensions/UpdateManager.java
@@ -1,0 +1,61 @@
+package com.impossibl.postgres.test.extensions;
+
+import com.impossibl.postgres.test.annotations.Execute;
+import com.impossibl.postgres.test.annotations.Insert;
+
+import static com.impossibl.postgres.test.extensions.DBProvider.open;
+
+import java.lang.reflect.AnnotatedElement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findRepeatableAnnotations;
+
+public class UpdateManager implements BeforeAllCallback, BeforeEachCallback {
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    executeAll(context);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    executeAll(extensionContext);
+  }
+
+  private static void executeAll(ExtensionContext extCtx) throws Exception {
+
+    AnnotatedElement element = extCtx.getElement().orElseThrow(IllegalStateException::new);
+
+    try (Statement statement = open(extCtx).createStatement()) {
+
+      for (Insert insert : findRepeatableAnnotations(element, Insert.class)) {
+        execute(statement, insert);
+      }
+
+      for (Execute execute : findRepeatableAnnotations(element, Execute.class)) {
+        execute(statement, execute);
+      }
+
+    }
+
+  }
+
+  private static void execute(Statement statement, Insert insert) throws SQLException {
+    String columnList = insert.columns().length != 0 ? "(" + String.join(",", insert.columns()) + ")" : "";
+    String dataCast = !insert.type().equals("") ? "::" + insert.type() : "";
+    statement.executeUpdate("INSERT INTO " + insert.table() + columnList + " VALUES (" + stream(insert.values()).map(val -> "'" + val + "'" + dataCast).collect(joining(",")) + ")");
+  }
+
+  private static void execute(Statement statement, Execute execute) throws SQLException {
+    statement.executeUpdate(execute.sql());
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/matchers/ColSnapshot.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/matchers/ColSnapshot.java
@@ -1,0 +1,54 @@
+package com.impossibl.postgres.test.matchers;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ColSnapshot<T> implements Snapshot<T> {
+
+  private Connection connection;
+  private String table;
+  private String column;
+  private Class<T> elementType;
+
+  public ColSnapshot(Connection connection, String table, String column, Class<T> elementType) {
+    this.connection = connection;
+    this.table = table;
+    this.column = column;
+    this.elementType = elementType;
+  }
+
+  public List<T> take() {
+    try (Statement statement = connection.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT " + column + " FROM " + table)) {
+        List<T> values = new ArrayList<>();
+        while (resultSet.next()) {
+          values.add(elementType.cast(resultSet.getObject(1)));
+        }
+        return values;
+      }
+    }
+    catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public List<String> takeText() {
+    try (Statement statement = connection.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT " + column + "::text FROM " + table)) {
+        List<String> values = new ArrayList<>();
+        while (resultSet.next()) {
+          values.add(resultSet.getString(1));
+        }
+        return values;
+      }
+    }
+    catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/matchers/InputStreamMatcher.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/matchers/InputStreamMatcher.java
@@ -1,0 +1,50 @@
+package com.impossibl.postgres.test.matchers;
+
+import com.impossibl.postgres.system.procs.Bytes;
+
+import static com.impossibl.postgres.utils.guava.ByteStreams.limit;
+import static com.impossibl.postgres.utils.guava.ByteStreams.toByteArray;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+
+public class InputStreamMatcher extends BaseMatcher<InputStream> {
+
+  private InputStream expected;
+
+  private InputStreamMatcher(InputStream expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean matches(Object item) {
+    InputStream actual = (InputStream) item;
+    try {
+      return Arrays.equals(toByteArray(expected), toByteArray(actual));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    try {
+      byte[] data = toByteArray(limit(expected, 20));
+      description.appendText("InputStream (" + data.length + ")").appendValue(Bytes.encodeHex(data));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static InputStreamMatcher contentEquals(InputStream expected) {
+    return new InputStreamMatcher(expected);
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/matchers/RowSnapshot.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/matchers/RowSnapshot.java
@@ -1,0 +1,64 @@
+package com.impossibl.postgres.test.matchers;
+
+import java.lang.reflect.Array;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RowSnapshot<T> implements Snapshot<T[]> {
+
+  private Connection connection;
+  private String table;
+  private String[] columnNames;
+  private Class<T> elementType;
+
+  public RowSnapshot(Connection connection, String table, String[] columnNames, Class<T> elementType) {
+    this.connection = connection;
+    this.table = table;
+    this.columnNames = columnNames;
+    this.elementType = elementType;
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<T[]> take() {
+    try (Statement statement = connection.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT " + String.join(", ", columnNames) + " FROM " + table)) {
+        List<T[]> rows = new ArrayList<>();
+        while (resultSet.next()) {
+          T[] columns = (T[]) Array.newInstance(elementType, columnNames.length);
+          for (int c = 0; c < columns.length; ++c) {
+            columns[c] = elementType.cast(resultSet.getObject(c + 1));
+          }
+          rows.add(columns);
+        }
+        return rows;
+      }
+    }
+    catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public List<String[]> takeText() {
+    try (Statement statement = connection.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT " + String.join(", ", columnNames) + " FROM " + table)) {
+        List<String[]> rows = new ArrayList<>();
+        while (resultSet.next()) {
+          String[] columns = new String[columnNames.length];
+          for (int c = 0; c < columns.length; ++c) {
+            columns[c] = resultSet.getString(c + 1);
+          }
+          rows.add(columns);
+        }
+        return rows;
+      }
+    }
+    catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/driver/src/test/java/com/impossibl/postgres/test/matchers/Snapshot.java
+++ b/driver/src/test/java/com/impossibl/postgres/test/matchers/Snapshot.java
@@ -1,0 +1,9 @@
+package com.impossibl.postgres.test.matchers;
+
+import java.util.List;
+
+public interface Snapshot<T> {
+
+  List<T> take();
+
+}


### PR DESCRIPTION
Builds on JUnit 5's annotation system to build a declarative DB testing framework.

Most of the test setup (and therefore teardown) is now either automatic or configured via a method or class annotation.

Dramatically simplifies creating tests with unique or shared schema. Required objects like Connections, Statement, PreparedStatements, etc. are provided via JUnit 5 parameters.

Documentation is forthcoming (via Javadoc) until then see the new `PreparedStatementTest` to see what it's capable of.

NOTE: This also adds `query-mode` parameter, and related fixes, that allows forcing the driver to use binary/text mode. When JUnit 5 gets the capability to parameterize entire test classes it will be used to run all tests in both modes.