### PR TITLE
Use current_schema function to retrieve current schema

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -963,7 +963,7 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
   @Override
   public String getSchema() throws SQLException {
     checkClosed();
-    return executeForString("SHOW search_path");
+    return executeForString("SELECT current_schema()");
   }
 
   @Override

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
@@ -538,6 +538,8 @@ public class ConnectionTest {
 
     con = TestUtil.openDB();
 
+    assertEquals(con.getSchema(), "public");
+
     con.setSchema(null);
     con.setSchema("public");
 


### PR DESCRIPTION
This has the advantage of returning a single schema name regardless of if the path has multiple entries (like the default)