### PR TITLE
Address hang during connection cleanup when DB bounces

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -129,6 +129,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -419,8 +420,9 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
    *
    */
   private void closeStatements() {
-    closeStatements(activeStatements);
+    Collection<WeakReference<PGStatement>> _activeStatements = new LinkedList<>(activeStatements);
     activeStatements.clear();
+    closeStatements(_activeStatements);
   }
 
   SQLText parseSQL(String sqlText) throws SQLException {


### PR DESCRIPTION
Fixes #539.

When cleaning up statements held by PGDirectConnection, take a snapshot of
the list to cleanup, clear the list, then issue cleanup.  Avoids potentially
recursing through cleanup endlessly, as well as ConcurrentModificationException.