### PR TITLE
Allow executeQuery to operate normally on CallableStatement

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGCallableStatement.java
@@ -174,7 +174,7 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
     ReferenceCountUtil.release(outParameterData);
     outParameterData = null;
 
-    super.execute();
+    boolean res = super.execute();
 
     if (!outParameterSQLTypes.isEmpty()) {
 
@@ -199,6 +199,10 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
       }
 
     }
+    else if (!hasAnyParameterModes()) {
+      // treat as normal PreparedStatement execute
+      return res;
+    }
 
     if (!resultBatches.isEmpty()) {
       resultBatches.get(0).clearRowsAffected();
@@ -213,6 +217,13 @@ public class PGCallableStatement extends PGPreparedStatement implements Callable
 
     ReferenceCountUtil.release(outParameterData);
     outParameterData = null;
+  }
+
+  private boolean hasAnyParameterModes() {
+    for (ParameterMode mode : allParameterModes) {
+      if (mode != null) return true;
+    }
+    return false;
   }
 
   private int mapToInParameterIndex(int parameterIdx) {

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/CallableStatementTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/CallableStatementTest.java
@@ -191,6 +191,16 @@ public class CallableStatementTest {
     TestUtil.closeDB(con);
   }
 
+  @Test
+  public void testUseAsPreparedStatement() throws Exception {
+    try (CallableStatement stmt = con.prepareCall("SELECT current_schema()")) {
+      try (ResultSet rs = stmt.executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals(rs.getString(1), "public");
+      }
+    }
+  }
+
   final String func = "{ ? = call ";
   final String pkgName = "testspg__";
 


### PR DESCRIPTION
When calling `executeQuery` on a CallableStatement, if no parameters modes have been assigned, treat it as  a normal `PreparedStatement`.  This makes its operation more compatible with the mainline driver and some libraries expected usage.