### PR TITLE
Fix UDT generator documentation

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/udt-generator.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/udt-generator.adoc
@@ -10,8 +10,8 @@ the matching classes.
 
 === Generation
 
-The generator can generate _POJOs_ for composite types and enum classes for enumeration types. A simple example
-can be seen in this <<udt-generator-example>>.
+The generator can generate _POJOs_ for composite types and enum classes for enumeration types as well as mapping
+to standard Java types for all other supported types.
 
 ==== Referencing/Nested Types
 
@@ -20,7 +20,7 @@ The generator supports generating classes for SQL types that reference/contain o
 If the referenced type(s) have POJOs or enums being generated during the same execution, the generator will use
 the generated type value instead of the standard mapping.
 
-If not, composite types will be created as `java.sql.Struct`s and enums will be created as ``String``s.
+If not, composite types will be created as ``java.sql.Struct``s and enums will be created as ``String``s.
 
 === Executing
 
@@ -85,11 +85,13 @@ import java.io.File;
 
 class ExecGen {
   public static void executeGenerator(Connection connection, List<String> typeNames) {
-    UDTGenerator.generate(connection, new File("out"), "sql.schema.types", typeNames);
+    new UDTGenerator(connection, "sql.schema.types", typeNames)
+        .generate(new File("out"));
   }
 }
 ----
 
+[[udt-generator-example]]
 ==== Example
 
 [source,sql]

--- a/udt-gen/build.gradle.kts
+++ b/udt-gen/build.gradle.kts
@@ -24,6 +24,6 @@ dependencies {
 
 apply {
   from("src/build/testing.gradle.kts")
-  from("$rootDir/shared/src/build/uber-packaging.gradle.kts")
+  from("src/build/uber-packaging.gradle.kts")
   from("$rootDir/shared/src/build/publishing.gradle.kts")
 }

--- a/udt-gen/src/build/uber-packaging.gradle.kts
+++ b/udt-gen/src/build/uber-packaging.gradle.kts
@@ -1,0 +1,25 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+buildscript {
+  repositories { gradlePluginPortal() }
+  dependencies {
+    classpath("com.github.jengelman.gradle.plugins:shadow:${Versions.shadowPlugin}")
+  }
+}
+
+
+apply { from("$rootDir/shared/src/build/uber-packaging.gradle.kts") }
+
+
+/**
+ * UBER JAR
+ */
+
+tasks.named<ShadowJar>("uberJar") {
+  manifest {
+    from()
+    attributes(mapOf(
+       "Main-Class" to "com.impossibl.postgres.tools.UDTGenerator"
+    ))
+  }
+}


### PR DESCRIPTION
Ensures the docs are correct for programmatic generation and also adds `Main-Class` attribute to the uber jar; as was documented.

Fixes #400 