### PR TITLE
Proper handling of client/server locales

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/system/Context.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/Context.java
@@ -34,7 +34,6 @@ import com.impossibl.postgres.protocol.ServerConnection;
 import com.impossibl.postgres.types.Registry;
 
 import java.nio.charset.Charset;
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.time.ZoneId;
 import java.util.Map;
@@ -60,17 +59,20 @@ public interface Context extends Configuration {
 
   ServerConnection.KeyData getKeyData();
 
-  NumberFormat getIntegerFormatter();
+  NumberFormat getClientIntegerFormatter();
+  NumberFormat getClientDecimalFormatter();
 
-  DecimalFormat getDecimalFormatter();
+  NumberFormat getServerCurrencyFormatter();
+  NumberFormat getClientCurrencyFormatter();
 
-  DecimalFormat getCurrencyFormatter();
+  DateTimeFormat getServerDateFormat();
+  DateTimeFormat getClientDateFormat();
 
-  DateTimeFormat getDateFormat();
+  DateTimeFormat getServerTimeFormat();
+  DateTimeFormat getClientTimeFormat();
 
-  DateTimeFormat getTimeFormat();
-
-  DateTimeFormat getTimestampFormat();
+  DateTimeFormat getServerTimestampFormat();
+  DateTimeFormat getClientTimestampFormat();
 
   Map<String, Class<?>> getCustomTypeMap();
 

--- a/driver/src/main/java/com/impossibl/postgres/system/DecoratorContext.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/DecoratorContext.java
@@ -34,7 +34,6 @@ import com.impossibl.postgres.protocol.ServerConnection;
 import com.impossibl.postgres.types.Registry;
 
 import java.nio.charset.Charset;
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.time.ZoneId;
 import java.util.Map;
@@ -83,33 +82,53 @@ class DecoratorContext extends AbstractContext {
   }
 
   @Override
-  public DateTimeFormat getDateFormat() {
-    return base.getDateFormat();
+  public DateTimeFormat getServerDateFormat() {
+    return base.getServerDateFormat();
   }
 
   @Override
-  public DateTimeFormat getTimeFormat() {
-    return base.getTimeFormat();
+  public DateTimeFormat getClientDateFormat() {
+    return base.getClientDateFormat();
   }
 
   @Override
-  public NumberFormat getIntegerFormatter() {
-    return base.getIntegerFormatter();
+  public DateTimeFormat getServerTimeFormat() {
+    return base.getServerTimeFormat();
   }
 
   @Override
-  public DateTimeFormat getTimestampFormat() {
-    return base.getTimestampFormat();
+  public DateTimeFormat getClientTimeFormat() {
+    return base.getClientTimeFormat();
   }
 
   @Override
-  public DecimalFormat getDecimalFormatter() {
-    return base.getDecimalFormatter();
+  public DateTimeFormat getServerTimestampFormat() {
+    return base.getServerTimestampFormat();
   }
 
   @Override
-  public DecimalFormat getCurrencyFormatter() {
-    return base.getCurrencyFormatter();
+  public DateTimeFormat getClientTimestampFormat() {
+    return base.getClientTimestampFormat();
+  }
+
+  @Override
+  public NumberFormat getClientIntegerFormatter() {
+    return base.getClientIntegerFormatter();
+  }
+
+  @Override
+  public NumberFormat getClientDecimalFormatter() {
+    return base.getClientDecimalFormatter();
+  }
+
+  @Override
+  public NumberFormat getServerCurrencyFormatter() {
+    return base.getServerCurrencyFormatter();
+  }
+
+  @Override
+  public NumberFormat getClientCurrencyFormatter() {
+    return base.getClientCurrencyFormatter();
   }
 
   @Override

--- a/driver/src/main/java/com/impossibl/postgres/system/JavaTypeMapping.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/JavaTypeMapping.java
@@ -179,7 +179,7 @@ public class JavaTypeMapping {
     String typeName = sqlDataTypeNameMap.get(cls);
     if (typeName == null) {
       try {
-        typeName = cls.asSubclass(SQLData.class).newInstance().getSQLTypeName();
+        typeName = cls.getConstructor().newInstance().getSQLTypeName();
       }
       catch (Exception e) {
         throw new IOException("Unable to determine type of SQLData; a no-arg constructor is required");

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Dates.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Dates.java
@@ -85,7 +85,7 @@ public class Dates extends SimpleProcProvider {
       if (s.equals(POS_INFINITY)) return LocalDate.MAX;
       if (s.equals(NEG_INFINITY)) return LocalDate.MIN;
 
-      TemporalAccessor parsed = context.getDateFormat().getParser().parse(s);
+      TemporalAccessor parsed = context.getClientDateFormat().getParser().parse(s);
 
       return LocalDate.from(parsed);
     }
@@ -121,7 +121,7 @@ public class Dates extends SimpleProcProvider {
     }
 
     if (targetClass == String.class) {
-      return context.getDateFormat().getPrinter().format(date);
+      return context.getClientDateFormat().getPrinter().format(date);
     }
 
     if (targetClass == Timestamp.class) {
@@ -214,7 +214,7 @@ public class Dates extends SimpleProcProvider {
         return convertInfinityOutput(buffer.equals(POS_INFINITY), type, targetClass);
       }
 
-      TemporalAccessor parsed = context.getDateFormat().getParser().parse(buffer);
+      TemporalAccessor parsed = context.getServerDateFormat().getParser().parse(buffer);
 
       LocalDate date = LocalDate.from(parsed);
 
@@ -240,7 +240,7 @@ public class Dates extends SimpleProcProvider {
       }
       else {
 
-        String strVal = context.getDateFormat().getPrinter().format(date);
+        String strVal = context.getServerDateFormat().getPrinter().format(date);
 
         buffer.append(strVal);
       }

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Int2Vectors.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Int2Vectors.java
@@ -73,7 +73,7 @@ public class Int2Vectors extends SimpleProcProvider {
         String[] items = buffer.toString().split(" ");
         values = new Short[items.length];
         for (int c = 0; c < items.length; ++c) {
-          values[c] = Short.parseShort(items[c]);
+          values[c] = Short.valueOf(items[c]);
         }
       }
 

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/NumericDecoders.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/NumericDecoders.java
@@ -29,20 +29,16 @@
 package com.impossibl.postgres.system.procs;
 
 import com.impossibl.postgres.system.Context;
+import com.impossibl.postgres.system.ConversionException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.function.Function;
 
 
 abstract class NumericBinaryDecoder<N extends Number> extends AutoConvertingBinaryDecoder<N> {
 
-  protected NumericBinaryDecoder(Integer requiredLength) {
-    this(requiredLength, Number::toString);
-  }
-
-  protected NumericBinaryDecoder(Integer requiredLength, Function<N, String> converter) {
+  protected NumericBinaryDecoder(Integer requiredLength, ContextConversionFunction<N, String> converter) {
     super(requiredLength, new NumericDecodingConverter<>(converter));
   }
 
@@ -50,29 +46,25 @@ abstract class NumericBinaryDecoder<N extends Number> extends AutoConvertingBina
 
 abstract class NumericTextDecoder<N extends Number> extends AutoConvertingTextDecoder<N> {
 
-  protected NumericTextDecoder(Function<N, String> converter) {
+  protected NumericTextDecoder(ContextConversionFunction<N, String> converter) {
     super(new NumericDecodingConverter<>(converter));
-  }
-
-  protected NumericTextDecoder(Converter<N> converter) {
-    super(converter);
   }
 
 }
 
 class NumericDecodingConverter<N extends Number> implements AutoConvertingDecoder.Converter<N> {
 
-  private Function<N, String> stringConverter;
+  private ContextConversionFunction<N, String> stringConverter;
 
-  NumericDecodingConverter(Function<N, String> stringConverter) {
+  NumericDecodingConverter(ContextConversionFunction<N, String> stringConverter) {
     this.stringConverter = stringConverter;
   }
 
   @Override
-  public Object convert(Context context, N decoded, Class<?> targetClass, Object targetContext) {
+  public Object convert(Context context, N decoded, Class<?> targetClass, Object targetContext) throws ConversionException {
 
     if (targetClass == String.class) {
-      return stringConverter.apply(decoded);
+      return stringConverter.apply(context, decoded);
     }
 
     if (targetClass == BigDecimal.class) {

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/NumericEncoders.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/NumericEncoders.java
@@ -37,9 +37,15 @@ interface ConversionFunction<T, R> {
 
 }
 
+interface ContextConversionFunction<T, R> {
+
+  R apply(Context context, T t) throws ConversionException;
+
+}
+
 abstract class NumericBinaryEncoder<N extends Number> extends AutoConvertingBinaryEncoder<N> {
 
-  protected NumericBinaryEncoder(Integer binaryLength, ConversionFunction<String, N> stringCast, ConversionFunction<Boolean, N> boolCast, ConversionFunction<Number, N> numberCast) {
+  protected NumericBinaryEncoder(Integer binaryLength, ContextConversionFunction<String, N> stringCast, ConversionFunction<Boolean, N> boolCast, ConversionFunction<Number, N> numberCast) {
     super(binaryLength, new NumericEncodingConverter<>(stringCast, boolCast, numberCast));
   }
 
@@ -47,7 +53,7 @@ abstract class NumericBinaryEncoder<N extends Number> extends AutoConvertingBina
 
 abstract class NumericTextEncoder<N extends Number> extends AutoConvertingTextEncoder<N> {
 
-  protected NumericTextEncoder(ConversionFunction<String, N> stringCast, ConversionFunction<Boolean, N> boolCast, ConversionFunction<Number, N> numberCast) {
+  protected NumericTextEncoder(ContextConversionFunction<String, N> stringCast, ConversionFunction<Boolean, N> boolCast, ConversionFunction<Number, N> numberCast) {
     super(new NumericEncodingConverter<>(stringCast, boolCast, numberCast));
   }
 
@@ -55,11 +61,11 @@ abstract class NumericTextEncoder<N extends Number> extends AutoConvertingTextEn
 
 class NumericEncodingConverter<N extends Number> implements AutoConvertingEncoder.Converter<N> {
 
-  private ConversionFunction<String, N> stringCast;
+  private ContextConversionFunction<String, N> stringCast;
   private ConversionFunction<Boolean, N> boolCast;
   private ConversionFunction<Number, N> numberCast;
 
-  NumericEncodingConverter(ConversionFunction<String, N> stringCast, ConversionFunction<Boolean, N> boolCast, ConversionFunction<Number, N> numberCast) {
+  NumericEncodingConverter(ContextConversionFunction<String, N> stringCast, ConversionFunction<Boolean, N> boolCast, ConversionFunction<Number, N> numberCast) {
     this.stringCast = stringCast;
     this.boolCast = boolCast;
     this.numberCast = numberCast;
@@ -69,7 +75,7 @@ class NumericEncodingConverter<N extends Number> implements AutoConvertingEncode
   public N convert(Context context, Object source, Object sourceContext) throws ConversionException {
 
     if (source instanceof String) {
-      return stringCast.apply((String) source);
+      return stringCast.apply(context, (String) source);
     }
 
     if (source instanceof Boolean) {

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Numerics.java
@@ -52,7 +52,7 @@ public class Numerics extends SimpleProcProvider {
     super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "numeric_");
   }
 
-  private static Number convertStringInput(String value) {
+  private static Number convertStringInput(Context context, String value) throws ConversionException {
     if (value.equalsIgnoreCase("NaN")) {
       return Double.NaN;
     }
@@ -62,7 +62,12 @@ public class Numerics extends SimpleProcProvider {
     if (value.equalsIgnoreCase("-infinity")) {
       return Double.POSITIVE_INFINITY;
     }
-    return new BigDecimal(value);
+    try {
+      return context.getClientDecimalFormatter().parse(value);
+    }
+    catch (ParseException e) {
+      throw new ConversionException("Invalid Numeric Value", e);
+    }
   }
 
   private static BigDecimal convertBoolInput(Boolean value) {
@@ -116,8 +121,8 @@ public class Numerics extends SimpleProcProvider {
     return null;
   }
 
-  private static String convertStringOutput(Number value) {
-    return value.toString();
+  private static String convertStringOutput(Context context, Number value) {
+    return context.getClientDecimalFormatter().format(value);
   }
 
   static class BinDecoder extends NumericBinaryDecoder<Number> {
@@ -222,7 +227,7 @@ public class Numerics extends SimpleProcProvider {
 
     @Override
     protected Number decodeNativeValue(Context context, Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Class<?> targetClass, Object targetContext) throws IOException, ParseException {
-      return context.getDecimalFormatter().parse(buffer.toString());
+      return new BigDecimal(buffer.toString());
     }
 
   }
@@ -240,7 +245,7 @@ public class Numerics extends SimpleProcProvider {
 
     @Override
     protected void encodeNativeValue(Context context, Type type, Number value, Object sourceContext, StringBuilder buffer) throws IOException {
-      buffer.append(context.getDecimalFormatter().format(value));
+      buffer.append(value);
     }
 
   }

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithTZ.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithTZ.java
@@ -83,7 +83,7 @@ public class TimesWithTZ extends SettingSelectProcProvider {
     if (value instanceof CharSequence) {
       CharSequence chars = (CharSequence) value;
 
-      TemporalAccessor parsed = context.getTimeFormat().getParser().parse(chars);
+      TemporalAccessor parsed = context.getClientTimeFormat().getParser().parse(chars);
 
       if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
         return OffsetTime.from(parsed);
@@ -119,7 +119,7 @@ public class TimesWithTZ extends SettingSelectProcProvider {
     }
 
     if (targetClass == String.class) {
-      return context.getTimeFormat().getPrinter().format(time);
+      return context.getClientTimeFormat().getPrinter().format(time);
     }
 
     if (targetClass == Time.class) {
@@ -202,7 +202,7 @@ public class TimesWithTZ extends SettingSelectProcProvider {
 
       Calendar calendar = targetContext != null ? (Calendar) targetContext : Calendar.getInstance();
 
-      TemporalAccessor parsed = context.getTimeFormat().getParser().parse(buffer);
+      TemporalAccessor parsed = context.getServerTimeFormat().getParser().parse(buffer);
 
       OffsetTime time;
       if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
@@ -236,7 +236,7 @@ public class TimesWithTZ extends SettingSelectProcProvider {
       }
       else {
 
-        String strVal = context.getTimeFormat().getPrinter().format(time);
+        String strVal = context.getServerTimeFormat().getPrinter().format(time);
 
         buffer.append(strVal);
       }

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/TimesWithoutTZ.java
@@ -74,7 +74,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
     if (value instanceof CharSequence) {
       CharSequence chars = (CharSequence) value;
 
-      TemporalAccessor parsed = context.getTimeFormat().getParser().parse(chars);
+      TemporalAccessor parsed = context.getClientTimeFormat().getParser().parse(chars);
 
       ZoneOffset offset =
           ZoneOffset.ofTotalSeconds((int) MILLISECONDS.toSeconds(sourceCalendar.getTimeZone().getRawOffset()));
@@ -117,7 +117,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
     }
 
     if (targetClass == String.class) {
-      return context.getTimeFormat().getPrinter().format(time);
+      return context.getClientTimeFormat().getPrinter().format(time);
     }
 
     if (targetClass == Time.class) {
@@ -193,7 +193,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
 
       Calendar calendar = targetContext != null ? (Calendar) targetContext : Calendar.getInstance();
 
-      TemporalAccessor parsed = context.getTimeFormat().getParser().parse(buffer);
+      TemporalAccessor parsed = context.getServerTimeFormat().getParser().parse(buffer);
 
       LocalTime time = LocalTime.from(parsed);
 
@@ -211,7 +211,7 @@ public class TimesWithoutTZ extends SettingSelectProcProvider {
 
       LocalTime time = convertInput(context, type, value, calendar);
 
-      String strVal = context.getTimeFormat().getPrinter().format(time);
+      String strVal = context.getServerTimeFormat().getPrinter().format(time);
 
       buffer.append(strVal);
     }

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/TimestampsWithTZ.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/TimestampsWithTZ.java
@@ -82,7 +82,7 @@ public class TimestampsWithTZ extends SettingSelectProcProvider {
       if (value.equals(POS_INFINITY)) return OffsetDateTime.MAX;
       if (value.equals(NEG_INFINITY)) return OffsetDateTime.MIN;
 
-      TemporalAccessor parsed = context.getTimestampFormat().getParser().parse(chars);
+      TemporalAccessor parsed = context.getClientTimestampFormat().getParser().parse(chars);
 
       if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
         return OffsetDateTime.from(parsed);
@@ -147,7 +147,7 @@ public class TimestampsWithTZ extends SettingSelectProcProvider {
     }
 
     if (targetClass == String.class) {
-      return context.getTimestampFormat().getPrinter().format(dateTime);
+      return context.getClientTimestampFormat().getPrinter().format(dateTime);
     }
 
     ZoneId targetZoneId = targetCalendar.getTimeZone().toZoneId();
@@ -253,7 +253,7 @@ public class TimestampsWithTZ extends SettingSelectProcProvider {
         return convertInfinityOutput(buffer.equals(POS_INFINITY), type, targetClass);
       }
 
-      TemporalAccessor parsed = context.getTimestampFormat().getParser().parse(buffer);
+      TemporalAccessor parsed = context.getServerTimestampFormat().getParser().parse(buffer);
 
       ZonedDateTime dateTime;
       if (parsed.isSupported(ChronoField.OFFSET_SECONDS)) {
@@ -284,7 +284,7 @@ public class TimestampsWithTZ extends SettingSelectProcProvider {
       }
       else {
 
-        String strVal = context.getTimestampFormat().getPrinter().format(dateTime);
+        String strVal = context.getServerTimestampFormat().getPrinter().format(dateTime);
 
         buffer.append(strVal);
       }

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/TimestampsWithoutTZ.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/TimestampsWithoutTZ.java
@@ -81,7 +81,7 @@ public class TimestampsWithoutTZ extends SettingSelectProcProvider {
       if (value.equals(POS_INFINITY)) return LocalDateTime.MAX;
       if (value.equals(NEG_INFINITY)) return LocalDateTime.MIN;
 
-      TemporalAccessor parsed = context.getTimestampFormat().getParser().parse(chars);
+      TemporalAccessor parsed = context.getClientTimestampFormat().getParser().parse(chars);
 
       return LocalDateTime.from(parsed);
     }
@@ -151,7 +151,7 @@ public class TimestampsWithoutTZ extends SettingSelectProcProvider {
     }
 
     if (targetClass == String.class) {
-      return context.getTimestampFormat().getPrinter().format(dateTime);
+      return context.getClientTimestampFormat().getPrinter().format(dateTime);
     }
 
     ZoneId targetZoneId = targetCalendar.getTimeZone().toZoneId();
@@ -257,7 +257,7 @@ public class TimestampsWithoutTZ extends SettingSelectProcProvider {
         return convertInfinityOutput(buffer.equals(POS_INFINITY), type, targetClass);
       }
 
-      TemporalAccessor parsed = context.getTimestampFormat().getParser().parse(buffer);
+      TemporalAccessor parsed = context.getServerTimestampFormat().getParser().parse(buffer);
 
       LocalDateTime localDateTime = LocalDateTime.from(parsed);
 
@@ -283,7 +283,7 @@ public class TimestampsWithoutTZ extends SettingSelectProcProvider {
       }
       else {
 
-        String strVal = context.getTimestampFormat().getPrinter().format(dateTime);
+        String strVal = context.getServerTimestampFormat().getPrinter().format(dateTime);
 
         buffer.append(strVal);
       }

--- a/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
@@ -49,6 +49,8 @@ public class Locales {
    * @throws IllegalArgumentException in case of an invalid locale specification
    */
   public static Locale parseLocale(String localeValue) {
+    // Strip encoding/codepage
+    localeValue = localeValue.split("\\.", 2)[0];
 
     switch (localeValue.toUpperCase(Locale.ROOT)) {
       case "C":
@@ -84,8 +86,6 @@ public class Locales {
   }
 
   private static String[] tokenizeLocaleSource(String localeSource) {
-    // Strip encoding/codepage
-    localeSource = localeSource.split("\\.", 2)[0];
     return localeSource.split("_");
   }
 

--- a/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
@@ -112,7 +112,37 @@ public class Locales {
       country = "";
     }
 
+    if (!isISOLanguage(language) || !isISOCountry(country)) {
+      return null;
+    }
+
     return (language.length() > 0 ? new Locale(language, country, variant) : null);
+  }
+
+  private static boolean isISOCountry(String code) {
+    if (code.length() > 2) {
+      return false;
+    }
+    code = code.toUpperCase();
+    for (String isoCode : Locale.getISOCountries()) {
+      if (code.equals(isoCode)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isISOLanguage(String code) {
+    if (code.length() > 2) {
+      return false;
+    }
+    code = code.toLowerCase();
+    for (String isoCode : Locale.getISOLanguages()) {
+      if (code.equals(isoCode)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static void validateLocalePart(String localePart) {

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/ResultSetTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/ResultSetTest.java
@@ -488,7 +488,7 @@ public class ResultSetTest {
     while (rs.next()) {
       try {
         rs.getLong(1);
-        fail("Exception expected." + rs.getString(1));
+        fail("Exception expected. " + rs.getString(1));
       }
       catch (Exception e) {
         // Ok

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/StructTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/StructTest.java
@@ -139,7 +139,7 @@ public class StructTest {
     ts.str2 = "A second string";
 
     TestStructArray tsa = new TestStructArray(), tsa2;
-    tsa.values = new TestStruct[] { ts, nullts, null };
+    tsa.values = new TestStruct[] {ts, nullts, null};
 
     PreparedStatement pst = conn.prepareStatement("INSERT INTO struct_array_test VALUES (?)");
     pst.setObject(1, tsa);


### PR DESCRIPTION
## Overview
PostgreSQL’s text output is (mostly) never affected by the server’s locale. Previously the server locale was mapped and the client was using it to parse numeric and monetary values. This doesn’t work since the server always outputs in ‘C’ locale.

Secondarily JDBC has conversion requirements from String to numbers, dates, etc. These must be done in the JVM’s locale, or by an API specified locale when available.

## Solution
`Context` now users client & server specific formatters for integers, decimals, currency, dates, times and timestamps. All of the `Proc` encoders and decoders now use the correct formatting method based on where the string/text is coming from.

Server formatters are “locked” to the ‘C’/‘POSIX’ locale matching the server, usually utilitizing Java’s default parsing/formatting. The client formatters are initialized utilizing the JVM’s current locale during connection.

This has the effect of properly translating JDBC text input in non ‘C’ locales to/from their ‘C’ locale format required for PostgreSQL’s “text” value format.  This happens when utilizing JDBC casting and together with PostgreSQL’s “text” value formats.

## Locale ID/Name Parsing
The locale parsing has been rewritten and should now handle a variety of input types including Win32 verbose names. The Win32 parsing now properly requests language & country in English to ensure it maps properly.

When it cannot find a matching locale it now emits a warning and defautls to the ‘C’/‘POSIX’ locale. This is because locale parsing is no longer required for for normal driver operation (as it should have been all along). It is currently only used for the `money` type (which has problems, see below).

## Money Type
Note that the `money` type is unique and PostgreSQL outputs it according to the `lc_monetary` variable. This changes the numeric formatting symbols as well as adds a currency symbol.  This means that the “server” currency formatter is **not** locked to ‘C’ but is assigned a value matching the server’s `lc_monetary`.

The `money` type seems generally to be “wrong” changing monetary locales causes values to change currency (e.g. from USD to EUR) without any exchange (which would be nearly impossible).  It is assumed you probable shouldn’t be using this type and you certainly shouldn’t be relying on the server’s output to properly format it in a “currency”.