### PR TITLE
Remove side effects from Connection.isValid

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutor.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/RequestExecutor.java
@@ -56,6 +56,16 @@ public interface RequestExecutor {
 
   }
 
+  /**
+   * Issues an isolated synchronization message. Useful to
+   * determine connection status without side effects.
+   *
+   * @param handler Simple handler to receive status.
+   * @throws IOException If an error occurs submitting the request.
+   */
+  void sync(SynchronizedHandler handler) throws IOException;
+
+
   /*****
    * Query requests. Directly execute unparsed SQL text.
    */

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/ServerConnection.java
@@ -196,6 +196,11 @@ class ServerConnection implements com.impossibl.postgres.protocol.ServerConnecti
   }
 
   @Override
+  public void sync(SynchronizedHandler handler) throws IOException {
+    submit(new SynchronizeRequest(handler));
+  }
+
+  @Override
   public void query(String sql, QueryHandler handler) throws IOException {
     if (sqlTrace != null) {
       sqlTrace.query(sql);

--- a/driver/src/main/java/com/impossibl/postgres/protocol/v30/SynchronizeRequest.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/v30/SynchronizeRequest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2013, impossibl.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of impossibl.com nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.impossibl.postgres.protocol.v30;
+
+import com.impossibl.postgres.protocol.RequestExecutor.SynchronizedHandler;
+import com.impossibl.postgres.protocol.TransactionStatus;
+import com.impossibl.postgres.protocol.v30.ProtocolHandler.ReadyForQuery;
+
+import java.io.IOException;
+
+import static java.util.Collections.emptyList;
+
+
+public class SynchronizeRequest implements ServerRequest {
+
+  private SynchronizedHandler handler;
+
+  SynchronizeRequest(SynchronizedHandler handler) {
+    this.handler = handler;
+  }
+
+  class SyncedHandler implements ReadyForQuery {
+
+    @Override
+    public String toString() {
+      return "Synchronize";
+    }
+
+    @Override
+    public Action readyForQuery(TransactionStatus txnStatus) throws IOException {
+      handler.handleReady(txnStatus);
+      return Action.Complete;
+    }
+
+    @Override
+    public void exception(Throwable cause) throws IOException {
+      handler.handleError(cause, emptyList());
+    }
+
+  }
+
+  @Override
+  public ProtocolHandler createHandler() {
+    return new SyncedHandler();
+  }
+
+  @Override
+  public void execute(ProtocolChannel channel) throws IOException {
+
+    channel
+        .writeSync()
+        .flush();
+
+  }
+
+}


### PR DESCRIPTION
Issues a lone synchronize message to check connection status and adds test to ensure transaction status is never altered by `Connection.isValid(int)`