### PR TITLE
Gradle 6 upgrade

### DIFF
--- a/build-cache.gradle.kts
+++ b/build-cache.gradle.kts
@@ -1,7 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 buildCache {
-  local<DirectoryBuildCache> {
+  local {
     directory = rootDir.resolve("$rootDir/.build-cache")
     removeUnusedEntriesAfterDays = 30
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 
-import com.github.breadmoirai.GithubReleaseTask
+import com.github.breadmoirai.githubreleaseplugin.GithubReleaseTask
 import de.undercouch.gradle.tasks.download.Download
 
 plugins {
@@ -63,7 +63,6 @@ tasks {
 
   named<GithubReleaseTask>("githubRelease") {
     dependsOn(downloadArtifacts)
-    setToken(project.properties["github.token"]?.toString() ?: "")
     setOwner("impossibl")
     setRepo("pgjdbc-ng")
     setTagName("v$version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ tasks {
 
   named<GithubReleaseTask>("githubRelease") {
     dependsOn(downloadArtifacts)
+    setAuthorization("token ${project.properties["github.token"]?.toString() ?: ""}")
     setOwner("impossibl")
     setRepo("pgjdbc-ng")
     setTagName("v$version")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,9 +1,8 @@
 
 plugins {
   id("java-library")
-  id("org.jetbrains.kotlin.jvm") version "1.3.11"
+  id("org.jetbrains.kotlin.jvm") version "1.3.30"
 }
-
 
 repositories {
   mavenLocal()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
   id("java-library")
-  id("org.jetbrains.kotlin.jvm") version "1.3.30"
+  id("org.jetbrains.kotlin.jvm") version "1.3.61"
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -39,6 +39,6 @@ object Versions {
   const val gitPublishPlugin = "2.0.0"
   const val aptIdeaPlugin = "0.20"
   const val testLoggerPlugin = "1.6.0"
-  const val githubReleasePlugin = "2.2.4"
+  const val githubReleasePlugin = "2.2.10"
 
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -36,7 +36,7 @@ object Versions {
   const val shadowPlugin = "5.1.0"
   const val dockerComposePlugin = "0.8.13"
   const val asciiDoctorPlugin = "1.5.9.2"
-  const val gitPublishPlugin = "2.0.0"
+  const val gitPublishPlugin = "2.1.3"
   const val aptIdeaPlugin = "0.20"
   const val testLoggerPlugin = "1.6.0"
   const val githubReleasePlugin = "2.2.10"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip

--- a/shared/src/build/compile-java.gradle.kts
+++ b/shared/src/build/compile-java.gradle.kts
@@ -1,10 +1,5 @@
 
-apply {
-  plugin("java")
-}
-
-
-withConvention(JavaPluginConvention::class) {
+configure<JavaPluginExtension> {
   sourceCompatibility = Versions.javaTarget
   targetCompatibility = Versions.javaTarget
 }


### PR DESCRIPTION
Hi from the openSUSE project Uyuni :wave:!

As (Linux) distros, we get to package all software we ship, in our case, in the RPM format. We have a need to have reproducible offline builds of our packages, and Gradle has a history of making our life a bit difficult in that respect.

Fortunately though, the very latest versions of Gradle now feature relocatable caches, meaning you can build a project from a machine with Internet access, zip its cache and then later repeat the build from a different host even if completely isolated from any network.

So here I am, proposing to upgrade Gradle to version 6 with this PR :sweat_smile: 

I admit I am a total newbie when it comes to Gradle and Kotlin, so things might have escaped my attention, but so far at least build and tests work from my machine. I'd appreciate if you could take the time to have a look and see if this is merge-able as it is or what needs to be done in order to be on the latest Gradle.

Thank you in advance!

