### PR TITLE
Fixes to encoding of numeric types from Java types

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/system/procs/BaseEncoders.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/BaseEncoders.java
@@ -122,11 +122,14 @@ abstract class AutoConvertingBinaryEncoder<N> extends BaseBinaryEncoder implemen
 
   protected N convertInput(Context context, Type type, Object source, Object sourceContext) throws ConversionException {
 
+    if (converter != null) {
+      N res = converter.convert(context, source, sourceContext);
+      if (res != null) {
+        return res;
+      }
+    }
     if (getDefaultClass().isInstance(source)) {
       return getDefaultClass().cast(source);
-    }
-    if (converter != null) {
-      return converter.convert(context, source, sourceContext);
     }
 
     throw new ConversionException(source.getClass(), type);
@@ -185,11 +188,14 @@ abstract class AutoConvertingTextEncoder<N> extends BaseTextEncoder implements A
 
   protected N convertInput(Context context, Type type, Object source, Object sourceContext) throws ConversionException {
 
+    if (converter != null) {
+      N res = converter.convert(context, source, sourceContext);
+      if (res != null) {
+        return res;
+      }
+    }
     if (getDefaultClass().isInstance(source)) {
       return getDefaultClass().cast(source);
-    }
-    if (converter != null) {
-      return converter.convert(context, source, sourceContext);
     }
 
     throw new ConversionException(source.getClass(), type);

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
@@ -29,6 +29,7 @@
 package com.impossibl.postgres.system.procs;
 
 import com.impossibl.postgres.system.Context;
+import com.impossibl.postgres.system.ConversionException;
 import com.impossibl.postgres.types.Type;
 
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class Numerics extends SimpleProcProvider {
     return value ? BigDecimal.ONE : BigDecimal.ZERO;
   }
 
-  private static Number convertInput(Number source) {
+  private static Number convertInput(Number source) throws ConversionException {
 
     if (source instanceof BigDecimal) {
       return source;
@@ -92,16 +93,22 @@ public class Numerics extends SimpleProcProvider {
 
     if (source instanceof Float) {
       Float source1 = (Float) source;
-      if (source1.isNaN() || source1.isInfinite()) {
+      if (source1.isNaN()) {
         return source1.doubleValue();
+      }
+      if (source1.isInfinite()) {
+        throw new ConversionException("Numeric types cannot represent +/- infinity");
       }
       return BigDecimal.valueOf(source1);
     }
 
     if (source instanceof Double) {
       Double source1 = (Double) source;
-      if (source1.isNaN() || source1.isInfinite()) {
+      if (source1.isNaN()) {
         return source1;
+      }
+      if (source1.isInfinite()) {
+        throw new ConversionException("Numeric types cannot represent +/- infinity");
       }
       return BigDecimal.valueOf(source1);
     }

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
@@ -534,6 +534,97 @@ public class PreparedStatementTest {
   }
 
   @Test
+  public void testSetDecimalIntObject() throws SQLException {
+    PreparedStatement pstmt = conn.prepareStatement("CREATE temp TABLE dec_tab (max_val decimal, min_val decimal, null_val decimal)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    Integer maxInteger = 2147483647, minInteger = -2147483648;
+    Double maxFloat = 2147483647d, minFloat = -2147483648d;
+
+    pstmt = conn.prepareStatement("insert into dec_tab values (?,?,?)");
+    pstmt.setObject(1, maxInteger);
+    pstmt.setObject(2, minInteger);
+    pstmt.setNull(3, Types.INTEGER);
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("select * from dec_tab");
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+
+    assertEquals("expected " + maxFloat + " ,received " + rs.getObject(1), rs.getObject(1), BigDecimal.valueOf(maxFloat));
+    assertEquals("expected " + minFloat + " ,received " + rs.getObject(2), rs.getObject(2), BigDecimal.valueOf(minFloat));
+    rs.getFloat(3);
+    assertTrue(rs.wasNull());
+    rs.close();
+    pstmt.close();
+
+  }
+
+  @Test
+  public void testSetDecimalDoubleNan() throws SQLException {
+    PreparedStatement pstmt = conn.prepareStatement("CREATE temp TABLE dec_tab (nan_val decimal)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("insert into dec_tab values (?)");
+    pstmt.setObject(1, Double.NaN);
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("select * from dec_tab");
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+
+    assertEquals("expected NaN ,received " + rs.getObject(1), rs.getObject(1), Double.NaN);
+    rs.close();
+    pstmt.close();
+
+  }
+
+  @Test
+  public void testSetDecimalFloatNan() throws SQLException {
+    PreparedStatement pstmt = conn.prepareStatement("CREATE temp TABLE dec_tab (nan_val decimal)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("insert into dec_tab values (?)");
+    pstmt.setObject(1, Float.NaN);
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("select * from dec_tab");
+    ResultSet rs = pstmt.executeQuery();
+    assertTrue(rs.next());
+
+    assertEquals("expected NaN ,received " + rs.getObject(1), rs.getObject(1), Double.NaN);
+    rs.close();
+    pstmt.close();
+
+  }
+
+  @Test(expected = SQLException.class)
+  public void testSetDecimalDoubleInfinity() throws SQLException {
+    PreparedStatement pstmt = conn.prepareStatement("CREATE temp TABLE dec_tab (nan_val decimal)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("insert into dec_tab values (?)");
+    pstmt.setObject(1, Double.POSITIVE_INFINITY);
+  }
+
+  @Test(expected = SQLException.class)
+  public void testSetDecimalFloatInfinity() throws SQLException {
+    PreparedStatement pstmt = conn.prepareStatement("CREATE temp TABLE dec_tab (nan_val decimal)");
+    pstmt.executeUpdate();
+    pstmt.close();
+
+    pstmt = conn.prepareStatement("insert into dec_tab values (?)");
+    pstmt.setObject(1, Float.POSITIVE_INFINITY);
+  }
+
+  @Test
   public void testSetFloatInteger() throws SQLException {
     PreparedStatement pstmt = conn.prepareStatement("CREATE temp TABLE float_tab (max_val float8, min_val float, null_val float8)");
     pstmt.executeUpdate();


### PR DESCRIPTION
* Fixes issue where numerics from `setObject` was throwing exception
* Adds tests for `NaN` storage and retrieval
* Disallows `+/- infinity` and adds tests