### PR TITLE
Datasource Properties Update

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/ConnectionUtil.java
@@ -34,8 +34,11 @@ import com.impossibl.postgres.types.SharedRegistry;
 
 import static com.impossibl.postgres.jdbc.ErrorUtils.makeSQLException;
 import static com.impossibl.postgres.jdbc.JDBCSettings.HOUSEKEEPER;
+import static com.impossibl.postgres.jdbc.JDBCSettings.JDBC;
 import static com.impossibl.postgres.system.SystemSettings.DATABASE_NAME;
 import static com.impossibl.postgres.system.SystemSettings.DATABASE_URL;
+import static com.impossibl.postgres.system.SystemSettings.PROTO;
+import static com.impossibl.postgres.system.SystemSettings.SYS;
 import static com.impossibl.postgres.utils.guava.Strings.emptyToNull;
 import static com.impossibl.postgres.utils.guava.Strings.nullToEmpty;
 
@@ -224,7 +227,12 @@ class ConnectionUtil {
       }
 
       if (database != null) {
-        url += database;
+        try {
+          url += URLEncoder.encode(database, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+          url += database;
+        }
       }
 
       String unixPath = getUnixPath();
@@ -338,7 +346,7 @@ class ConnectionUtil {
    * @return Single group of settings
    */
   private static Settings buildSettings(ConnectionSpecifier connSpec, Properties connectInfo) {
-    Settings settings = new Settings();
+    Settings settings = new Settings(JDBC, SYS, PROTO);
 
     //Start by adding all parameters from the URL query string
     settings.setAll(connSpec.getParameters());
@@ -369,11 +377,11 @@ class ConnectionUtil {
 
   /**
    * Parses a URL connection string.
-   * 
+   *
    * Uses the URL_PATTERN to capture a hostname or ip address, port, database
    * name and a list of parameters specified as query name=value pairs. All
    * parts but the database name are optional.
-   * 
+   *
    * @param url
    *          Connection URL to parse
    * @return Connection specifier of parsed URL

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/DataSourceSettings.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/DataSourceSettings.java
@@ -70,6 +70,27 @@ public class DataSourceSettings {
   public static final Setting<Integer> PORT_NUMBER = Setting.declare();
 
   @Setting.Info(
+      desc = "Unix socket name for local server connections.",
+      name = "server.local-name",
+      group = "jdbc-ds",
+      alternateNames = {"localServerName"}
+  )
+  public static final Setting<String> LOCAL_SERVER_NAME = Setting.declare();
+
+  @Setting.Info(
+      desc = "Comma separated list of server addresses for which a connection will be attempted in order.\n\n" +
+          "Supports providing DNS, IPv4, IPv6 & Unix socket addresses. DNS & IP addresses are specified in " +
+          "`host[:port]?` format while Unix socket addresses must contain a `/` to valid. Additionally IPv6 host " +
+          "names must be enclosed in `[]`.\n\n" +
+          "NOTE: Specifying a list of addresses takes precedence over `server.name`, `port.number` & " +
+          "`server.local-name' and will cause those settings to be ignored.",
+      name = "server.addresses",
+      group = "jdbc-ds",
+      alternateNames = {"serverAddresses"}
+  )
+  public static final Setting<String> SERVER_ADDRESSES = Setting.declare();
+
+  @Setting.Info(
       desc = "Maximum time to wait for a connection to be established.",
       def = "0", min = 0,
       name = "login.timeout",

--- a/driver/src/main/java/com/impossibl/postgres/system/Setting.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/Setting.java
@@ -46,6 +46,7 @@ import java.util.regex.Pattern;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Completely defined setting that can be transformed to/from text, use alternate
@@ -271,6 +272,15 @@ public class Setting<T> {
      */
     public Map<String, Setting<?>> getAllNamedSettings() {
       return Collections.unmodifiableMap(allNamed);
+    }
+
+    /**
+     * Retrieves a unique set of all settings owned by the group.
+     *
+     * @return Set of all settings.
+     */
+    public Set<Setting<?>> getAllOwnedSettings() {
+      return Collections.unmodifiableSet(all).stream().filter(setting -> setting.group == this).collect(toSet());
     }
 
     /**

--- a/driver/src/main/java/com/impossibl/postgres/system/Settings.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/Settings.java
@@ -28,6 +28,7 @@
  */
 package com.impossibl.postgres.system;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -78,12 +79,23 @@ public class Settings {
     }
   }
 
+  /**
+   * Duplicates the bag of settings knowing settings from all groups
+   *
+   * @return Duplicate settings bag
+   */
   public Settings duplicateKnowingAll() {
     Settings copy = new Settings();
     copy.values = new HashMap<>(values);
     return copy;
   }
 
+  /**
+   * Duplicates the bag of settings knowing settings from the specified groups
+   *
+   * @param groups Groups which the new settings bag will consider known.
+   * @return Duplicate settings bag
+   */
   public Settings duplicateKnowing(Setting.Group... groups) {
     Settings copy = new Settings(groups);
     copy.values = new HashMap<>(values);
@@ -292,6 +304,17 @@ public class Settings {
    */
   public void unset(String name) {
     set(name, null);
+  }
+
+  /**
+   * Remove any stored value associated with any of the settings.
+   *
+   * @param settings Settings to remove
+   */
+  public void unsetAll(Collection<Setting<?>> settings) {
+    for (Setting<?> setting : settings) {
+      set(setting, null);
+    }
   }
 
   public Setting<?> mapUnknownSetting(Setting<?> setting) {


### PR DESCRIPTION
#### New Properties
The URL connection spec. had capabilities like unix socket & fallback addresses that the ds couldn’t provide. This change adds those missing capabilities to make it easier to setup programmatically via data.

* `server.local-name`
  Unix sock name to attempt connection to, if used with `server.name` the unix socket is tried first (as it is in URL connection).
* `server.addresses`
  A comma separated list of DNS, IPv4, IPv6 or Unix socket addresses (with optional port).

#### Other changes
* Database Name is escaped
  When generating the URL from properties the database name is now escaped properly.
* Connections from URL & Properties now will ignore and issue warnings if Datasource settings are specified.