### PR TITLE
Load driver build properties from resource

### DIFF
--- a/driver/build.gradle.kts
+++ b/driver/build.gradle.kts
@@ -43,4 +43,7 @@ tasks {
   compileJava {
     outputs.dir("$buildDir/generated/docs")
   }
+  processResources {
+    expand(project.properties)
+  }
 }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDriver.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDriver.java
@@ -59,20 +59,26 @@ import java.util.stream.Stream;
  */
 public class PGDriver implements Driver, DriverAction {
 
+  private static final Properties DRIVER = new Properties();
+  static {
+    try {
+      DRIVER.load(PGDriver.class.getClassLoader().getResourceAsStream("META-INF/pgjdbc-ng.properties"));
+    }
+    catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
   /** The name of the driver */
   public static final String NAME;
   static {
-    String name = PGDriver.class.getPackage().getImplementationTitle();
-    name = name != null ? name : "DEVELOP"; // Ensure it works when in IDE
-    NAME = name;
+    NAME = DRIVER.getProperty("name");
   }
 
   /** The version of the driver */
   public static final Version VERSION;
   static {
-    String version = PGDriver.class.getPackage().getImplementationVersion();
-    version = version != null ? version : "0.0.0-DEVELOP"; // Ensure it works when in IDE
-    VERSION = Version.parse(version);
+    VERSION = Version.parse(DRIVER.getProperty("version"));
   }
 
   public static final Logger logger = Logger.getLogger(PGDriver.class.getName());

--- a/driver/src/main/resources/META-INF/pgjdbc-ng.properties
+++ b/driver/src/main/resources/META-INF/pgjdbc-ng.properties
@@ -1,0 +1,2 @@
+name=${name}
+version=${version}


### PR DESCRIPTION
This _should_ ensure that even if the packaging (e.g. MANFIEST.MF) changes that the driver name/version will always be reported correctly.