### PR TITLE
Fix bug with converting LocalTime.MIN

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
@@ -228,7 +228,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
         micros = Long.MAX_VALUE;
       }
       else if (time.equals(LocalTime.MIN)) {
-        micros = Long.MIN_VALUE;
+        micros = 0L;
       }
       else {
         // Convert to micros rounding nanoseconds

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
@@ -33,11 +33,6 @@ import com.impossibl.postgres.system.ConversionException;
 import com.impossibl.postgres.system.ServerInfo;
 import com.impossibl.postgres.types.Type;
 
-import static com.impossibl.postgres.system.procs.DatesTimes.JAVA_DATE_NEGATIVE_INFINITY_MSECS;
-import static com.impossibl.postgres.system.procs.DatesTimes.JAVA_DATE_POSITIVE_INFINITY_MSECS;
-import static com.impossibl.postgres.system.procs.DatesTimes.NEG_INFINITY;
-import static com.impossibl.postgres.system.procs.DatesTimes.POS_INFINITY;
-
 import java.io.IOException;
 import java.sql.Date;
 import java.sql.Time;
@@ -79,9 +74,6 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
     if (value instanceof CharSequence) {
       CharSequence chars = (CharSequence) value;
 
-      if (value.equals(POS_INFINITY)) return LocalTime.MAX;
-      if (value.equals(NEG_INFINITY)) return LocalTime.MIN;
-
       TemporalAccessor parsed = context.getTimeFormat().getParser().parse(chars);
 
       ZoneOffset offset =
@@ -96,58 +88,20 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
 
     if (value instanceof Time) {
       Time t = (Time) value;
-      if (t.getTime() == JAVA_DATE_POSITIVE_INFINITY_MSECS) return LocalTime.MAX;
-      if (t.getTime() == JAVA_DATE_NEGATIVE_INFINITY_MSECS) return LocalTime.MIN;
-
       return Instant.ofEpochMilli(t.getTime()).atZone(sourceCalendar.getTimeZone().toZoneId()).toLocalTime();
     }
 
     if (value instanceof Date) {
-      java.sql.Date d = (java.sql.Date) value;
-      if (d.getTime() == JAVA_DATE_POSITIVE_INFINITY_MSECS) return LocalTime.MAX;
-      if (d.getTime() == JAVA_DATE_NEGATIVE_INFINITY_MSECS) return LocalTime.MIN;
-
+      Date d = (Date) value;
       return Instant.ofEpochMilli(d.getTime()).atZone(sourceCalendar.getTimeZone().toZoneId()).toLocalTime();
     }
 
     if (value instanceof Timestamp) {
       Timestamp ts = (Timestamp) value;
-      if (ts.getTime() == JAVA_DATE_POSITIVE_INFINITY_MSECS) return LocalTime.MAX;
-      if (ts.getTime() == JAVA_DATE_NEGATIVE_INFINITY_MSECS) return LocalTime.MIN;
-
       return ts.toInstant().atZone(sourceCalendar.getTimeZone().toZoneId()).toLocalTime();
     }
 
     throw new ConversionException(value.getClass(), type);
-  }
-
-  private static Object convertInfinityOutput(boolean positive, Type type, Class<?> targetClass) throws ConversionException {
-
-    if (targetClass == LocalTime.class) {
-      return positive ? LocalTime.MAX : LocalTime.MIN;
-    }
-
-    if (targetClass == OffsetTime.class) {
-      return positive ? OffsetTime.MAX : OffsetTime.MIN;
-    }
-
-    if (targetClass == String.class) {
-      return positive ? POS_INFINITY : NEG_INFINITY;
-    }
-
-    if (targetClass == Time.class) {
-      return new Time(positive ? JAVA_DATE_POSITIVE_INFINITY_MSECS : JAVA_DATE_NEGATIVE_INFINITY_MSECS);
-    }
-
-    if (targetClass == Date.class) {
-      return new Date(positive ? JAVA_DATE_POSITIVE_INFINITY_MSECS : JAVA_DATE_NEGATIVE_INFINITY_MSECS);
-    }
-
-    if (targetClass == Timestamp.class) {
-      return new Timestamp(positive ? JAVA_DATE_POSITIVE_INFINITY_MSECS : JAVA_DATE_NEGATIVE_INFINITY_MSECS);
-    }
-
-    throw new ConversionException(type, targetClass);
   }
 
   private static Object convertOutput(Context context, Type type, LocalTime time, Class<?> targetClass, Calendar targetCalendar) throws ConversionException {
@@ -199,10 +153,6 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
 
       long micros = buffer.readLong();
 
-      if (micros == Long.MAX_VALUE || micros == Long.MIN_VALUE) {
-        return convertInfinityOutput(micros == Long.MAX_VALUE, type, targetClass);
-      }
-
       LocalTime time = LocalTime.ofNanoOfDay(MICROSECONDS.toNanos(micros));
 
       return convertOutput(context, type, time, targetClass, calendar);
@@ -223,17 +173,8 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
 
       LocalTime time = convertInput(context, type, value, calendar);
 
-      long micros;
-      if (time.equals(LocalTime.MAX)) {
-        micros = Long.MAX_VALUE;
-      }
-      else if (time.equals(LocalTime.MIN)) {
-        micros = 0L;
-      }
-      else {
-        // Convert to micros rounding nanoseconds
-        micros = NANOSECONDS.toMicros(time.toNanoOfDay() + 500) % DAYS.toMicros(1);
-      }
+      // Convert to micros rounding nanoseconds
+      long micros = NANOSECONDS.toMicros(time.toNanoOfDay() + 500) % DAYS.toMicros(1);
 
       buffer.writeLong(micros);
     }
@@ -270,19 +211,9 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
 
       LocalTime time = convertInput(context, type, value, calendar);
 
-      if (time.equals(LocalTime.MAX)) {
-        buffer.append(POS_INFINITY);
-      }
-      else if (time.equals(LocalTime.MIN)) {
-        buffer.append(NEG_INFINITY);
-      }
-      else {
+      String strVal = context.getTimeFormat().getPrinter().format(time);
 
-        String strVal = context.getTimeFormat().getPrinter().format(time);
-
-        buffer.append(strVal);
-      }
-
+      buffer.append(strVal);
     }
 
   }

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/shared/GetObject310Test.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/shared/GetObject310Test.java
@@ -68,17 +68,15 @@ public class GetObject310Test {
    */
   @Test
   public void testGetLocalDate() throws SQLException {
-    Statement stmt = con.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","date_column","DATE '1999-01-08'"));
+    try (Statement stmt = con.createStatement()) {
+      stmt.executeUpdate(TestUtil.insertSQL("table1", "date_column", "DATE '1999-01-08'"));
 
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "date_column"));
-    try {
-      assertTrue(rs.next());
-      LocalDate localDate = LocalDate.of(1999, 1, 8);
-      assertEquals(localDate, rs.getObject("date_column", LocalDate.class));
-      assertEquals(localDate, rs.getObject(1, LocalDate.class));
-    } finally {
-      rs.close();
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "date_column"))) {
+        assertTrue(rs.next());
+        LocalDate localDate = LocalDate.of(1999, 1, 8);
+        assertEquals(localDate, rs.getObject("date_column", LocalDate.class));
+        assertEquals(localDate, rs.getObject(1, LocalDate.class));
+      }
     }
   }
 
@@ -87,17 +85,22 @@ public class GetObject310Test {
    */
   @Test
   public void testGetLocalTime() throws SQLException {
-    Statement stmt = con.createStatement();
-    stmt.executeUpdate(TestUtil.insertSQL("table1","time_without_time_zone_column","TIME '04:05:06.123456'"));
+    try (Statement stmt = con.createStatement()) {
+      stmt.executeUpdate(TestUtil.insertSQL("table1", "time_without_time_zone_column", "TIME '04:05:06.123456'"));
+      stmt.executeUpdate(TestUtil.insertSQL("table1", "time_without_time_zone_column", "TIME '00:00:00'"));
+      stmt.executeUpdate(TestUtil.insertSQL("table1", "time_without_time_zone_column", "TIME '23:59:59.999999'"));
+      stmt.executeUpdate(TestUtil.insertSQL("table1", "time_without_time_zone_column", "TIME '23:59:59.9999999'"));
 
-    ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"));
-    try {
-      assertTrue(rs.next());
-      LocalTime localTime = LocalTime.of(4, 5, 6, 123456000);
-      assertEquals(localTime, rs.getObject("time_without_time_zone_column", LocalTime.class));
-      assertEquals(localTime, rs.getObject(1, LocalTime.class));
-    } finally {
-      rs.close();
+      try (ResultSet rs = stmt.executeQuery(TestUtil.selectSQL("table1", "time_without_time_zone_column"))) {
+        assertTrue(rs.next());
+        assertEquals(LocalTime.of(4, 5, 6, 123456000), rs.getObject(1, LocalTime.class));
+        assertTrue(rs.next());
+        assertEquals(LocalTime.MIN, rs.getObject(1, LocalTime.class));
+        assertTrue(rs.next());
+        assertEquals(LocalTime.of(23, 59, 59, 999999000), rs.getObject(1, LocalTime.class));
+        assertTrue(rs.next());
+        assertEquals(LocalTime.MIN, rs.getObject(1, LocalTime.class));
+      }
     }
   }
 

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/shared/SetObject310Test.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/shared/SetObject310Test.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.chrono.IsoChronology;
@@ -369,12 +370,23 @@ public class SetObject310Test {
    */
   @Test
   public void testSetLocalTimeAndReadBack() throws SQLException {
-    LocalTime data = LocalTime.parse("16:21:51.123456");
+    String test = "16:21:51.123456";
 
-    insertWithoutType(data, "time_without_time_zone_column");
+    insertWithoutType(LocalTime.parse(test), "time_without_time_zone_column");
+    assertEquals(test, readString("time_without_time_zone_column"));
+    deleteRows();
 
-    String readBack = readString("time_without_time_zone_column");
-    assertEquals("16:21:51.123456", readBack);
+    insertWithoutType(LocalTime.MIN, "time_without_time_zone_column");
+    assertEquals("00:00:00", readString("time_without_time_zone_column"));
+    deleteRows();
+
+    insertWithoutType(LocalTime.MAX, "time_without_time_zone_column");
+    assertEquals("00:00:00", readString("time_without_time_zone_column"));
+    deleteRows();
+
+    insertWithoutType(LocalTime.MAX.withNano(999999000), "time_without_time_zone_column");
+    assertEquals("23:59:59.999999", readString("time_without_time_zone_column"));
+    deleteRows();
   }
 
   /**
@@ -397,6 +409,30 @@ public class SetObject310Test {
     Time actual = insertThenReadWithoutType(data, "time_without_time_zone_column", Time.class);
     Time expected = Time.valueOf("16:21:51");
     assertEquals(expected, actual);
+  }
+
+  /**
+   * Test the behavior setObject for time with tz columns.
+   */
+  @Test
+  public void testSetOffsetTimeAndReadBack() throws SQLException {
+    String test = "16:21:51.123456+02:00";
+
+    insertWithoutType(OffsetTime.parse(test), "time_with_time_zone_column");
+    assertEquals(test.substring(0, test.length()-3), readString("time_with_time_zone_column"));
+    deleteRows();
+
+    insertWithoutType(LocalTime.MIN.atOffset(ZoneOffset.ofHoursMinutesSeconds(15,59,59)), "time_with_time_zone_column");
+    assertEquals("00:00:00+15:59:59", readString("time_with_time_zone_column"));
+    deleteRows();
+
+    insertWithoutType(LocalTime.MAX.atOffset(ZoneOffset.ofHoursMinutesSeconds(-15, -59, -59)), "time_with_time_zone_column");
+    assertEquals("00:00:00-15:59:59", readString("time_with_time_zone_column"));
+    deleteRows();
+
+    insertWithoutType(LocalTime.MAX.withNano(999999000).atOffset(ZoneOffset.ofHours(5)), "time_with_time_zone_column");
+    assertEquals("23:59:59.999999+05", readString("time_with_time_zone_column"));
+    deleteRows();
   }
 
 }


### PR DESCRIPTION
long is unsigned in java, so `MIN_VALUE` is some negative numer. `0L` should be used instead as a minimum value.