### PR TITLE
Fix handling of unsigned system ids

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Int4s.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Int4s.java
@@ -40,9 +40,7 @@ import io.netty.buffer.ByteBuf;
 public class Int4s extends SimpleProcProvider {
 
   public Int4s() {
-    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(),
-        "int4", "xid", "cid", "regproc", "regtype", "regclass", "regoper", "regnamespace", "regrole"
-    );
+    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "int4");
   }
 
   private static Integer convertStringInput(Context context, String value) throws ConversionException {
@@ -50,7 +48,7 @@ public class Int4s extends SimpleProcProvider {
       return context.getClientIntegerFormatter().parse(value).intValue();
     }
     catch (ParseException e) {
-      throw new ConversionException("Invalid Long", e);
+      throw new ConversionException("Invalid Integer", e);
     }
   }
 

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Oids.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Oids.java
@@ -46,7 +46,7 @@ public class Oids extends SimpleProcProvider {
     super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(), "oid");
   }
 
-  static class BinDecoder extends Int4s.BinDecoder {
+  static class BinDecoder extends UInt4s.BinDecoder {
 
     @Override
     protected Object convertOutput(Context context, Integer decoded, Class<?> targetClass, Object targetContext) throws IOException {
@@ -74,7 +74,7 @@ public class Oids extends SimpleProcProvider {
 
   }
 
-  static class BinEncoder extends Int4s.BinEncoder {
+  static class BinEncoder extends UInt4s.BinEncoder {
 
     @Override
     protected Integer convertInput(Context context, Type type, Object source, Object sourceContext) throws ConversionException {
@@ -91,7 +91,7 @@ public class Oids extends SimpleProcProvider {
     }
   }
 
-  static class TxtDecoder extends Int4s.TxtDecoder {
+  static class TxtDecoder extends UInt4s.TxtDecoder {
 
     @Override
     protected Object convertOutput(Context context, Integer decoded, Class<?> targetClass, Object targetContext) throws IOException {
@@ -119,7 +119,7 @@ public class Oids extends SimpleProcProvider {
 
   }
 
-  static class TxtEncoder extends Int4s.TxtEncoder {
+  static class TxtEncoder extends UInt4s.TxtEncoder {
 
     @Override
     protected Integer convertInput(Context context, Type type, Object source, Object sourceContext) throws ConversionException {

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/Procs.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/Procs.java
@@ -43,7 +43,7 @@ import io.netty.buffer.ByteBuf;
 
 public class Procs {
 
-  private static final int MIN_PROC_PROVIDER_SERVICES = 45;
+  private static final int MIN_PROC_PROVIDER_SERVICES = 47;
 
   public static final Type.Codec.Decoder<CharSequence> DEFAULT_TEXT_DECODER = new Unknowns.TxtDecoder();
   public static final Type.Codec.Decoder<ByteBuf> DEFAULT_BINARY_DECODER = new Unknowns.BinDecoder();

--- a/driver/src/main/java/com/impossibl/postgres/system/procs/UInt4s.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/procs/UInt4s.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.system.procs;
+
+import com.impossibl.postgres.system.Context;
+import com.impossibl.postgres.system.ConversionException;
+import com.impossibl.postgres.types.Type;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.ParseException;
+
+import io.netty.buffer.ByteBuf;
+
+public class UInt4s extends SimpleProcProvider {
+
+  public UInt4s() {
+    super(new TxtEncoder(), new TxtDecoder(), new BinEncoder(), new BinDecoder(),
+        "xid", "cid", "regproc", "regtype", "regclass", "regoper", "regnamespace", "regrole"
+    );
+  }
+
+  static class BinDecoder extends AutoConvertingBinaryDecoder<Integer> {
+
+    BinDecoder() {
+      super(4, new DecodingConverter());
+    }
+
+    @Override
+    public Class<Integer> getDefaultClass() {
+      return Integer.class;
+    }
+
+    @Override
+    protected Integer decodeNativeValue(Context context, Type type, Short typeLength, Integer typeModifier, ByteBuf buffer, Class<?> targetClass, Object targetContext) throws IOException {
+      return buffer.readInt();
+    }
+
+  }
+
+  static class BinEncoder extends AutoConvertingBinaryEncoder<Integer> {
+
+    BinEncoder() {
+      super(4, new EncodingConverter());
+    }
+
+    @Override
+    public Class<Integer> getDefaultClass() {
+      return Integer.class;
+    }
+
+    @Override
+    protected void encodeNativeValue(Context context, Type type, Integer value, Object sourceContext, ByteBuf buffer) throws IOException {
+      buffer.writeInt(value);
+    }
+
+  }
+
+  static class TxtDecoder extends AutoConvertingTextDecoder<Integer> {
+
+    TxtDecoder() {
+      super(new DecodingConverter());
+    }
+
+    @Override
+    public Class<Integer> getDefaultClass() {
+      return Integer.class;
+    }
+
+    @Override
+    protected Integer decodeNativeValue(Context context, Type type, Short typeLength, Integer typeModifier, CharSequence buffer, Class<?> targetClass, Object targetContext) throws IOException, ParseException {
+      return Integer.parseUnsignedInt(buffer.toString());
+    }
+
+  }
+
+  static class TxtEncoder extends AutoConvertingTextEncoder<Integer> {
+
+    TxtEncoder() {
+      super(new EncodingConverter());
+    }
+
+    @Override
+    public Class<Integer> getDefaultClass() {
+      return Integer.class;
+    }
+
+    @Override
+    protected void encodeNativeValue(Context context, Type type, Integer value, Object sourceContext, StringBuilder buffer) throws IOException {
+      buffer.append(Integer.toUnsignedString(value));
+    }
+
+  }
+
+  static class EncodingConverter implements AutoConvertingEncoder.Converter<Integer> {
+
+    @Override
+    public Integer convert(Context context, Object source, Object sourceContext) throws ConversionException {
+
+      if (source instanceof String) {
+        try {
+          return Integer.parseUnsignedInt((String) source);
+        }
+        catch (NumberFormatException e) {
+          throw new ConversionException("Invalid unsigned integer", e);
+        }
+      }
+
+      if (source instanceof Boolean) {
+        boolean boolVal = (boolean) source;
+        return boolVal ? 1 : 0;
+      }
+
+      if (source instanceof Number) {
+        Number numberVal = (Number) source;
+        return (int) numberVal.longValue();
+      }
+
+      return null;
+    }
+
+  }
+
+  static class DecodingConverter implements AutoConvertingDecoder.Converter<Integer> {
+
+    @Override
+    public Object convert(Context context, Integer decoded, Class<?> targetClass, Object targetContext) throws ConversionException {
+
+      if (targetClass == String.class) {
+        return Integer.toUnsignedString(decoded);
+      }
+
+      if (targetClass == BigDecimal.class) {
+        long longVal = Integer.toUnsignedLong(decoded);
+        return BigDecimal.valueOf(longVal);
+      }
+
+      if (targetClass == BigInteger.class) {
+        long longVal = Integer.toUnsignedLong(decoded);
+        return BigInteger.valueOf(longVal);
+      }
+
+      if (targetClass == Boolean.class || targetClass == boolean.class) {
+        return decoded.byteValue() != 0 ? Boolean.TRUE : Boolean.FALSE;
+      }
+
+      if (targetClass == Byte.class || targetClass == byte.class) {
+        long longVal = Integer.toUnsignedLong(decoded);
+        if (longVal < Byte.MIN_VALUE || longVal > Byte.MAX_VALUE) {
+          throw new ArithmeticException("Value out of byte range");
+        }
+        return (byte) longVal;
+      }
+
+      if (targetClass == Short.class || targetClass == short.class) {
+        long longVal = Integer.toUnsignedLong(decoded);
+        if (longVal < Short.MIN_VALUE || longVal > Short.MAX_VALUE) {
+          throw new ArithmeticException("Value out of short range");
+        }
+        return (short) longVal;
+      }
+
+      if (targetClass == Integer.class || targetClass == int.class) {
+        long longVal = Integer.toUnsignedLong(decoded);
+        if (longVal < Integer.MIN_VALUE || longVal > Integer.MAX_VALUE) {
+          throw new ArithmeticException("Value out of int range");
+        }
+        return (int) longVal;
+      }
+
+      if (targetClass == Long.class || targetClass == long.class) {
+        return Integer.toUnsignedLong(decoded);
+      }
+
+      return null;
+    }
+
+  }
+
+}

--- a/driver/src/main/resources/META-INF/services/com.impossibl.postgres.system.procs.ProcProvider
+++ b/driver/src/main/resources/META-INF/services/com.impossibl.postgres.system.procs.ProcProvider
@@ -42,5 +42,6 @@ com.impossibl.postgres.system.procs.TimestampsWithoutTZ
 com.impossibl.postgres.system.procs.TimestampsWithTZ
 com.impossibl.postgres.system.procs.TimesWithoutTZ
 com.impossibl.postgres.system.procs.TimesWithTZ
+com.impossibl.postgres.system.procs.UInt4s
 com.impossibl.postgres.system.procs.UUIDs
 com.impossibl.postgres.system.procs.XMLs

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/SystemIdsTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/SystemIdsTest.java
@@ -1,0 +1,233 @@
+package com.impossibl.postgres.jdbc;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class SystemIdsTest {
+
+  private Connection conn;
+
+  @Before
+  public void before() throws Exception {
+    conn = TestUtil.openDB();
+  }
+
+  @After
+  public void after() throws SQLException {
+    TestUtil.closeDB(conn);
+  }
+
+  @Test
+  public void testOids() throws SQLException {
+
+    try (Statement statement = conn.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT '2222793757'::oid")) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+    try (PreparedStatement statement = conn.prepareStatement("SELECT '2222793757'::oid")) {
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+    try (PreparedStatement statement = conn.prepareStatement("SELECT ?::oid = '2222793757'::oid")) {
+      statement.setInt(1, Integer.parseUnsignedInt("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setLong(1, 2222793757L);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setBigDecimal(1, new BigDecimal("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setObject(1, new BigInteger("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setString(1, "2222793757");
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+    }
+    try (PreparedStatement statement = conn.prepareStatement("SELECT ?::oid")) {
+      statement.setInt(1, Integer.parseUnsignedInt("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+  }
+
+  @Test
+  public void testXids() throws SQLException {
+
+    try (Statement statement = conn.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT '2222793757'::xid")) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+    try (PreparedStatement statement = conn.prepareStatement("SELECT '2222793757'::xid")) {
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+    try (PreparedStatement statement = conn.prepareStatement("SELECT ?::xid = '2222793757'::xid")) {
+      statement.setInt(1, Integer.parseUnsignedInt("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setLong(1, 2222793757L);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setBigDecimal(1, new BigDecimal("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setObject(1, new BigInteger("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setString(1, "2222793757");
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+    }
+    try (PreparedStatement statement = conn.prepareStatement("SELECT ?::xid")) {
+      statement.setInt(1, Integer.parseUnsignedInt("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+  }
+
+  @Test
+  public void testCids() throws SQLException {
+
+    try (Statement statement = conn.createStatement()) {
+      try (ResultSet resultSet = statement.executeQuery("SELECT '2222793757'::cid")) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+    try (PreparedStatement statement = conn.prepareStatement("SELECT '2222793757'::cid")) {
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+    try (PreparedStatement statement = conn.prepareStatement("SELECT ?::cid = '2222793757'::cid")) {
+      statement.setInt(1, Integer.parseUnsignedInt("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setLong(1, 2222793757L);
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setBigDecimal(1, new BigDecimal("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setObject(1, new BigInteger("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+      statement.setString(1, "2222793757");
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertTrue(resultSet.getBoolean(1));
+      }
+    }
+    try (PreparedStatement statement = conn.prepareStatement("SELECT ?::cid")) {
+      statement.setInt(1, Integer.parseUnsignedInt("2222793757"));
+      try (ResultSet resultSet = statement.executeQuery()) {
+        assertTrue(resultSet.next());
+        assertEquals(-2072173539, resultSet.getInt(1));
+        assertEquals(2222793757L, resultSet.getLong(1));
+        assertEquals(BigDecimal.valueOf(2222793757L), resultSet.getBigDecimal(1));
+        assertEquals(BigInteger.valueOf(2222793757L), resultSet.getObject(1, BigInteger.class));
+        assertEquals("2222793757", resultSet.getString(1));
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Adds a new `UInt4s` procedure set that handles `xid`, `cid` & all `reg*` type olds.  Also, the standard `oid` type now uses it as a base.