### PR TITLE
Do not require BackendKeyData (#424)

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/CancelRequestTask.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/CancelRequestTask.java
@@ -44,10 +44,13 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.util.logging.Logger;
 
 import io.netty.channel.unix.DomainSocketAddress;
 
 public class CancelRequestTask extends ExecutionTimerTask {
+
+  private static final Logger logger = Logger.getLogger(CancelRequestTask.class.getName());
 
   private SocketAddress serverAddress;
   private ServerConnection.KeyData keyData;
@@ -63,6 +66,11 @@ public class CancelRequestTask extends ExecutionTimerTask {
   }
 
   private void sendCancelRequest() {
+
+    if (keyData.getProcessId() == 0 && keyData.getSecretKey() == 0) {
+      logger.warning("Cannot send CancelRequest because of missing BackendKeyData.");
+      return;
+    }
 
     try {
 

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnectionFactory.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnectionFactory.java
@@ -495,7 +495,7 @@ public class ServerConnectionFactory implements com.impossibl.postgres.protocol.
       }
 
       @Override
-      public void handleComplete(Integer processId, Integer secretKey, Map<String, String> parameterStatuses, List<Notice> notices) {
+      public void handleComplete(int processId, int secretKey, Map<String, String> parameterStatuses, List<Notice> notices) {
 
         startupParameterStatuses.putAll(parameterStatuses);
         startupKeyData.set(new KeyData(processId, secretKey));

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/StartupRequest.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/StartupRequest.java
@@ -63,7 +63,7 @@ public class StartupRequest implements ServerRequest {
 
     void handleNegotiate(Version maxProtocolVersion, List<String> unrecognizedParameters) throws IOException;
 
-    void handleComplete(Integer processId, Integer secretKey, Map<String, String> parameterStatuses, List<Notice> notices) throws IOException;
+    void handleComplete(int processId, int secretKey, Map<String, String> parameterStatuses, List<Notice> notices) throws IOException;
     void handleError(Throwable cause, List<Notice> notices) throws IOException;
 
   }
@@ -71,8 +71,8 @@ public class StartupRequest implements ServerRequest {
   private Version protocolVersion;
   private Map<String, Object> startupParameters;
   private CompletionHandler handler;
-  private Integer backendProcessId;
-  private Integer backendSecretKey;
+  private int backendProcessId;
+  private int backendSecretKey;
   private Map<String, String> parameterStatuses;
   private List<Notice> notices;
 


### PR DESCRIPTION
Some databases, such as CockroachDB, do not send BackendKeyData on
connection initialization. Previously, the ServerConnectionFactory would
assume that BackendKeyData would always be present which caused a
NullPointerException. Now, the BackendKeyData defaults to 0 instead of
null.

closes #424