### PR TITLE
Interval overhaul

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/api/data/Interval.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/data/Interval.java
@@ -26,333 +26,704 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+/*
+ * ##########################################################################
+ * This file is derived from the file PeriodDuration.java from the project
+ * "threeten-extra" located at http://www.threeten.org/threeten-extra. The
+ * original portions of the file are are covered by the license following this
+ * disclaimer; which is compatible with the license of the pgjdbc-ng project.
+ * ##########################################################################
+ */
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.impossibl.postgres.api.data;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.util.Calendar;
-import java.util.Date;
+import java.io.Serializable;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.chrono.ChronoPeriod;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalQueries;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
-import java.util.StringTokenizer;
+import java.util.Objects;
 
-import static java.lang.Double.parseDouble;
-import static java.lang.Integer.parseInt;
-import static java.lang.Math.round;
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.NANOS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.YEARS;
 
-public class Interval {
+/**
+ * An amount of time in the ISO-8601 calendar system that combines a period and a duration.
+ * <p>
+ * This class models a quantity or amount of time in terms of a {@code Period} and {@code Duration}.
+ * A period is a date-based amount of time, consisting of years, months and days.
+ * A duration is a time-based amount of time, consisting of seconds and nanoseconds.
+ * See the {@link Period} and {@link Duration} classes for more details.
+ * <p>
+ * The days in a period take account of daylight saving changes (23 or 25 hour days).
+ * When performing calculations, the period is added first, then the duration.
+ * <p>
+ * The model is of a directed amount, meaning that the amount may be negative.
+ *
+ * <h3>Implementation Requirements:</h3>
+ * This class is immutable and thread-safe.
+ * <p>
+ * This class must be treated as a value type. Do not synchronize, rely on the
+ * identity hash code or use the distinction between equals() and ==.
+ */
+public final class Interval implements TemporalAmount, Serializable {
 
-  private int totalMonths;
-  private int totalDays;
-  private long totalMicros;
+  /**
+   * A constant for a duration of zero.
+   */
+  public static final Interval ZERO = new Interval(Period.ZERO, Duration.ZERO);
 
-  private static final long SECS_TO_MICROS = SECONDS.toMicros(1);
-  private static final long SECS_TO_MILLIS = SECONDS.toMillis(1);
+  /**
+   * A serialization identifier for this class.
+   */
+  private static final long serialVersionUID = 8815521625671589L;
+  /**
+   * The supported units.
+   */
+  private static final List<TemporalUnit> SUPPORTED_UNITS =
+      Collections.unmodifiableList(Arrays.<TemporalUnit>asList(YEARS, MONTHS, DAYS, SECONDS, NANOS));
+  /**
+   * The number of seconds per day.
+   */
+  private static final long SECONDS_PER_DAY = 86400;
 
-  public Interval(int months, int days, long timeMicros) {
-    super();
-    setValue(months, days, timeMicros);
+  /**
+   * The period.
+   */
+  private final Period period;
+  /**
+   * The duration.
+   */
+  private final Duration duration;
+
+  //-----------------------------------------------------------------------
+
+  /**
+   * Obtains an instance based on a period and duration.
+   * <p>
+   * The total amount of time of the resulting instance is the period plus the duration.
+   *
+   * @param period  the period, not null
+   * @param duration  the duration, not null
+   * @return the combined period-duration, not null
+   */
+  public static Interval of(Period period, Duration duration) {
+    Objects.requireNonNull(period, "The period must not be null");
+    Objects.requireNonNull(duration, "The duration must not be null");
+    return new Interval(period, duration);
   }
 
-  public Interval(int years, int months, int days, int hours, int minutes, double seconds) {
-    super();
-    setValue(years, months, days, hours, minutes, seconds);
+  /**
+   * Obtains an instance based on a period.
+   * <p>
+   * The duration will be zero.
+   *
+   * @param period  the period, not null
+   * @return the combined period-duration, not null
+   */
+  public static Interval of(Period period) {
+    Objects.requireNonNull(period, "The period must not be null");
+    return new Interval(period, Duration.ZERO);
   }
 
-  public Interval(String interval) {
-    this(interval, Locale.getDefault());
+  /**
+   * Obtains an instance based on a duration.
+   * <p>
+   * The period will be zero.
+   *
+   * @param duration  the duration, not null
+   * @return the combined period-duration, not null
+   */
+  public static Interval of(Duration duration) {
+    Objects.requireNonNull(duration, "The duration must not be null");
+    return new Interval(Period.ZERO, duration);
   }
 
-  public Interval(String interval, Locale locale) {
-    super();
-    setValue(interval, locale);
-  }
+  //-----------------------------------------------------------------------
 
-  public Interval() {
-  }
-
-  public void setValue(String value) {
-    setValue(value, Locale.getDefault());
-  }
-
-  public void setValue(String value, Locale locale) {
-
-    boolean isISOFormat = !value.startsWith("@");
-
-    // Just a simple '0'
-    if (!isISOFormat && value.length() == 3 && value.charAt(2) == '0') {
-      totalMonths = totalDays = 0;
-      totalMicros = 0;
-      return;
+  /**
+   * Obtains an instance from a temporal amount.
+   * <p>
+   * This obtains an instance based on the specified amount.
+   * A {@code TemporalAmount} represents an amount of time which this factory
+   * extracts to a {@code Interval}.
+   * <p>
+   * The result is calculated by looping around each unit in the specified amount.
+   * Any amount that is zero is ignore.
+   * If a unit has an exact duration, it will be totalled using {@link Duration#plus(Duration)}.
+   * If the unit is days or weeks, it will be totalled into the days part of the period.
+   * If the unit is months or quarters, it will be totalled into the months part of the period.
+   * If the unit is years, decades, centuries or millennia, it will be totalled into the years part of the period.
+   *
+   * @param amount  the temporal amount to convert, not null
+   * @return the equivalent duration, not null
+   * @throws DateTimeException if unable to convert to a {@code Duration}
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  public static Interval from(TemporalAmount amount) {
+    if (amount instanceof Interval) {
+      return (Interval) amount;
     }
-
+    if (amount instanceof Period) {
+      return Interval.of((Period) amount);
+    }
+    if (amount instanceof Duration) {
+      return Interval.of((Duration) amount);
+    }
+    if (amount instanceof ChronoPeriod) {
+      if (!IsoChronology.INSTANCE.equals(((ChronoPeriod) amount).getChronology())) {
+        throw new DateTimeException("Period requires ISO chronology: " + amount);
+      }
+    }
+    Objects.requireNonNull(amount, "amount");
     int years = 0;
     int months = 0;
     int days = 0;
-    int hours = 0;
-    int minutes = 0;
-    double seconds = 0;
-    boolean ago = false;
-
-    try {
-
-      String valueToken;
-
-      final String changedValue = value.replace('+', ' ').replace('@', ' ');
-
-      StringTokenizer st = new StringTokenizer(changedValue);
-      while (st.hasMoreTokens()) {
-
-        String token = st.nextToken();
-
-        if (token.equals("ago")) {
-          ago = true;
-          break;
-        }
-
-        int endHours = token.indexOf(':');
-        if (endHours == -1) {
-          valueToken = token;
+    Duration duration = Duration.ZERO;
+    for (TemporalUnit unit : amount.getUnits()) {
+      long value = amount.get(unit);
+      if (value != 0) {
+        // ignore unless non-zero
+        if (unit.isDurationEstimated()) {
+          if (unit == ChronoUnit.DAYS) {
+            days = Math.addExact(days, Math.toIntExact(value));
+          }
+          else if (unit == ChronoUnit.WEEKS) {
+            days = Math.addExact(days, Math.toIntExact(Math.multiplyExact(value, 7)));
+          }
+          else if (unit == ChronoUnit.MONTHS) {
+            months = Math.addExact(months, Math.toIntExact(value));
+          }
+          else if (unit == IsoFields.QUARTER_YEARS) {
+            months = Math.addExact(months, Math.toIntExact(Math.multiplyExact(value, 3)));
+          }
+          else if (unit == ChronoUnit.YEARS) {
+            years = Math.addExact(years, Math.toIntExact(value));
+          }
+          else if (unit == ChronoUnit.DECADES) {
+            years = Math.addExact(years, Math.toIntExact(Math.multiplyExact(value, 10)));
+          }
+          else if (unit == ChronoUnit.CENTURIES) {
+            years = Math.addExact(years, Math.toIntExact(Math.multiplyExact(value, 100)));
+          }
+          else if (unit == ChronoUnit.MILLENNIA) {
+            years = Math.addExact(years, Math.toIntExact(Math.multiplyExact(value, 1000)));
+          }
+          else {
+            throw new DateTimeException("Unknown unit: " + unit);
+          }
         }
         else {
-
-          // This handles hours, minutes, seconds and microseconds for
-          // ISO intervals
-          int offset = (token.charAt(0) == '-') ? 1 : 0;
-
-          hours = parseInt(token.substring(offset + 0, endHours));
-          minutes = parseInt(token.substring(endHours + 1, endHours + 3));
-
-          // Pre 7.4 servers do not put second information into the results
-          // unless it is non-zero.
-          int endMinutes = token.indexOf(':', endHours + 1);
-          if (endMinutes != -1) {
-            NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
-            seconds = numberFormat.parse(token.substring(endMinutes + 1)).doubleValue();
-          }
-
-          if (offset == 1) {
-            hours = -hours;
-            minutes = -minutes;
-            seconds = -seconds;
-          }
-
-          break;
+          // total of exact durations
+          duration = duration.plus(amount.get(unit), unit);
         }
-
-        if (!st.hasMoreTokens()) {
-          throw new IllegalArgumentException("invalid interval");
-        }
-
-        token = st.nextToken();
-
-        // This handles years, months, days for both, ISO and
-        // Non-ISO intervals. Hours, minutes, seconds and microseconds
-        // are handled for Non-ISO intervals here.
-
-        if (token.startsWith("year"))
-          years = parseInt(valueToken);
-        else if (token.startsWith("mon"))
-          months = parseInt(valueToken);
-        else if (token.startsWith("day"))
-          days = parseInt(valueToken);
-        else if (token.startsWith("hour"))
-          hours = parseInt(valueToken);
-        else if (token.startsWith("min"))
-          minutes = parseInt(valueToken);
-        else if (token.startsWith("sec"))
-          seconds = parseDouble(valueToken);
-
       }
     }
-    catch (ParseException e) {
-      throw new IllegalArgumentException("invalid interval", e);
+    return Interval.of(Period.of(years, months, days), duration);
+  }
+
+  //-----------------------------------------------------------------------
+
+  /**
+   * Obtains an instance from a text string such as {@code PnYnMnDTnHnMnS}.
+   * <p>
+   * This will parse the string produced by {@code toString()} which is
+   * based on the ISO-8601 period formats {@code PnYnMnDTnHnMnS} and {@code PnW}.
+   * <p>
+   * The string starts with an optional sign, denoted by the ASCII negative
+   * or positive symbol. If negative, the whole amount is negated.
+   * The ASCII letter "P" is next in upper or lower case.
+   * There are then a number of sections, each consisting of a number and a suffix.
+   * At least one of the sections must be present.
+   * The sections have suffixes in ASCII of "Y" for years, "M" for months,
+   * "W" for weeks, "D" for days, "H" for hours, "M" for minutes, "S" for seconds,
+   * accepted in upper or lower case. Note that the ASCII letter "T" separates
+   * the date and time parts and must be present if any time part is present.
+   * The suffixes must occur in order.
+   * The number part of each section must consist of ASCII digits.
+   * The number may be prefixed by the ASCII negative or positive symbol.
+   * The number must parse to an {@code int}.
+   * Any week-based input is multiplied by 7 and treated as a number of days.
+   * <p>
+   * The leading plus/minus sign, and negative values for weeks and days are
+   * not part of the ISO-8601 standard.
+   * <p>
+   * Note that the date style format {@code PYYYY-MM-DDTHH:MM:SS} is not supported.
+   * <p>
+   * For example, the following are valid inputs:
+   * <pre>
+   *   "P2Y"             -- PeriodDuration.of(Period.ofYears(2))
+   *   "P3M"             -- PeriodDuration.of(Period.ofMonths(3))
+   *   "P4W"             -- PeriodDuration.of(Period.ofWeeks(4))
+   *   "P5D"             -- PeriodDuration.of(Period.ofDays(5))
+   *   "PT6H"            -- PeriodDuration.of(Duration.ofHours(6))
+   *   "P1Y2M3D"         -- PeriodDuration.of(Period.of(1, 2, 3))
+   *   "P1Y2M3W4DT8H"    -- PeriodDuration.of(Period.of(1, 2, 25), Duration.ofHours(8))
+   *   "P-1Y2M"          -- PeriodDuration.of(Period.of(-1, 2, 0))
+   *   "-P1Y2M"          -- PeriodDuration.of(Period.of(-1, -2, 0))
+   * </pre>
+   *
+   * @param text  the text to parse, not null
+   * @return the parsed period, not null
+   * @throws DateTimeParseException if the text cannot be parsed to a period
+   */
+  public static Interval parse(CharSequence text) {
+    Objects.requireNonNull(text, "text");
+    String upper = text.toString().toUpperCase(Locale.ENGLISH);
+    String negate = "";
+    if (upper.startsWith("+")) {
+      upper = upper.substring(1);
     }
-
-    if (!isISOFormat && ago) {
-      // Inverse the leading sign
-      setValue(-years, -months, -days, -hours, -minutes, -seconds);
+    else if (upper.startsWith("-")) {
+      upper = upper.substring(1);
+      negate = "-";
     }
-    else {
-      setValue(years, months, days, hours, minutes, seconds);
+    // duration only, parse original text so it does negation
+    if (upper.startsWith("PT")) {
+      return Interval.of(Duration.parse(text));
     }
-
+    // period only, parse original text so it does negation
+    int tpos = upper.indexOf('T');
+    if (tpos < 0) {
+      return Interval.of(Period.parse(text));
+    }
+    // period and duration
+    Period period = Period.parse(negate + upper.substring(0, tpos));
+    Duration duration = Duration.parse(negate + "P" + upper.substring(tpos));
+    return Interval.of(period, duration);
   }
 
-  public void setValue(int months, int days, long timeMicros) {
-    this.totalMonths = months;
-    this.totalDays = days;
-    this.totalMicros = timeMicros;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Obtains an instance consisting of the amount of time between two temporals.
+   * <p>
+   * The start is included, but the end is not.
+   * The result of this method can be negative if the end is before the start.
+   * <p>
+   * The calculation examines the temporals and extracts {@link LocalDate} and {@link LocalTime}.
+   * If the time is missing, it will be defaulted to midnight.
+   * If one date is missing, it will be defaulted to the other date.
+   * It then finds the amount of time between the two dates and between the two times.
+   *
+   * @param startInclusive  the start, inclusive, not null
+   * @param endExclusive  the end, exclusive, not null
+   * @return the number of days between this date and the end date, not null
+   */
+  public static Interval between(Temporal startInclusive, Temporal endExclusive) {
+    LocalDate startDate = startInclusive.query(TemporalQueries.localDate());
+    LocalDate endDate = endExclusive.query(TemporalQueries.localDate());
+    Period period = Period.ZERO;
+    if (startDate != null && endDate != null) {
+      period = Period.between(startDate, endDate);
+    }
+    LocalTime startTime = startInclusive.query(TemporalQueries.localTime());
+    LocalTime endTime = endExclusive.query(TemporalQueries.localTime());
+    startTime = startTime != null ? startTime : LocalTime.MIDNIGHT;
+    endTime = endTime != null ? endTime : LocalTime.MIDNIGHT;
+    Duration duration = Duration.between(startTime, endTime);
+    return Interval.of(period, duration);
   }
 
-  public void setValue(int years, int months, int days, int hours, int minutes, double seconds) {
-    this.totalMonths += years * 12 + months;
-    this.totalDays = days;
-    this.totalMicros += HOURS.toMicros(hours);
-    this.totalMicros += MINUTES.toMicros(minutes);
-    this.totalMicros += (long) (seconds * SECONDS.toMicros(1));
+  //-----------------------------------------------------------------------
+
+  /**
+   * Constructs an instance.
+   *
+   * @param period  the period
+   * @param duration  the duration
+   */
+  private Interval(Period period, Duration duration) {
+    this.period = period;
+    this.duration = duration;
   }
 
-  public long getRawTime() {
-    return totalMicros;
+  /**
+   * Resolves singletons.
+   *
+   * @return the singleton instance
+   */
+  private Object readResolve() {
+    return Interval.of(period, duration);
   }
 
-  public void setRawTime(long time) {
-    this.totalMicros = time;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Gets the value of the requested unit.
+   * <p>
+   * This returns a value for the supported units - {@link ChronoUnit#YEARS},
+   * {@link ChronoUnit#MONTHS}, {@link ChronoUnit#DAYS}, {@link ChronoUnit#SECONDS}
+   * and {@link ChronoUnit#NANOS}.
+   * All other units throw an exception.
+   * Note that hours and minutes throw an exception.
+   *
+   * @param unit  the {@code TemporalUnit} for which to return the value
+   * @return the long value of the unit
+   * @throws UnsupportedTemporalTypeException if the unit is not supported
+   */
+  @Override
+  public long get(TemporalUnit unit) {
+    if (unit instanceof ChronoUnit) {
+      switch ((ChronoUnit) unit) {
+        case YEARS:
+          return period.getYears();
+        case MONTHS:
+          return period.getMonths();
+        case DAYS:
+          return period.getDays();
+        case SECONDS:
+          return duration.getSeconds();
+        case NANOS:
+          return duration.getNano();
+        default:
+          break;
+      }
+    }
+    throw new UnsupportedTemporalTypeException("Unsupported unit: " + unit);
   }
 
-  public int getRawDays() {
-    return totalDays;
+  /**
+   * Gets the set of units supported by this amount.
+   * <p>
+   * This returns the list {@link ChronoUnit#YEARS}, {@link ChronoUnit#MONTHS},
+   * {@link ChronoUnit#DAYS}, {@link ChronoUnit#SECONDS} and {@link ChronoUnit#NANOS}.
+   * <p>
+   * This set can be used in conjunction with {@link #get(TemporalUnit)}
+   * to access the entire state of the amount.
+   *
+   * @return a list containing the days unit, not null
+   */
+  @Override
+  public List<TemporalUnit> getUnits() {
+    return SUPPORTED_UNITS;
   }
 
-  public void setRawDays(int days) {
-    this.totalDays = days;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Gets the period part.
+   *
+   * @return the period part
+   */
+  public Period getPeriod() {
+    return period;
   }
 
-  public int getRawMonths() {
-    return totalMonths;
+  /**
+   * Returns a copy of this period-duration with a different period.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param period  the new period
+   * @return the updated period-duration
+   */
+  public Interval withPeriod(Period period) {
+    return Interval.of(period, duration);
   }
 
-  public void setRawMonths(int months) {
-    this.totalMonths = months;
+  /**
+   * Gets the duration part.
+   *
+   * @return the duration part
+   */
+  public Duration getDuration() {
+    return duration;
   }
 
-  public long getHours() {
-    return MICROSECONDS.toHours(totalMicros);
+  /**
+   * Returns a copy of this period-duration with a different duration.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param duration  the new duration
+   * @return the updated period-duration
+   */
+  public Interval withDuration(Duration duration) {
+    return Interval.of(period, duration);
   }
 
-  public void setHours(long hours) {
-    totalMicros -= HOURS.toMicros(getHours());
-    totalMicros += HOURS.toMicros(hours);
+  //-----------------------------------------------------------------------
+
+  /**
+   * Checks if all parts of this amount are zero.
+   * <p>
+   * This returns true if both {@link Period#isZero()} and {@link Duration#isZero()}
+   * return true.
+   *
+   * @return true if this period is zero-length
+   */
+  public boolean isZero() {
+    return period.isZero() && duration.isZero();
   }
 
-  public long getMinutes() {
-    return MICROSECONDS.toMinutes(totalMicros) - HOURS.toMinutes(getHours());
+  //-----------------------------------------------------------------------
+
+  /**
+   * Returns a copy of this amount with the specified amount added.
+   * <p>
+   * The parameter is converted using {@link Interval#from(TemporalAmount)}.
+   * The period and duration are combined separately.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param amountToAdd  the amount to add, not null
+   * @return a {@code Days} based on this instance with the requested amount added, not null
+   * @throws DateTimeException if the specified amount contains an invalid unit
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  public Interval plus(TemporalAmount amountToAdd) {
+    Interval other = Interval.from(amountToAdd);
+    return of(period.plus(other.period), duration.plus(other.duration));
   }
 
-  public void setMinutes(long minutes) {
-    totalMicros -= MINUTES.toMicros(getMinutes());
-    totalMicros += MINUTES.toMicros(minutes);
+  //-----------------------------------------------------------------------
+
+  /**
+   * Returns a copy of this amount with the specified amount subtracted.
+   * <p>
+   * The parameter is converted using {@link Interval#from(TemporalAmount)}.
+   * The period and duration are combined separately.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param amountToAdd  the amount to add, not null
+   * @return a {@code Days} based on this instance with the requested amount subtracted, not null
+   * @throws DateTimeException if the specified amount contains an invalid unit
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  public Interval minus(TemporalAmount amountToAdd) {
+    Interval other = Interval.from(amountToAdd);
+    return of(period.minus(other.period), duration.minus(other.duration));
   }
 
-  public double getSeconds() {
-    double microsDiff = totalMicros - MINUTES.toMicros(MICROSECONDS.toMinutes(totalMicros));
-    return microsDiff / SECS_TO_MICROS;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Returns an instance with the amount multiplied by the specified scalar.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param scalar  the scalar to multiply by, not null
+   * @return the amount multiplied by the specified scalar, not null
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  public Interval multipliedBy(int scalar) {
+    if (scalar == 1) {
+      return this;
+    }
+    return of(period.multipliedBy(scalar), duration.multipliedBy(scalar));
   }
 
-  public void setSeconds(double seconds) {
-    totalMicros -= getSeconds() * SECS_TO_MICROS;
-    totalMicros += seconds * SECS_TO_MICROS;
+  /**
+   * Returns an instance with the amount negated.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @return the negated amount, not null
+   * @throws ArithmeticException if numeric overflow occurs, which only happens if
+   *  the amount is {@code Long.MIN_VALUE}
+   */
+  public Interval negated() {
+    return multipliedBy(-1);
   }
 
-  public int getDays() {
-    return totalDays;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Returns a copy of this instance with the years and months exactly normalized.
+   * <p>
+   * This normalizes the years and months units, leaving the days unit unchanged.
+   * The result is exact, always representing the same amount of time.
+   * <p>
+   * The months unit is adjusted to have an absolute value less than 11,
+   * with the years unit being adjusted to compensate. For example, a period of
+   * "1 year and 15 months" will be normalized to "2 years and 3 months".
+   * <p>
+   * The sign of the years and months units will be the same after normalization.
+   * For example, a period of "1 year and -25 months" will be normalized to
+   * "-1 year and -1 month".
+   * <p>
+   * Note that no normalization is performed on the days or duration.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @return a {@code PeriodDuration} based on this one with excess months normalized to years, not null
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  public Interval normalizedYears() {
+    return withPeriod(period.normalized());
   }
 
-  public void setDays(int days) {
-    this.totalDays = days;
+  /**
+   * Returns a copy of this instance with the days and duration normalized using the standard day of 24 hours.
+   * <p>
+   * This normalizes the days and duration, leaving the years and months unchanged.
+   * The result uses a standard day length of 24 hours.
+   * <p>
+   * This combines the duration seconds with the number of days and shares the total
+   * seconds between the two fields. For example, a period of
+   * "2 days and 86401 seconds" will be normalized to "3 days and 1 second".
+   * <p>
+   * The sign of the days and duration will be the same after normalization.
+   * For example, a period of "1 day and -172801 seconds" will be normalized to
+   * "-1 day and -1 second".
+   * <p>
+   * Note that no normalization is performed on the years or months.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @return a {@code PeriodDuration} based on this one with excess duration normalized to days, not null
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  public Interval normalizedStandardDays() {
+    long totalSecs = period.getDays() * SECONDS_PER_DAY + duration.getSeconds();
+    int splitDays = Math.toIntExact(totalSecs / SECONDS_PER_DAY);
+    long splitSecs = totalSecs % SECONDS_PER_DAY;
+    if (splitDays == period.getDays() && splitSecs == duration.getSeconds()) {
+      return this;
+    }
+    return Interval.of(period.withDays(splitDays), duration.withSeconds(splitSecs));
   }
 
-  public int getMonths() {
-    return totalMonths % 12;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Adds this amount to the specified temporal object.
+   * <p>
+   * This returns a temporal object of the same observable type as the input
+   * with this amount added. This simply adds the period and duration to the temporal.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param temporal  the temporal object to adjust, not null
+   * @return an object of the same type with the adjustment made, not null
+   * @throws DateTimeException if unable to add
+   * @throws UnsupportedTemporalTypeException if the DAYS unit is not supported
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  @Override
+  public Temporal addTo(Temporal temporal) {
+    return temporal.plus(period).plus(duration);
   }
 
-  public void setMonths(int months) {
-    totalMonths -= getMonths();
-    totalMonths += months;
+  /**
+   * Subtracts this amount from the specified temporal object.
+   * <p>
+   * This returns a temporal object of the same observable type as the input
+   * with this amount subtracted. This simply subtracts the period and duration from the temporal.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param temporal  the temporal object to adjust, not null
+   * @return an object of the same type with the adjustment made, not null
+   * @throws DateTimeException if unable to subtract
+   * @throws UnsupportedTemporalTypeException if the DAYS unit is not supported
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  @Override
+  public Temporal subtractFrom(Temporal temporal) {
+    return temporal.minus(period).minus(duration);
   }
 
-  public int getYears() {
-    return totalMonths / 12;
+  //-----------------------------------------------------------------------
+
+  /**
+   * Checks if this amount is equal to the specified {@code PeriodDuration}.
+   * <p>
+   * The comparison is based on the underlying period and duration.
+   *
+   * @param otherAmount  the other amount, null returns false
+   * @return true if the other amount is equal to this one
+   */
+  @Override
+  public boolean equals(Object otherAmount) {
+    if (this == otherAmount) {
+      return true;
+    }
+    if (otherAmount instanceof Interval) {
+      Interval other = (Interval) otherAmount;
+      return this.period.equals(other.period) && this.duration.equals(other.duration);
+    }
+    return false;
   }
 
-  public void setYears(int years) {
-    totalMonths -= getYears() * 12;
-    totalMonths += years * 12;
-  }
-
-  public void addTo(Calendar cal) {
-
-    long millis = round(getSeconds() * SECS_TO_MILLIS);
-
-    cal.add(Calendar.MILLISECOND, (int) millis);
-    cal.add(Calendar.MINUTE, (int) getMinutes());
-    cal.add(Calendar.HOUR, (int) getHours());
-    cal.add(Calendar.DAY_OF_MONTH, getDays());
-    cal.add(Calendar.MONTH, getMonths());
-    cal.add(Calendar.YEAR, getYears());
-  }
-
-  public void addTo(Date date) {
-
-    Calendar cal = Calendar.getInstance();
-    cal.setTime(date);
-
-    addTo(cal);
-
-    date.setTime(cal.getTimeInMillis());
-  }
-
-  public void addTo(Interval interval) {
-    interval.totalMonths += totalMonths;
-    interval.totalDays += totalDays;
-    interval.totalMicros += totalMicros;
-  }
-
+  /**
+   * A hash code for this amount.
+   *
+   * @return a suitable hash code
+   */
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + totalDays;
-    result = prime * result + totalMonths;
-    result = prime * result + (int) (totalMicros ^ (totalMicros >>> 32));
-    return result;
+    return period.hashCode() ^ duration.hashCode();
   }
 
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    Interval other = (Interval) obj;
-    if (totalDays != other.totalDays)
-      return false;
-    if (totalMonths != other.totalMonths)
-      return false;
-    if (totalMicros != other.totalMicros)
-      return false;
-    return true;
-  }
+  //-----------------------------------------------------------------------
 
+  /**
+   * Returns a string representation of the amount.
+   * This will be in the format 'PnYnMnDTnHnMnS', with sections omitted as necessary.
+   * An empty amount will return "PT0S".
+   *
+   * @return the period in ISO-8601 string format
+   */
   @Override
   public String toString() {
-    return toString(Locale.getDefault());
-  }
-
-  public String toString(Locale locale) {
-
-    DecimalFormat secondsFormat = new DecimalFormat("0.00####", DecimalFormatSymbols.getInstance(locale));
-
-    StringBuilder buffer = new StringBuilder();
-
-    buffer.
-        append("@ ").
-        append(getYears()).append(" years ").
-        append(getMonths()).append(" months ").
-        append(getDays()).append(" days ").
-        append(getHours()).append(" hours ").
-        append(getMinutes()).append(" minutes ").
-        append(secondsFormat.format(getSeconds())).append(" seconds");
-
-    return buffer.toString();
+    if (period.isZero()) {
+      return duration.toString();
+    }
+    if (duration.isZero()) {
+      return period.toString();
+    }
+    return period.toString() + duration.toString().substring(1);
   }
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/datetime/ISOIntervalFormat.java
+++ b/driver/src/main/java/com/impossibl/postgres/datetime/ISOIntervalFormat.java
@@ -26,60 +26,18 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.impossibl.postgres.system;
+package com.impossibl.postgres.datetime;
 
-import com.impossibl.postgres.datetime.DateTimeFormat;
-import com.impossibl.postgres.datetime.IntervalFormat;
-import com.impossibl.postgres.protocol.RequestExecutor;
-import com.impossibl.postgres.protocol.ServerConnection;
-import com.impossibl.postgres.types.Registry;
+import com.impossibl.postgres.api.data.Interval;
 
-import java.nio.charset.Charset;
-import java.text.NumberFormat;
-import java.time.ZoneId;
-import java.util.Map;
-import java.util.TimeZone;
+public class ISOIntervalFormat implements IntervalFormat {
+  @Override
+  public Parser getParser() {
+    return Interval::parse;
+  }
 
-import io.netty.buffer.ByteBufAllocator;
-
-public interface Context extends Configuration {
-
-  RequestExecutor getRequestExecutor();
-
-  ByteBufAllocator getAllocator();
-
-  Registry getRegistry();
-
-  TimeZone getTimeZone();
-
-  ZoneId getTimeZoneId();
-
-  Charset getCharset();
-
-  ServerInfo getServerInfo();
-
-  ServerConnection.KeyData getKeyData();
-
-  NumberFormat getClientIntegerFormatter();
-  NumberFormat getClientDecimalFormatter();
-
-  NumberFormat getServerCurrencyFormatter();
-  NumberFormat getClientCurrencyFormatter();
-
-  DateTimeFormat getServerDateFormat();
-  DateTimeFormat getClientDateFormat();
-
-  DateTimeFormat getServerTimeFormat();
-  DateTimeFormat getClientTimeFormat();
-
-  DateTimeFormat getServerTimestampFormat();
-  DateTimeFormat getClientTimestampFormat();
-
-  IntervalFormat getServerIntervalFormat();
-  IntervalFormat getClientIntervalFormat();
-
-  Map<String, Class<?>> getCustomTypeMap();
-
-  Context unwrap();
-
+  @Override
+  public Printer getPrinter() {
+    return Interval::toString;
+  }
 }

--- a/driver/src/main/java/com/impossibl/postgres/datetime/IntervalFormat.java
+++ b/driver/src/main/java/com/impossibl/postgres/datetime/IntervalFormat.java
@@ -26,60 +26,27 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.impossibl.postgres.system;
+package com.impossibl.postgres.datetime;
 
-import com.impossibl.postgres.datetime.DateTimeFormat;
-import com.impossibl.postgres.datetime.IntervalFormat;
-import com.impossibl.postgres.protocol.RequestExecutor;
-import com.impossibl.postgres.protocol.ServerConnection;
-import com.impossibl.postgres.types.Registry;
+import com.impossibl.postgres.api.data.Interval;
 
-import java.nio.charset.Charset;
-import java.text.NumberFormat;
-import java.time.ZoneId;
-import java.util.Map;
-import java.util.TimeZone;
+public interface IntervalFormat {
 
-import io.netty.buffer.ByteBufAllocator;
+  interface Parser {
 
-public interface Context extends Configuration {
+    Interval parse(CharSequence text);
 
-  RequestExecutor getRequestExecutor();
+  }
 
-  ByteBufAllocator getAllocator();
+  Parser getParser();
 
-  Registry getRegistry();
 
-  TimeZone getTimeZone();
+  interface Printer {
 
-  ZoneId getTimeZoneId();
+    String format(Interval value);
 
-  Charset getCharset();
+  }
 
-  ServerInfo getServerInfo();
-
-  ServerConnection.KeyData getKeyData();
-
-  NumberFormat getClientIntegerFormatter();
-  NumberFormat getClientDecimalFormatter();
-
-  NumberFormat getServerCurrencyFormatter();
-  NumberFormat getClientCurrencyFormatter();
-
-  DateTimeFormat getServerDateFormat();
-  DateTimeFormat getClientDateFormat();
-
-  DateTimeFormat getServerTimeFormat();
-  DateTimeFormat getClientTimeFormat();
-
-  DateTimeFormat getServerTimestampFormat();
-  DateTimeFormat getClientTimestampFormat();
-
-  IntervalFormat getServerIntervalFormat();
-  IntervalFormat getClientIntervalFormat();
-
-  Map<String, Class<?>> getCustomTypeMap();
-
-  Context unwrap();
+  Printer getPrinter();
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/datetime/PostgresIntervalFormat.java
+++ b/driver/src/main/java/com/impossibl/postgres/datetime/PostgresIntervalFormat.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.datetime;
+
+import com.impossibl.postgres.api.data.Interval;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.Period;
+import java.util.Locale;
+import java.util.StringTokenizer;
+
+import static java.lang.Double.parseDouble;
+import static java.lang.Integer.parseInt;
+
+public class PostgresIntervalFormat implements IntervalFormat {
+
+  private Interval parse(CharSequence chars) {
+
+    String value = chars.toString();
+
+    boolean isVerbose = value.startsWith("@");
+
+    // Just a simple '0'
+    if (isVerbose && value.length() == 3 && value.charAt(2) == '0') {
+      return Interval.of(Duration.ofSeconds(0));
+    }
+
+    int years = 0;
+    int months = 0;
+    int days = 0;
+    int hours = 0;
+    int minutes = 0;
+    double seconds = 0;
+    boolean ago = false;
+
+    try {
+
+      String valueToken;
+
+      final String changedValue = value.replace('+', ' ').replace('@', ' ');
+
+      StringTokenizer st = new StringTokenizer(changedValue);
+      while (st.hasMoreTokens()) {
+
+        String token = st.nextToken();
+
+        if (token.equals("ago")) {
+          ago = true;
+          break;
+        }
+
+        int endHours = token.indexOf(':');
+        if (endHours == -1) {
+          valueToken = token;
+        }
+        else {
+
+          // This handles hours, minutes, seconds and microseconds for
+          // ISO intervals
+          int offset = (token.charAt(0) == '-') ? 1 : 0;
+
+          hours = parseInt(token.substring(offset + 0, endHours));
+          minutes = parseInt(token.substring(endHours + 1, endHours + 3));
+
+          // Pre 7.4 servers do not put second information into the results
+          // unless it is non-zero.
+          int endMinutes = token.indexOf(':', endHours + 1);
+          if (endMinutes != -1) {
+            NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.ROOT);
+            seconds = numberFormat.parse(token.substring(endMinutes + 1)).doubleValue();
+          }
+
+          if (offset == 1) {
+            hours = -hours;
+            minutes = -minutes;
+            seconds = -seconds;
+          }
+
+          break;
+        }
+
+        if (!st.hasMoreTokens()) {
+          throw new IllegalArgumentException("invalid interval");
+        }
+
+        token = st.nextToken();
+
+        // This handles years, months, days for both, ISO and
+        // Non-ISO intervals. Hours, minutes, seconds and microseconds
+        // are handled for Non-ISO intervals here.
+
+        if (token.startsWith("year"))
+          years = parseInt(valueToken);
+        else if (token.startsWith("mon"))
+          months = parseInt(valueToken);
+        else if (token.startsWith("day"))
+          days = parseInt(valueToken);
+        else if (token.startsWith("hour"))
+          hours = parseInt(valueToken);
+        else if (token.startsWith("min"))
+          minutes = parseInt(valueToken);
+        else if (token.startsWith("sec"))
+          seconds = parseDouble(valueToken);
+
+      }
+    }
+    catch (ParseException e) {
+      throw new IllegalArgumentException("invalid interval", e);
+    }
+
+    if (isVerbose && ago) {
+      // Inverse the leading sign
+      years = -years;
+      months = -months;
+      days = -days;
+      hours = -hours;
+      minutes = -minutes;
+      seconds = -seconds;
+    }
+
+    Period period = Period.of(years, months, days);
+    Duration duration = Duration.ofHours(hours).plusMinutes(minutes).plusNanos((long) (seconds * 1_000_000_000));
+
+    return Interval.of(period, duration);
+  }
+
+  private DecimalFormat secondsFormat = new DecimalFormat("0.00####", DecimalFormatSymbols.getInstance(Locale.ROOT));
+
+  private String print(Interval interval) {
+
+    StringBuilder buffer = new StringBuilder();
+
+    Period period = interval.getPeriod();
+    Duration duration = interval.getDuration();
+
+    long hours = duration.toHours();
+    long minutes = duration.minusHours(duration.toHours()).toMinutes();
+    long seconds = duration.minusMinutes(duration.toMinutes()).getSeconds();
+    double fullSeconds = (double) seconds + ((double) duration.getNano() / (double) 1_000_000_000);
+
+    return buffer
+        .append("@ ")
+        .append(period.getYears()).append(" years ")
+        .append(period.getMonths()).append(" months ")
+        .append(period.getDays()).append(" days ")
+        .append(hours).append(" hours ")
+        .append(minutes).append(" minutes ")
+        .append(secondsFormat.format(fullSeconds)).append(" seconds")
+        .toString();
+  }
+
+  @Override
+  public Parser getParser() {
+    return this::parse;
+  }
+
+  @Override
+  public Printer getPrinter() {
+    return this::print;
+  }
+
+}

--- a/driver/src/main/java/com/impossibl/postgres/system/DecoratorContext.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/DecoratorContext.java
@@ -29,6 +29,7 @@
 package com.impossibl.postgres.system;
 
 import com.impossibl.postgres.datetime.DateTimeFormat;
+import com.impossibl.postgres.datetime.IntervalFormat;
 import com.impossibl.postgres.protocol.RequestExecutor;
 import com.impossibl.postgres.protocol.ServerConnection;
 import com.impossibl.postgres.types.Registry;
@@ -99,6 +100,16 @@ class DecoratorContext extends AbstractContext {
   @Override
   public DateTimeFormat getClientTimeFormat() {
     return base.getClientTimeFormat();
+  }
+
+  @Override
+  public IntervalFormat getServerIntervalFormat() {
+    return base.getServerIntervalFormat();
+  }
+
+  @Override
+  public IntervalFormat getClientIntervalFormat() {
+    return base.getClientIntervalFormat();
   }
 
   @Override

--- a/driver/src/main/java/com/impossibl/postgres/system/IntervalStyle.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/IntervalStyle.java
@@ -28,58 +28,17 @@
  */
 package com.impossibl.postgres.system;
 
-import com.impossibl.postgres.datetime.DateTimeFormat;
-import com.impossibl.postgres.datetime.IntervalFormat;
-import com.impossibl.postgres.protocol.RequestExecutor;
-import com.impossibl.postgres.protocol.ServerConnection;
-import com.impossibl.postgres.types.Registry;
+/**
+ * Enumeration for PostgreSQL IntervalStyle
+ *
+ * @author kdubb
+ *
+ */
+public enum IntervalStyle {
 
-import java.nio.charset.Charset;
-import java.text.NumberFormat;
-import java.time.ZoneId;
-import java.util.Map;
-import java.util.TimeZone;
-
-import io.netty.buffer.ByteBufAllocator;
-
-public interface Context extends Configuration {
-
-  RequestExecutor getRequestExecutor();
-
-  ByteBufAllocator getAllocator();
-
-  Registry getRegistry();
-
-  TimeZone getTimeZone();
-
-  ZoneId getTimeZoneId();
-
-  Charset getCharset();
-
-  ServerInfo getServerInfo();
-
-  ServerConnection.KeyData getKeyData();
-
-  NumberFormat getClientIntegerFormatter();
-  NumberFormat getClientDecimalFormatter();
-
-  NumberFormat getServerCurrencyFormatter();
-  NumberFormat getClientCurrencyFormatter();
-
-  DateTimeFormat getServerDateFormat();
-  DateTimeFormat getClientDateFormat();
-
-  DateTimeFormat getServerTimeFormat();
-  DateTimeFormat getClientTimeFormat();
-
-  DateTimeFormat getServerTimestampFormat();
-  DateTimeFormat getClientTimestampFormat();
-
-  IntervalFormat getServerIntervalFormat();
-  IntervalFormat getClientIntervalFormat();
-
-  Map<String, Class<?>> getCustomTypeMap();
-
-  Context unwrap();
+  SQL_STANDARD,
+  POSTGRES,
+  POSTGRES_VERBOSE,
+  ISO_8601;
 
 }

--- a/driver/src/main/java/com/impossibl/postgres/system/ParameterNames.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/ParameterNames.java
@@ -39,5 +39,6 @@ public class ParameterNames {
   public static final String STANDARD_CONFORMING_STRINGS = "standard_conforming_strings";
   public static final String TIME_ZONE = "TimeZone";
   public static final String DATE_STYLE = "DateStyle";
+  public static final String INTERVAL_STYLE = "IntervalStyle";
 
 }

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/IntervalTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/IntervalTest.java
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.jdbc;
+
+import com.impossibl.postgres.api.data.Interval;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.Period;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class IntervalTest {
+  private Connection conn;
+
+  @Before
+  public void setUp() throws Exception {
+    conn = TestUtil.openDB();
+    TestUtil.createTable(conn, "testinterval", "v interval");
+    TestUtil.createTable(conn, "testdate", "v date");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TestUtil.dropTable(conn, "testinterval");
+    TestUtil.dropTable(conn, "testdate");
+
+    TestUtil.closeDB(conn);
+
+    System.clearProperty("pgjdbc.param.format");
+    System.clearProperty("pgjdbc.field.format");
+  }
+
+  @Test
+  public void testOnlinePostgresStyle() throws SQLException {
+
+    try (Statement stmt = conn.createStatement()) {
+      assertFalse(stmt.execute("SET INTERVALSTYLE = 'postgres'"));
+
+      PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+      pstmt.setObject(1, Interval.of(Period.of(2004, 13, 28), Duration.ofSeconds(43000, 901_300_000)));
+      pstmt.executeUpdate();
+      pstmt.close();
+
+      try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+        assertTrue(rs.next());
+        Interval pgi = (Interval) rs.getObject(1);
+        assertEquals(2005, pgi.getPeriod().getYears());
+        assertEquals(1, pgi.getPeriod().getMonths());
+        assertEquals(28, pgi.getPeriod().getDays());
+        assertEquals(43000, pgi.getDuration().getSeconds());
+        assertEquals(901_300_000, pgi.getDuration().getNano());
+        assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+        assertFalse(rs.next());
+      }
+      try (ResultSet rs = stmt.executeQuery("SELECT v::text FROM testinterval")) {
+        assertTrue(rs.next());
+        assertEquals("2005 years 1 mon 28 days 11:56:40.9013", rs.getString(1));
+        assertFalse(rs.next());
+      }
+    }
+  }
+
+  @Test
+  public void testOnlinePostgresStyleText() throws SQLException {
+    System.setProperty("pgjdbc.param.format", "text");
+    System.setProperty("pgjdbc.field.format", "text");
+
+    Properties props = new Properties();
+    props.setProperty(JDBCSettings.REGISTRY_SHARING.getName(), "false");
+
+    try (Connection conn = TestUtil.openDB(props)) {
+      try (Statement stmt = conn.createStatement()) {
+        assertFalse(stmt.execute("SET INTERVALSTYLE = 'postgres'"));
+
+        PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+        pstmt.setObject(1, Interval.of(Period.of(2004, 13, 28), Duration.ofSeconds(43000, 901_300_000)));
+        pstmt.executeUpdate();
+        pstmt.close();
+
+        try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+          assertTrue(rs.next());
+          Interval pgi = (Interval) rs.getObject(1);
+          assertEquals(2005, pgi.getPeriod().getYears());
+          assertEquals(1, pgi.getPeriod().getMonths());
+          assertEquals(28, pgi.getPeriod().getDays());
+          assertEquals(43000, pgi.getDuration().getSeconds());
+          assertEquals(901_300_000, pgi.getDuration().getNano());
+          assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+          assertFalse(rs.next());
+        }
+        try (ResultSet rs = stmt.executeQuery("SELECT v::text FROM testinterval")) {
+          assertTrue(rs.next());
+          assertEquals("2005 years 1 mon 28 days 11:56:40.9013", rs.getString(1));
+          assertFalse(rs.next());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testOnlinePostgresVerboseStyle() throws SQLException {
+
+    try (Statement stmt = conn.createStatement()) {
+      assertFalse(stmt.execute("SET INTERVALSTYLE = 'postgres_verbose'"));
+
+      PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+      pstmt.setObject(1, Interval.of(Period.of(2004, 13, 28), Duration.ofSeconds(43000, 901_300_000)));
+      pstmt.executeUpdate();
+      pstmt.close();
+
+      try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+        assertTrue(rs.next());
+        Interval pgi = (Interval) rs.getObject(1);
+        assertEquals(2005, pgi.getPeriod().getYears());
+        assertEquals(1, pgi.getPeriod().getMonths());
+        assertEquals(28, pgi.getPeriod().getDays());
+        assertEquals(43000, pgi.getDuration().getSeconds());
+        assertEquals(901_300_000, pgi.getDuration().getNano());
+        assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+        assertFalse(rs.next());
+      }
+      try (ResultSet rs = stmt.executeQuery("SELECT v::text FROM testinterval")) {
+        assertTrue(rs.next());
+        assertEquals("@ 2005 years 1 mon 28 days 11 hours 56 mins 40.9013 secs", rs.getString(1));
+        assertFalse(rs.next());
+      }
+    }
+  }
+
+  @Test
+  public void testOnlinePostgresVerboseStyleText() throws SQLException {
+    System.setProperty("pgjdbc.param.format", "text");
+    System.setProperty("pgjdbc.field.format", "text");
+
+    Properties props = new Properties();
+    props.setProperty(JDBCSettings.REGISTRY_SHARING.getName(), "false");
+
+    try (Connection conn = TestUtil.openDB(props)) {
+      try (Statement stmt = conn.createStatement()) {
+        assertFalse(stmt.execute("SET INTERVALSTYLE = 'postgres_verbose'"));
+
+        PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+        pstmt.setObject(1, Interval.of(Period.of(2004, 13, 28), Duration.ofSeconds(43000, 901_300_000)));
+        pstmt.executeUpdate();
+        pstmt.close();
+
+        try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+          assertTrue(rs.next());
+          Interval pgi = (Interval) rs.getObject(1);
+          assertEquals(2005, pgi.getPeriod().getYears());
+          assertEquals(1, pgi.getPeriod().getMonths());
+          assertEquals(28, pgi.getPeriod().getDays());
+          assertEquals(43000, pgi.getDuration().getSeconds());
+          assertEquals(901_300_000, pgi.getDuration().getNano());
+          assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+          assertFalse(rs.next());
+        }
+        try (ResultSet rs = stmt.executeQuery("SELECT v::text FROM testinterval")) {
+          assertTrue(rs.next());
+          assertEquals("@ 2005 years 1 mon 28 days 11 hours 56 mins 40.9013 secs", rs.getString(1));
+          assertFalse(rs.next());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testOnlineISOStyle() throws SQLException {
+
+    try (Statement stmt = conn.createStatement()) {
+      assertFalse(stmt.execute("SET INTERVALSTYLE = 'iso_8601'"));
+
+      PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+      pstmt.setObject(1, Interval.of(Period.of(2004, 13, 28), Duration.ofSeconds(43000, 901_300_000)));
+      pstmt.executeUpdate();
+      pstmt.close();
+
+      try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+        assertTrue(rs.next());
+        Interval pgi = (Interval) rs.getObject(1);
+        assertEquals(2005, pgi.getPeriod().getYears());
+        assertEquals(1, pgi.getPeriod().getMonths());
+        assertEquals(28, pgi.getPeriod().getDays());
+        assertEquals(43000, pgi.getDuration().getSeconds());
+        assertEquals(901_300_000, pgi.getDuration().getNano());
+        assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+        assertFalse(rs.next());
+      }
+      try (ResultSet rs = stmt.executeQuery("SELECT v::text FROM testinterval")) {
+        assertTrue(rs.next());
+        assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+        assertFalse(rs.next());
+      }
+    }
+  }
+
+  @Test
+  public void testOnlineISOStyleText() throws SQLException {
+    System.setProperty("pgjdbc.param.format", "text");
+    System.setProperty("pgjdbc.field.format", "text");
+
+    Properties props = new Properties();
+    props.setProperty(JDBCSettings.REGISTRY_SHARING.getName(), "false");
+
+    try (Connection conn = TestUtil.openDB(props)) {
+      try (Statement stmt = conn.createStatement()) {
+        assertFalse(stmt.execute("SET INTERVALSTYLE = 'iso_8601'"));
+
+        PreparedStatement pstmt = conn.prepareStatement("INSERT INTO testinterval VALUES (?)");
+        pstmt.setObject(1, Interval.of(Period.of(2004, 13, 28), Duration.ofSeconds(43000, 901_300_000)));
+        pstmt.executeUpdate();
+        pstmt.close();
+
+        try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+          assertTrue(rs.next());
+          Interval pgi = (Interval) rs.getObject(1);
+          assertEquals(2005, pgi.getPeriod().getYears());
+          assertEquals(1, pgi.getPeriod().getMonths());
+          assertEquals(28, pgi.getPeriod().getDays());
+          assertEquals(43000, pgi.getDuration().getSeconds());
+          assertEquals(901_300_000, pgi.getDuration().getNano());
+          assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+          assertFalse(rs.next());
+        }
+        try (ResultSet rs = stmt.executeQuery("SELECT v::text FROM testinterval")) {
+          assertTrue(rs.next());
+          assertEquals("P2005Y1M28DT11H56M40.9013S", rs.getString(1));
+          assertFalse(rs.next());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testStringToIntervalCoercion() throws SQLException {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate(TestUtil.insertSQL("testdate", "'2010-01-01'"));
+    stmt.executeUpdate(TestUtil.insertSQL("testdate", "'2010-01-02'"));
+    stmt.executeUpdate(TestUtil.insertSQL("testdate", "'2010-01-04'"));
+    stmt.executeUpdate(TestUtil.insertSQL("testdate", "'2010-01-05'"));
+    stmt.close();
+
+    PreparedStatement pstmt =
+        conn.prepareStatement("SELECT v FROM testdate WHERE v < (?::timestamp with time zone + ? * ?::interval) ORDER BY v");
+    pstmt.setObject(1, makeDate(2010, 1, 1));
+    pstmt.setObject(2, Integer.valueOf(2));
+    pstmt.setObject(3, "P1D");
+    ResultSet rs = pstmt.executeQuery();
+
+    assertNotNull(rs);
+
+    java.sql.Date d;
+
+    assertTrue(rs.next());
+    d = rs.getDate(1);
+    assertNotNull(d);
+    assertEquals(makeDate(2010, 1, 1), d);
+
+    assertTrue(rs.next());
+    d = rs.getDate(1);
+    assertNotNull(d);
+    assertEquals(makeDate(2010, 1, 2), d);
+
+    assertFalse(rs.next());
+
+    rs.close();
+    pstmt.close();
+  }
+
+  @Test
+  public void testStringToIntervalCoercion2() throws SQLException {
+    try (PreparedStatement ps = conn.prepareStatement("INSERT INTO testinterval(v) VALUES(?::interval)")) {
+      ps.setString(1, "PT12345678.234567S");
+      ps.executeUpdate();
+    }
+    try (Statement stmt = conn.createStatement()) {
+      try (ResultSet rs = stmt.executeQuery("SELECT v FROM testinterval")) {
+        assertTrue(rs.next());
+        assertEquals(Interval.of(Duration.ofSeconds(12345678, 234_567_000)), rs.getObject(1));
+      }
+    }
+  }
+
+  @Test
+  public void testDaysHours() throws SQLException {
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT '101:12:00'::interval");
+    assertTrue(rs.next());
+    Interval i = (Interval) rs.getObject(1);
+    assertEquals(0, i.getPeriod().getDays());
+    assertEquals(101, i.getDuration().toHours());
+    assertEquals(12, i.getDuration().minusHours(i.getDuration().toHours()).toMinutes());
+  }
+
+  @SuppressWarnings("deprecation")
+  private java.sql.Date makeDate(int y, int m, int d) {
+    return new java.sql.Date(y - 1900, m - 1, d);
+  }
+
+}


### PR DESCRIPTION
## Interval class
The `Interval` type has been completely replaced with a verions based on Java 8’s `java.time` package.  The file is based on the fully featured `PeriodDuration` class from [three-ten](https://github.com/ThreeTen/threeten-extra).

## Server/Client parsing
Like Numeric & Date parsing/formatting the “server” parsing is matched to the server based on the `IntervalStyle` server setting.  The client parsing is independently set to ISO.  This means that all JDBC text input for intervals is in ISO 8601 format and doesn’t accept Postgres’s interval format.

To pass data to the server in Postgres format it can be done be passing it as text and casting it to an interval (or relying on implicit casting) on the server.