### PR TITLE
Fixes #455: use URLDecoder on database portion of URL when connecting

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
@@ -413,7 +413,7 @@ class ConnectionUtil {
 
       //Assign the database
 
-      spec.setDatabase(urlMatcher.group("database"));
+      spec.setDatabase(URLDecoder.decode(urlMatcher.group("database"), "UTF-8"));
 
       //Assign username/password (if available)
 


### PR DESCRIPTION
Per the regex, the database portion of the URL is required, so cannot be null.  It should be safe to pass database through URLDecoder as is done for username, password, and jdbc parameters.  This looks like an oversight from prior changes.