### PR TITLE
Pipeline `executeBatch` requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   # PostgreSQL requires specific permissions... this meets the requirements when running via docker in Travis
   - chmod 0400 ./driver/src/test/resources/certdir/server/server.key
   - sudo chown 70:70 ./driver/src/test/resources/certdir/server/server.key
-script: ./gradlew --stacktrace -PpostgresVersions=$PGVERSION test -x checkstyleMain
+script: ./gradlew -PpostgresVersions=$PGVERSION test -x checkstyleMain
 
 jobs:
   include:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.github.breadmoirai.GithubReleaseTask
 import de.undercouch.gradle.tasks.download.Download
 
 plugins {
+  base
   id("de.undercouch.download") version "3.4.3"
   id("com.github.breadmoirai.github-release") version Versions.githubReleasePlugin
 }
@@ -85,9 +86,17 @@ fun centralDownload(group: String, artifact: String, classifier: String? = null)
   val base = "http://oss.sonatype.org/service/local/artifact/maven/redirect"
   val repo = if(isSnapshot) "snapshots" else "releases"
   val queryClassifier = classifier?.let { "&c=$it" } ?: ""
+  val dest = "$buildDir/artifacts/$artifact-$version${classifier?.let { "-$it" } ?: ""}.jar"
+
+  tasks.named("clean") {
+    doFirst {
+      file(dest).delete()
+    }
+  }
+
   return tasks.register<Download>("downloadCentral" + "$group-$artifact-${classifier ?: ""}") {
     src("$base?r=$repo&g=$group&a=$artifact$queryClassifier&v=$version")
-    dest("$buildDir/artifacts/$artifact-$version${classifier?.let { "-$it" } ?: ""}.jar")
+    dest(dest)
   }
 
 }

--- a/driver/src/build/testing.gradle.kts
+++ b/driver/src/build/testing.gradle.kts
@@ -1,5 +1,6 @@
 import com.avast.gradle.dockercompose.ComposeExtension
 import com.avast.gradle.dockercompose.DockerComposePlugin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.nio.file.Files
@@ -21,6 +22,9 @@ val defaultPostgresVersions by extra("11, 10, 9.6, 9.5, 9.4")
 
 val testTask = tasks.named<Test>("test") {
   useJUnitPlatform()
+  testLogging {
+    exceptionFormat = TestExceptionFormat.FULL
+  }
   exclude(
      "**/RequiredTests.*",
      "**/DateTimeTests.*",

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -519,6 +519,11 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
 
     warningChain = chainWarnings(warningChain, request);
 
+    Throwable error = request.getError();
+    if (error != null) {
+      throw results.getException(batchIdx.get(), null, (Exception) error);
+    }
+
     try (ResultBatch resultBatch = request.getBatch()) {
 
       if (!allowBatchSelects() && resultBatch.getCommand().equals("SELECT")) {

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGPreparedStatement.java
@@ -69,6 +69,7 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
+import java.sql.BatchUpdateException;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -89,6 +90,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Integer.toHexString;
 import static java.lang.Long.min;
@@ -225,9 +227,8 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
   void verifyParameterSet() throws SQLException {
     if (parameterCount > 0) {
       int count = 0;
-      for (Boolean b : parameterSet) {
-        if (b != null && Boolean.TRUE.equals(b))
-          count++;
+      for (boolean b : parameterSet) {
+        if (b) count++;
       }
       if (count != parameterCount)
         throw new SQLException("Incorrect parameter count, was " + count + ", expected: " + parameterCount);
@@ -449,16 +450,24 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
       ResultField[] lastResultFields = null;
 
       int batchIdx = 0;
+      AtomicInteger completedBatchIdx = new AtomicInteger(0);
       int sz = batchParameterBuffers.size();
 
       try {
         RequestExecutor requestExecutor = connection.getRequestExecutor();
+        List<ExecuteResult> requestHandlers = new ArrayList<>();
 
         while (batchIdx < sz) {
 
           Type[] suggestedParameterTypes = mergedTypes(batchParameterTypes.get(batchIdx), lastParameterTypes);
 
           if (lastParameterTypes == null || !Arrays.equals(lastParameterTypes, parameterTypes)) {
+
+            /**
+             * Note: This causes all in-flight requests to finish at
+             * this point; negating any pipe-lining effect we could
+             * have achieved.
+             **/
 
             PrepareResult prep = connection.execute((timeout) -> {
               PrepareResult handler = new PrepareResult();
@@ -478,37 +487,19 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
           ByteBuf[] parameterBuffers = batchParameterBuffers.get(batchIdx);
           ResultField[] resultFields = lastResultFields;
 
-          ExecuteResult exec = connection.execute((timeout) -> {
-            ExecuteResult handler = new ExecuteResult(resultFields);
-            requestExecutor.execute(null, null, parameterFormats, parameterBuffers, resultFields, 0, handler);
-            handler.await(timeout, MILLISECONDS);
-            return handler;
-          });
-
-          warningChain = chainWarnings(warningChain, exec);
-
-          try (ResultBatch resultBatch = exec.getBatch()) {
-
-            if (!allowBatchSelects() && resultBatch.getCommand().equals("SELECT")) {
-              throw results.getException(batchIdx, "SELECT in executeBatch", null);
-            }
-            else if (resultBatch.getRowsAffected() != null) {
-              results.setUpdateCount(batchIdx, resultBatch.getRowsAffected());
-            }
-            else {
-              results.setUpdateCount(batchIdx, SUCCESS_NO_INFO);
-            }
-
-            if (wantsGeneratedKeys) {
-              generatedKeys.add(resultBatch.borrowRows().take(0));
-            }
-          }
+          ExecuteResult handler = new ExecuteResult(resultFields);
+          requestExecutor.execute(null, null, parameterFormats, parameterBuffers, resultFields, 0, handler);
+          requestHandlers.add(handler);
 
           batchIdx++;
+
+          finishCompletedRequests(requestHandlers, completedBatchIdx, results, generatedKeys);
         }
+
+        finishRequests(requestHandlers, completedBatchIdx, results, generatedKeys);
       }
       catch (IOException | SQLException se) {
-        throw results.getException(batchIdx, null, se);
+        throw results.getException(completedBatchIdx.get(), null, se);
       }
 
       generatedKeysResultSet = createResultSet(lastResultFields, generatedKeys, true, connection.getTypeMap());
@@ -520,6 +511,56 @@ class PGPreparedStatement extends PGStatement implements PreparedStatement {
         batchParameterBuffers.forEach(ByteBufs::releaseAll);
         batchParameterBuffers = null;
       }
+    }
+
+  }
+
+  private void finishRequest(AtomicInteger batchIdx, ExecuteResult request, BatchResults results, RowDataSet generatedKeys) throws BatchUpdateException {
+
+    warningChain = chainWarnings(warningChain, request);
+
+    try (ResultBatch resultBatch = request.getBatch()) {
+
+      if (!allowBatchSelects() && resultBatch.getCommand().equals("SELECT")) {
+        throw results.getException(batchIdx.get(), "SELECT in executeBatch", null);
+      }
+      else if (resultBatch.getRowsAffected() != null) {
+        results.setUpdateCount(batchIdx.get(), resultBatch.getRowsAffected());
+      }
+      else {
+        results.setUpdateCount(batchIdx.get(), SUCCESS_NO_INFO);
+      }
+
+      if (wantsGeneratedKeys) {
+        generatedKeys.add(resultBatch.borrowRows().take(0));
+      }
+    }
+  }
+
+  private void finishCompletedRequests(List<ExecuteResult> batchRequests, AtomicInteger batchIdx, BatchResults results, RowDataSet generatedKeys) throws BatchUpdateException {
+
+    while (!batchRequests.isEmpty() && batchRequests.get(0).isCompleted()) {
+      ExecuteResult request = batchRequests.remove(0);
+
+      finishRequest(batchIdx, request, results, generatedKeys);
+
+      batchIdx.incrementAndGet();
+    }
+
+  }
+
+  private void finishRequests(List<ExecuteResult> batchRequests, AtomicInteger batchIdx, BatchResults results, RowDataSet generatedKeys) throws SQLException {
+
+    while (!batchRequests.isEmpty()) {
+      ExecuteResult request = batchRequests.remove(0);
+
+      connection.execute(timeout -> {
+        request.await(timeout, MILLISECONDS);
+      });
+
+      finishRequest(batchIdx, request, results, generatedKeys);
+
+      batchIdx.incrementAndGet();
     }
 
   }

--- a/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutorHandlers.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutorHandlers.java
@@ -81,6 +81,15 @@ public class RequestExecutorHandlers {
       completed.countDown();
     }
 
+    public boolean isCompleted() {
+      try {
+        return completed.await(0, SECONDS);
+      }
+      catch (InterruptedException ignored) {
+        return false;
+      }
+    }
+
     void checkCompleted() {
       try {
         if (completed.await(0, SECONDS))

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/BatchExecuteTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/BatchExecuteTest.java
@@ -36,6 +36,7 @@
 package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.api.jdbc.PGConnection;
+import com.impossibl.postgres.utils.Timer;
 
 import java.sql.Array;
 import java.sql.BatchUpdateException;
@@ -49,6 +50,7 @@ import java.sql.Types;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -266,6 +268,28 @@ public class BatchExecuteTest {
 
     con.rollback();
     assertCol1HasValue(10);
+
+    pstmt.close();
+  }
+
+  @Ignore
+  @Test
+  public void testPreparedStatementPerformance() throws Exception {
+    PreparedStatement pstmt = con.prepareStatement("UPDATE testbatch SET col1 = col1 + ? WHERE PK = ?");
+
+    for (int c = 0; c < 10000; ++c) {
+      pstmt.setInt(1, c);
+      pstmt.setInt(2, c);
+      pstmt.addBatch();
+    }
+
+    Timer timer = new Timer();
+
+    con.setAutoCommit(false);
+    pstmt.executeBatch();
+    con.commit();
+
+    System.out.println("Total time: " + timer.getTotalSeconds());
 
     pstmt.close();
   }

--- a/udt-gen/src/build/testing.gradle.kts
+++ b/udt-gen/src/build/testing.gradle.kts
@@ -1,5 +1,6 @@
 import com.avast.gradle.dockercompose.ComposeExtension
 import com.avast.gradle.dockercompose.DockerComposePlugin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 buildscript {
   repositories { jcenter() }
@@ -22,6 +23,9 @@ val pgVersion = (project.properties["postgresVersions"] as? String ?: defaultPos
 
 val testTask = tasks.named<Test>("test") {
   useJUnitPlatform()
+  testLogging {
+    exceptionFormat = TestExceptionFormat.FULL
+  }
 }
 
 


### PR DESCRIPTION
This dramatically reduces the overhead in batch executions without compromising functionality. My preliminary tests show about 70% reduction in batch execution.

The implementation continuously checks the status of outstanding requests, completing them and checking for failures. This ensures that as soon as the driver knows about an error, it stops sending requests to the server.