### PR TITLE
Fix NPE on connect when current schema is null

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
+++ b/driver/src/main/java/com/impossibl/postgres/system/BasicContext.java
@@ -640,8 +640,9 @@ public class BasicContext extends AbstractContext {
   protected String queryString(String queryTxt, long timeout) throws IOException {
 
     try (ResultBatch resultBatch = queryBatch(queryTxt, timeout)) {
-      String val = resultBatch.borrowRows().borrow(0)
-          .getField(0, resultBatch.getFields()[0], this, String.class, null).toString();
+      Object field = resultBatch.borrowRows().borrow(0)
+          .getField(0, resultBatch.getFields()[0], this, String.class, null);
+      String val = field == null ? null : field.toString();
       return nullToEmpty(val);
     }
 

--- a/driver/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
+++ b/driver/src/test/java/com/impossibl/postgres/jdbc/ConnectionTest.java
@@ -572,6 +572,11 @@ public class ConnectionTest {
     con.setSchema("public");
 
     assertEquals(con.getSchema(), "public");
+
+    con.prepareStatement("set search_path to ''").execute();
+
+    assertEquals(con.getSchema(), "");
+
   }
 
   @Test


### PR DESCRIPTION
If your users "current schema" is null (because search_path is empty or you don't have access to the schemas listed) then there's an NPE when the PGDirectConnection attempts to load the current schema. This PR fixes that, and adds a test for it