### PR TITLE
Fix #479 reading nulls in Struct#getAttributes()

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGBuffersStruct.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGBuffersStruct.java
@@ -118,7 +118,13 @@ public abstract class PGBuffersStruct<Buffer> extends PGStruct {
     Object[] attributeValues = new Object[attributeBuffers.length];
 
     for (int attributeIdx = 0; attributeIdx < attributeValues.length; ++attributeIdx) {
-      attributeValues[attributeIdx] = getAttribute(context, attributeTypes[attributeIdx], attributeBuffers[attributeIdx]);
+      Buffer attributeBuffer = attributeBuffers[attributeIdx];
+      if (attributeBuffer == null) {
+        attributeValues[attributeIdx] = null;
+      }
+      else {
+        attributeValues[attributeIdx] = getAttribute(context, attributeTypes[attributeIdx], attributeBuffer);
+      }
     }
 
     return attributeValues;


### PR DESCRIPTION
Fixes a NullPointerException when a Struct contains a null field (#479).

Also adds test coverage for accessing composite (and anonymous) types via the Struct, which is where the original issue originated from.