### PR TITLE
Fix ArrayIndexOutOfBounds for very large oids

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/protocol/TypeOid.java
+++ b/driver/src/main/java/com/impossibl/postgres/protocol/TypeOid.java
@@ -39,7 +39,7 @@ public class TypeOid implements TypeRef {
 
   public static TypeOid valueOf(int oid) {
     // Craziness is to reduce garbage creation for frequently used types
-    if (oid < fastCachedOids.length()) {
+    if (oid < fastCachedOids.length() && oid >= 0) {
       if (fastCachedOids.compareAndSet(oid, null, INVALID)) {
         // Was null, is now INVALID, set to correct value
         TypeOid toid = new TypeOid(oid);


### PR DESCRIPTION
ArrayIndexOutOfBounds when the oid for "enum" type in postgres is large enough to be negative when treated as a signed int

```
2021-02-01T04:14:17.932204324Z Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1846158966 out of bounds for length 4096
2021-02-01T04:14:17.932213915Z 	at java.base/java.lang.invoke.VarHandle$1.apply(Unknown Source)
2021-02-01T04:14:17.932343417Z 	at java.base/java.lang.invoke.VarHandle$1.apply(Unknown Source)
2021-02-01T04:14:17.932367979Z 	at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
2021-02-01T04:14:17.932376899Z 	at java.base/jdk.internal.util.Preconditions$1.apply(Unknown Source)
2021-02-01T04:14:17.932382713Z 	at java.base/jdk.internal.util.Preconditions.outOfBounds(Unknown Source)
2021-02-01T04:14:17.932388616Z 	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Unknown Source)
2021-02-01T04:14:17.932405831Z 	at java.base/jdk.internal.util.Preconditions.checkIndex(Unknown Source)
2021-02-01T04:14:17.932413144Z 	at java.base/java.lang.invoke.VarHandleObjects$Array.compareAndSet(Unknown Source)
2021-02-01T04:14:17.932419435Z 	at java.base/java.lang.invoke.VarHandleGuards.guard_LILL_Z(Unknown Source)
2021-02-01T04:14:17.932544638Z 	at java.base/java.util.concurrent.atomic.AtomicReferenceArray.compareAndSet(Unknown Source)
2021-02-01T04:14:17.932553735Z 	at com.impossibl.postgres.protocol.TypeOid.valueOf(TypeOid.java:43)
2021-02-01T04:14:17.932557924Z 	at com.impossibl.postgres.protocol.v30.MessageDispatchHandler.receiveParameterDescriptions(MessageDispatchHandler.java:496)
2021-02-01T04:14:17.932561965Z 	at com.impossibl.postgres.protocol.v30.MessageDispatchHandler.parseAndDispatch(MessageDispatchHandler.java:311)
2021-02-01T04:14:17.932565935Z 	at com.impossibl.postgres.protocol.v30.MessageDispatchHandler.dispatch(MessageDispatchHandler.java:192)
2021-02-01T04:14:17.932569943Z 	at com.impossibl.postgres.protocol.v30.MessageDispatchHandler.channelRead(MessageDispatchHandler.java:147)
```