### PR TITLE
Stop multiple notification listener `close` calls

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -681,13 +681,14 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
    *
    */
   private void internalClose() {
-
-    closeStatements();
+    cleanupClosed();
 
     shutdown().awaitUninterruptibly(networkTimeout > 0 ? networkTimeout : Integer.MAX_VALUE);
+  }
 
-    reportClosed();
-    notificationListeners.clear();
+  private void cleanupClosed() {
+
+    closeStatements();
 
     if (housekeeper != null) {
       housekeeper.remove(cleanupKey);
@@ -697,7 +698,11 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
 
   @Override
   protected void connectionClosed() {
-    internalClose();
+
+    cleanupClosed();
+
+    reportClosed();
+    notificationListeners.clear();
   }
 
   /**


### PR DESCRIPTION
* Reports close only from the I/O thread’s close signal
* Adds test to ensure close is only called once per connection