### PR TITLE
Fix params overwriting settings for getConnection

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/AbstractDataSource.java
@@ -96,6 +96,8 @@ public abstract class AbstractDataSource implements CommonDataSource {
    */
   protected PGDirectConnection createConnection(String username, String password) throws SQLException {
 
+    Settings settings = this.settings.duplicateKnowingAll();
+
     settings.set(CREDENTIALS_USERNAME, username);
     settings.set(CREDENTIALS_PASSWORD, password);
 


### PR DESCRIPTION
A copy of the current settings is made in the beginning of `createConnection` to ensure all modifications the the settings are local to that create connection call.

Test coverage added to verify bug & fix.

Closes #462 