### PR TITLE
Fix #523: Use the appropriate type map in Struct.getAttributes

### DIFF
--- a/documentation/src/docs/asciidoc/user-guide/jdbc.adoc
+++ b/documentation/src/docs/asciidoc/user-guide/jdbc.adoc
@@ -63,6 +63,10 @@ the standard `java.sql.Struct` API or via custom mapped Java classes that implem
 {drivername} fully supports UDTs via the JDBC `java.sql.Struct` API for specifying UDT parameters
 and for retrieving UDT values in from ``ResultSet``s.
 
+NOTE: Strong typing on the elements returned from `Struct.getAttributes()` will only be present if the
+query was run from a `PreparedStatement`. A regular `Statement` uses the text-based {vendorname} protocol,
+which will always return the values of the UDT represented as strings.
+
 ==== java.sql.SQLData
 
 Alternatively to using the standard Struct interface to access UDTs, custom Java classes can be created

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGBuffersStruct.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGBuffersStruct.java
@@ -29,6 +29,7 @@
 package com.impossibl.postgres.jdbc;
 
 import com.impossibl.postgres.system.Context;
+import com.impossibl.postgres.system.CustomTypes;
 import com.impossibl.postgres.types.CompositeType;
 import com.impossibl.postgres.types.Type;
 
@@ -84,7 +85,8 @@ public abstract class PGBuffersStruct<Buffer> extends PGStruct {
 
     @Override
     protected Object getAttribute(Context context, Type type, ByteBuf buffer) throws IOException {
-      return type.getBinaryCodec().getDecoder().decode(context, type, type.getLength(), null, buffer, null, null);
+      Class<?> targetClass = CustomTypes.lookupCustomType(type, context.getCustomTypeMap(), null);
+      return type.getBinaryCodec().getDecoder().decode(context, type, type.getLength(), null, buffer, targetClass, null);
     }
 
   }
@@ -97,7 +99,8 @@ public abstract class PGBuffersStruct<Buffer> extends PGStruct {
 
     @Override
     protected Object getAttribute(Context context, Type type, CharSequence buffer) throws IOException {
-      return type.getTextCodec().getDecoder().decode(context, type, type.getLength(), null, buffer, null, null);
+      Class<?> targetClass = CustomTypes.lookupCustomType(type, context.getCustomTypeMap(), null);
+      return type.getTextCodec().getDecoder().decode(context, type, type.getLength(), null, buffer, targetClass, null);
     }
 
   }


### PR DESCRIPTION
Any custom type map registered with the connection or `getAttributes` call is now used.

Also adds a short note to the documentation on the behaviour of the method when using `Statement`/`PreparedStatement`.