### PR TITLE
Ensure procs can be found when installed in schemas

### DIFF
--- a/driver/src/build/testing.gradle.kts
+++ b/driver/src/build/testing.gradle.kts
@@ -105,6 +105,7 @@ if ((project.properties["noDocker"] ?: false) == false) {
 
     tasks.named("postgres${pgVersion}ComposeUp") {
       doLast {
+        execPSQL(pgVersion, serviceName, composeProjectName, "CREATE DATABASE testnoexts OWNER test;", "test")
         execPSQL(pgVersion, serviceName, composeProjectName, "CREATE EXTENSION hstore; CREATE EXTENSION citext;", "test")
 
         execPSQL(pgVersion, serviceName, composeProjectName, "CREATE DATABASE hostdb OWNER test;", "test")

--- a/driver/src/main/java/com/impossibl/postgres/types/SharedRegistry.java
+++ b/driver/src/main/java/com/impossibl/postgres/types/SharedRegistry.java
@@ -371,7 +371,10 @@ public class SharedRegistry {
    * @param decoderName proc-name of the decoder
    * @return A matching Codec instance
    */
-  Type.TextCodec loadTextCodec(String encoderName, String decoderName) {
+  Type.TextCodec loadTextCodec(String namespace, String encoderName, String decoderName) {
+    String nsPrefix = namespace + ".";
+    encoderName = encoderName.startsWith(nsPrefix) ? encoderName.substring(nsPrefix.length()) : encoderName;
+    decoderName = decoderName.startsWith(nsPrefix) ? decoderName.substring(nsPrefix.length()) : decoderName;
     return new Type.TextCodec(
         loadDecoderProc(decoderName, DEFAULT_TEXT_DECODER, CharSequence.class),
         loadEncoderProc(encoderName, DEFAULT_TEXT_ENCODER, StringBuilder.class)
@@ -385,7 +388,10 @@ public class SharedRegistry {
    * @param decoderName proc-name of the decoder
    * @return A matching Codec instance
    */
-  Type.BinaryCodec loadBinaryCodec(String encoderName, String decoderName) {
+  Type.BinaryCodec loadBinaryCodec(String namespace, String encoderName, String decoderName) {
+    String nsPrefix = namespace + ".";
+    encoderName = encoderName.startsWith(nsPrefix) ? encoderName.substring(nsPrefix.length()) : encoderName;
+    decoderName = decoderName.startsWith(nsPrefix) ? decoderName.substring(nsPrefix.length()) : decoderName;
     return new Type.BinaryCodec(
         loadDecoderProc(decoderName, DEFAULT_BINARY_DECODER, ByteBuf.class),
         loadEncoderProc(encoderName, DEFAULT_BINARY_ENCODER, ByteBuf.class)

--- a/driver/src/main/java/com/impossibl/postgres/types/Type.java
+++ b/driver/src/main/java/com/impossibl/postgres/types/Type.java
@@ -349,8 +349,8 @@ public abstract class Type implements TypeRef {
     delimeter = source.getDeliminator() != null ? source.getDeliminator().charAt(0) : null;
     arrayTypeId = source.getArrayTypeId();
     relationId = source.getRelationId();
-    textCodec = registry.getShared().loadTextCodec(source.getInputId(), source.getOutputId());
-    binaryCodec = registry.getShared().loadBinaryCodec(source.getReceiveId(), source.getSendId());
+    textCodec = registry.getShared().loadTextCodec(source.getNamespace(), source.getInputId(), source.getOutputId());
+    binaryCodec = registry.getShared().loadBinaryCodec(source.getNamespace(), source.getReceiveId(), source.getSendId());
     modifierParser = registry.getShared().loadModifierParser(source.getModInId());
     preferredParameterFormat = PARAM_FORMAT_PREF.getSystem();
     preferredResultFormat = FIELD_FORMAT_PREF.getSystem();

--- a/driver/src/test/resources/certdir/server/pg_hba.conf
+++ b/driver/src/test/resources/certdir/server/pg_hba.conf
@@ -79,3 +79,4 @@ hostssl   hostssldb     all         0.0.0.0/0             md5    clientcert=0
 hostssl   hostsslcertdb all         0.0.0.0/0             md5    clientcert=1
 hostssl   certdb        all         0.0.0.0/0             cert
 host      test          all         0.0.0.0/0             md5
+host      testnoexts    all         0.0.0.0/0             md5


### PR DESCRIPTION
When types are installed into a schema but queried from another schema the names are prefixed with their namespace. This fix ensures the procs can be found by name in this case.