### PR TITLE
Fix Local support for Norwegian Bokmal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ allprojects {
   }
 
   group = "com.impossibl.pgjdbc-ng"
-  version = "0.8.9"
+  version = "0.8.9-bokmal"
 
   extra["isSnapshot"] = version.toString().endsWith("SNAPSHOT")
 

--- a/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
@@ -52,7 +52,7 @@ public class Locales {
     // Strip encoding/codepage
     localeValue = localeValue.split("\\.", 2)[0];
     if (localeValue.startsWith("Norwegian Bokm")) {
-      localeValue = "Norwegian Bokmal";
+      localeValue = "Norwegian_Norway";
     }
 
     switch (localeValue.toUpperCase(Locale.ROOT)) {

--- a/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
+++ b/driver/src/main/java/com/impossibl/postgres/utils/Locales.java
@@ -51,6 +51,9 @@ public class Locales {
   public static Locale parseLocale(String localeValue) {
     // Strip encoding/codepage
     localeValue = localeValue.split("\\.", 2)[0];
+    if (localeValue.startsWith("Norwegian Bokm")) {
+      localeValue = "Norwegian Bokmal";
+    }
 
     switch (localeValue.toUpperCase(Locale.ROOT)) {
       case "C":


### PR DESCRIPTION
Connection to a PostgreSQL database on Windows 7 or newer configured to use Norwegian Bokmal language always fails.
This is a quick-and-dirty solution I should use to make the driver to work.
I'm available to test the official fix when it will be available.