### PR TITLE
Fixes #465.   Corrections for quoted identifiers and embedded double quotes

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/SQLText.java
@@ -365,16 +365,22 @@ public class SQLText {
   }
 
   private static int consumeQuotedIdentifier(final String sql, final int start, final CompositeNode parent) throws ParseException {
-    int ndx = start + 1;
+    int ndx = start + 1, adjacentQuoteCount = 0;
     do {
       char c = sql.charAt(ndx);
       if (c == '"') {
-        if (sql.charAt(ndx - 1) == '"') {  // look-behind
+        ++adjacentQuoteCount;
+        if (sql.charAt(ndx - 1) == '"' && (adjacentQuoteCount % 2) == 0) {  // look-behind
           // skip escaped
         }
         else {
-          break;
+          if ((ndx == sql.length() - 1 || sql.charAt(ndx + 1) != '"')) {  // look-ahead
+            break;
+          }
         }
+      }
+      else {
+        adjacentQuoteCount = 0;
       }
 
       if (lookAhead(sql, ndx) == 0) {

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/PreparedStatementTest.java
@@ -350,7 +350,9 @@ public class PreparedStatementTest {
 
   @Test
   public void testDoubleQuotes() throws SQLException {
-    String[] testStrings = new String[] {"bare ? question mark", "single ' quote", "doubled '' single quote", "doubled \"\" double quote", "no backslash interpretation here: \\", };
+    String[] testStrings = new String[] {"bare ? question mark", "single ' quote", "doubled '' single quote", "doubled \"\" double quote", "no backslash interpretation here: \\",
+      "\"\"leading_double_quote", "trailing_double_quote\"\"", "\"\"surrounding_double_quotes\"\"", " \"\"surrounding_double_quotes_surrounding_space\"\" ", " \"\"surrounding_double_quotes_leading_space\"\"", "\"\"surrounding_double_quotes_trailing_space\"\" ",
+      "\"\"", "\"\"\"\""};
 
     for (int i = 0; i < testStrings.length; ++i) {
       PreparedStatement pstmt = conn.prepareStatement("CREATE TABLE \"" + testStrings[i] + "\" (i integer)");


### PR DESCRIPTION
(1) add a bunch of tests for double quote insanity: trailing, leading, and
    intermixed double quotes in identifiers.
(2) alter SQLText::consumeQuotedIdentifier() to understand not skipping
    quoted identifiers unless adjacent quotes encountered (ie. not processing
    an odd number in a row), and to do look-ahead for adjacent double quotes that
    do not terminate an identifier.