### PR TITLE
Fix uber jar generation & publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The driver is built with Gradle. To build & test, execute:
 	./gradlew clean build.
 
 This will produce, in the `driver/build/libs` directory, two JAR files. One with dependencies
-packaged inside (`pgjdbg-nc-<VERSION>-all`) and another without (`pgjdbc-ng-VERSION`).
+packaged inside (`pgjdbg-nc-all-<VERSION>`) and another without (`pgjdbc-ng-VERSION`).
 
 *NOTE:* Building requires a working install of [Docker](https://docs.docker.com/docker) and 
 [Docker Compose](https://docs.docker.com/compose) as the unit tests are executed against a

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,13 +45,13 @@ val isSnapshot: Boolean by project
 tasks {
 
   val downloadTasks = listOf(
-     centralDownload("com.impossibl.pgjdbc-ng", "pgjdbc-ng", "all"),
+     centralDownload("com.impossibl.pgjdbc-ng", "pgjdbc-ng-all"),
      centralDownload("com.impossibl.pgjdbc-ng", "pgjdbc-ng", "javadoc"),
      centralDownload("com.impossibl.pgjdbc-ng", "pgjdbc-ng", "sources"),
      centralDownload("com.impossibl.pgjdbc-ng", "spy"),
      centralDownload("com.impossibl.pgjdbc-ng", "spy", "javadoc"),
      centralDownload("com.impossibl.pgjdbc-ng", "spy", "sources"),
-     centralDownload("com.impossibl.pgjdbc-ng.tools", "udt-gen", "all"),
+     centralDownload("com.impossibl.pgjdbc-ng.tools", "udt-gen-all"),
      centralDownload("com.impossibl.pgjdbc-ng.tools", "udt-gen", "javadoc"),
      centralDownload("com.impossibl.pgjdbc-ng.tools", "udt-gen", "sources")
   )

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -33,7 +33,7 @@ object Versions {
    * Plugin dependencies
    */
   const val kotlinPlugin = kotlin
-  const val shadowPlugin = "4.0.4"
+  const val shadowPlugin = "5.1.0"
   const val dockerComposePlugin = "0.8.13"
   const val asciiDoctorPlugin = "1.5.9.2"
   const val gitPublishPlugin = "2.0.0"

--- a/documentation/build.gradle.kts
+++ b/documentation/build.gradle.kts
@@ -99,7 +99,7 @@ tasks {
        "udtdepgroup" to udtPrj.group.toString(),
        "udtdepname" to udtPrj.name,
        "udtdepver" to udtPrj.version,
-       "uberclass" to "all",
+       "ubersuffix" to "all",
        "mavenrepo" to if (isSnapshot) "snapshots" else "releases",
        "maintainers" to loadMaintainers(docsDir),
        "source-highlighter" to "coderay",

--- a/documentation/src/docs/asciidoc/user-guide/index.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/index.adoc
@@ -6,8 +6,8 @@ include::../maintainers.txt[]
 :vendorname: PostgreSQL
 :toclevels: 3
 :sectnums:
-:driveruberjar: {driverdepname}-{driverdepver}-{uberclass}.jar
-:udtuberjar: {udtdepname}-{udtdepver}-{uberclass}.jar
+:driveruberjar: {driverdepname}-{ubersuffix}-{driverdepver}.jar
+:udtuberjar: {udtdepname}-{ubersuffix}-{udtdepver}.jar
 
 include::overview.adoc[]
 

--- a/documentation/src/docs/asciidoc/user-guide/overview.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/overview.adoc
@@ -70,7 +70,7 @@ If you are using a project that does not support Maven style dependencies or you
 an application server like Glassfish, <<appservers-wildfly>> or Tomcat you can download the dependency embedded
 version of the driver and copy it to the location required by your project or usage.
 
-{maven-central}?r={mavenrepo}&g={driverdepgroup}&a={driverdepname}&c={uberclass}&v={driverdepver}[Download JAR]
+{maven-central}?r={mavenrepo}&g={driverdepgroup}&a={driverdepname}-{ubersuffix}&v={driverdepver}[Download JAR]
 
 
 [[overview-getting-started-connect]]

--- a/driver/src/build/packaging.gradle.kts
+++ b/driver/src/build/packaging.gradle.kts
@@ -1,5 +1,5 @@
 
-apply{ from("$rootDir/shared/src/build/uber-packaging.gradle.kts") }
+apply{ from("src/build/uber-packaging.gradle.kts") }
 
 
 tasks.named<ProcessResources>("processTestResources") {

--- a/driver/src/build/uber-packaging.gradle.kts
+++ b/driver/src/build/uber-packaging.gradle.kts
@@ -16,14 +16,6 @@ apply { from("$rootDir/shared/src/build/uber-packaging.gradle.kts") }
  */
 
 tasks.named<ShadowJar>("uberJar") {
-  relocate("com.xenomachina", "com.impossibl.shadow.com.xenomachina")
-  relocate("com.squareup", "com.impossibl.shadow.com.squareup")
-  relocate("org.jetbrains.kotlin", "com.impossibl.shadow.org.jetbrains.kotlin")
+  relocate("io.netty", "com.impossibl.shadow.io.netty")
   minimize()
-  manifest {
-    from()
-    attributes(mapOf(
-       "Main-Class" to "com.impossibl.postgres.tools.UDTGenerator"
-    ))
-  }
 }

--- a/shared/src/build/uber-packaging.gradle.kts
+++ b/shared/src/build/uber-packaging.gradle.kts
@@ -22,9 +22,6 @@ tasks.register<ShadowJar>("uberJar") {
   manifest {
     from(jar.get().manifest)
   }
-  archiveClassifier.set("all")
   from(mainSourceSet.output)
   configurations = listOf(project.configurations["runtime"])
-  relocate( "io.netty", "com.impossibl.shadow.io.netty")
-  minimize()
 }


### PR DESCRIPTION
Reworks the generation of uber jars and publishes them under a new artifact ids `pgjdbc-ng-all` & `udt-gen-all` with **no** classifier. This artifact id change is required so that the published jar is independent of the standard jar and has its own published pom with no dependencies.

closes #446 