### PR TITLE
Fixes #482: the hostname verifier incorrectly throws SSLPeerUnverifie…

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnectionFactory.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnectionFactory.java
@@ -569,7 +569,15 @@ public class ServerConnectionFactory implements com.impossibl.postgres.protocol.
       // We have a wildcard
       if (hostname.endsWith(CN.substring(1))) {
         // Avoid IndexOutOfBoundsException because hostname already ends with CN
-        if (!(hostname.substring(0, hostname.length() - CN.length() + 1).contains("."))) {
+
+        /**
+         * NB: the hostname cannot contain a '.' per spec: https://www.postgresql.org/docs/current/libpq-ssl.html
+         *
+         *     "If the certificate's name attribute starts with an asterisk (*),
+         *      the asterisk will be treated as a wildcard, which will match all
+         *      characters except a dot (.)"
+         */
+        if (hostname.substring(0, hostname.length() - CN.length() + 1).contains(".")) {
           throw new SSLPeerUnverifiedException("The hostname " + hostname + " could not be verified");
         }
       }


### PR DESCRIPTION
…dException() if encountering a wildcard ssl certificate and a normal hostname.

  Example:
    CN in certificate: *.company.com
    Hostname:          mydatabase.company.com

Would throw, whereas "mydatabase.prod.company.com" would not.

The PG docs say that a "." character is not allowed, so this check was backwards.