### PR TITLE
Prevent doubly executing close logic in `Connection`, `Statement` & `ResultSet`

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGDirectConnection.java
@@ -125,6 +125,7 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Struct;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -419,8 +420,10 @@ public class PGDirectConnection extends BasicContext implements PGConnection {
    *
    */
   private void closeStatements() {
+    Collection<WeakReference<PGStatement>> activeStatements = this.activeStatements;
+    this.activeStatements = new ArrayList<>();
+
     closeStatements(activeStatements);
-    activeStatements.clear();
   }
 
   SQLText parseSQL(String sqlText) throws SQLException {

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -589,14 +589,17 @@ class PGResultSet implements ResultSet {
 
     //Release resources
 
-    if (scroller != null)
+    Scroller scroller = this.scroller;
+    this.scroller = null;
+    if (scroller != null) {
       scroller.close();
+    }
 
-    if (housekeeper != null)
+    if (housekeeper != null) {
       housekeeper.remove(cleanupKey);
+    }
 
     statement = null;
-    scroller = null;
   }
 
   @Override

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGStatement.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGStatement.java
@@ -48,6 +48,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -225,6 +226,9 @@ public abstract class PGStatement implements Statement {
    *
    */
   void closeResultSets() {
+    Collection<WeakReference<PGResultSet>> activeResultSets = this.activeResultSets;
+    this.activeResultSets = new ArrayList<>();
+
     closeResultSets(activeResultSets);
 
     generatedKeysResultSet = null;


### PR DESCRIPTION
Fixes #539, Replaces #540

Doubly executing the logic would sometimes cause an infinite loop; a reproducing test was added in `ConnectionTest`.

The test also validates that further attempts at closing all the failed and closed resources doesn’t throw any other external exceptions.