### PR TITLE
Support version 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ stages:
     if: (branch = develop OR branch =~ /^rel\/.+$/) AND type = push
 
 env:
+  - PGVERSION=12
   - PGVERSION=11
   - PGVERSION=10
   - PGVERSION=9.6

--- a/driver/src/build/testing.gradle.kts
+++ b/driver/src/build/testing.gradle.kts
@@ -17,7 +17,7 @@ buildscript {
 apply { type(DockerComposePlugin::class) }
 
 
-val defaultPostgresVersions by extra("11, 10, 9.6, 9.5, 9.4")
+val defaultPostgresVersions by extra("12, 11, 10, 9.6, 9.5, 9.4")
 
 
 val testTask = tasks.named<Test>("test") {

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/DatabaseMetaDataTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/DatabaseMetaDataTest.java
@@ -194,7 +194,12 @@ public class DatabaseMetaDataTest {
       assertTrue(fkColumnName.equals("m") || fkColumnName.equals("n"));
 
       String fkName = rs.getString("FK_NAME");
-      assertEquals("ww_m_fkey", fkName);
+      if (((PGDirectConnection)con).isServerMinimumVersion(12, 0)) {
+        assertEquals("ww_m_n_fkey", fkName);
+      }
+      else {
+        assertEquals("ww_m_fkey", fkName);
+      }
 
       String pkName = rs.getString("PK_NAME");
       assertEquals("vv_pkey", pkName);

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/ResultSetMetaDataTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/ResultSetMetaDataTest.java
@@ -97,7 +97,7 @@ public class ResultSetMetaDataTest {
   @Test
   public void testStandardResultSet() throws SQLException {
     Statement stmt = conn.createStatement();
-    ResultSet rs = stmt.executeQuery("SELECT a,b,c,a+c as total,oid,b as d FROM rsmd1");
+    ResultSet rs = stmt.executeQuery("SELECT a,b,c,a+c as total,serid,b as d FROM rsmd1");
     runStandardTests(rs.getMetaData());
     rs.close();
     stmt.close();
@@ -106,7 +106,7 @@ public class ResultSetMetaDataTest {
   @Test
   public void testPreparedResultSet() throws SQLException {
 
-    PreparedStatement pstmt = conn.prepareStatement("SELECT a,b,c,a+c as total,oid,b as d FROM rsmd1 WHERE b = ?");
+    PreparedStatement pstmt = conn.prepareStatement("SELECT a,b,c,a+c as total,serid,b as d FROM rsmd1 WHERE b = ?");
     runStandardTests(pstmt.getMetaData());
     pstmt.close();
   }
@@ -119,7 +119,7 @@ public class ResultSetMetaDataTest {
     assertEquals("total", rsmd.getColumnLabel(4));
 
     assertEquals("a", rsmd.getColumnName(1));
-    assertEquals("oid", rsmd.getColumnName(5));
+    assertEquals("serid", rsmd.getColumnName(5));
     assertEquals("total", rsmd.getColumnName(4));
     assertEquals("b", rsmd.getColumnName(6));
 

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/TestUtil.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/TestUtil.java
@@ -189,18 +189,19 @@ public class TestUtil {
   /*
    * Helper - creates a test table for use by a test
    */
-  public static void createTable(Connection con, String table, String columns, boolean withOids) throws SQLException {
+  public static void createTable(Connection con, String table, String columns, boolean withSerialIds) throws SQLException {
     Statement st = con.createStatement();
     try {
       // Drop the table
       dropTable(con, table);
 
+      if (withSerialIds) {
+        columns += ", serid serial";
+      }
+
       // Now create the table
       String sql = "CREATE TABLE " + table + " (" + columns + ") ";
 
-      if (withOids) {
-        sql += " WITH OIDS";
-      }
       st.executeUpdate(sql);
     }
     finally {

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/UpdatableResultTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/UpdatableResultTest.java
@@ -381,7 +381,7 @@ public class UpdatableResultTest {
 
     rs.close();
 
-    rs = st.executeQuery("select oid,* from updatable");
+    rs = st.executeQuery("select serid,* from updatable");
     assertTrue(rs.first());
     rs.updateInt("id", 3);
     rs.updateString("name", "dave3");


### PR DESCRIPTION
* Removes use of `OID` and `WITH OIDS` in tests
* Add `12` to tested versions
* Add PGVERSION=12 to travis matrix