### PR TITLE
Add module descriptors inside multi-release jar (#464)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,13 @@ jobs:
     strategy:
       matrix:
         pg: [10, 11, 12, 13]
-        jdk: [8, 11]
+        jdk: [11, 16]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'zulu'
       - name: Setup PostgreSQL SSL Permissions
         run: |
           chmod 0400 ./driver/src/test/resources/certdir/server/server.key

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ subprojects {
     mavenCentral()
   }
 
+  extra["moduleDescriptor"] = false
 }
 
 val isSnapshot: Boolean by project

--- a/driver/src/build/checkstyle.gradle.kts
+++ b/driver/src/build/checkstyle.gradle.kts
@@ -15,3 +15,6 @@ configure<CheckstyleExtension> {
 
 tasks.named<Checkstyle>("checkstyleMain") { exclude("**/guava/**") }
 tasks.named<Checkstyle>("checkstyleTest") { exclude("**/jdbc/shared/**") }
+tasks.named<Checkstyle>("checkstyleJava11") {
+  onlyIf { false }
+}

--- a/driver/src/build/compile.gradle.kts
+++ b/driver/src/build/compile.gradle.kts
@@ -9,6 +9,12 @@ tasks.named<JavaCompile>("compileJava") {
   options.annotationProcessorGeneratedSourcesDirectory = file("$buildDir/generated/sources/annotationProcessor/java/main")
 }
 
+tasks.named<JavaCompile>("compileJava11Java") {
+  options.compilerArgs.add("-Adoc.dir=$buildDir/generated/docs-java11/")
+  options.isDeprecation = true
+  options.annotationProcessorGeneratedSourcesDirectory = file("$buildDir/generated/sources/annotationProcessor/java/java11")
+}
+
 tasks.named<JavaCompile>("compileTestJava") {
   options.compilerArgs.add("-parameters")
   options.isDeprecation = true

--- a/driver/src/main/java11/module-info.java
+++ b/driver/src/main/java11/module-info.java
@@ -1,0 +1,79 @@
+module com.impossibl.postgres {
+  requires transitive com.impossibl.jdbc.spy;
+
+  requires io.netty.buffer;
+  requires io.netty.codec;
+  requires io.netty.common;
+  requires io.netty.handler;
+  requires io.netty.transport;
+  requires static io.netty.transport.epoll;
+  requires static io.netty.transport.kqueue;
+  requires static io.netty.transport.unix.common;
+
+  requires static java.compiler;
+  requires transitive java.logging;
+  requires transitive java.naming;
+  requires java.security.sasl;
+  requires transitive java.sql;
+  requires transitive java.transaction.xa;
+  requires java.xml;
+
+  exports com.impossibl.postgres.api.data;
+  exports com.impossibl.postgres.api.jdbc;  
+  exports com.impossibl.postgres.jdbc;
+  exports com.impossibl.postgres.jdbc.xa;
+
+  uses com.impossibl.postgres.system.procs.ProcProvider;
+
+  provides com.impossibl.postgres.system.procs.ProcProvider with
+    com.impossibl.postgres.system.procs.ACLItems,
+    com.impossibl.postgres.system.procs.Arrays,
+    com.impossibl.postgres.system.procs.BitMods,
+    com.impossibl.postgres.system.procs.Bits,
+    com.impossibl.postgres.system.procs.Bools,
+    com.impossibl.postgres.system.procs.Boxes,
+    com.impossibl.postgres.system.procs.Bytes,
+    com.impossibl.postgres.system.procs.Cidrs,
+    com.impossibl.postgres.system.procs.Circles,
+    com.impossibl.postgres.system.procs.Dates,
+    com.impossibl.postgres.system.procs.Domains,
+    com.impossibl.postgres.system.procs.Float4s,
+    com.impossibl.postgres.system.procs.Float8s,
+    com.impossibl.postgres.system.procs.HStores,
+    com.impossibl.postgres.system.procs.Inets,
+    com.impossibl.postgres.system.procs.Int2s,
+    com.impossibl.postgres.system.procs.Int2Vectors,
+    com.impossibl.postgres.system.procs.Int4s,
+    com.impossibl.postgres.system.procs.Int8s,
+    com.impossibl.postgres.system.procs.Intervals,
+    com.impossibl.postgres.system.procs.Jsons,
+    com.impossibl.postgres.system.procs.Lines,
+    com.impossibl.postgres.system.procs.LSegs,
+    com.impossibl.postgres.system.procs.MacAddrs,
+    com.impossibl.postgres.system.procs.MacAddr8s,
+    com.impossibl.postgres.system.procs.Moneys,
+    com.impossibl.postgres.system.procs.Names,
+    com.impossibl.postgres.system.procs.NumericMods,
+    com.impossibl.postgres.system.procs.Numerics,
+    com.impossibl.postgres.system.procs.Oids,
+    com.impossibl.postgres.system.procs.OidVectors,
+    com.impossibl.postgres.system.procs.Paths,
+    com.impossibl.postgres.system.procs.Points,
+    com.impossibl.postgres.system.procs.Polygons,
+    com.impossibl.postgres.system.procs.Ranges,
+    com.impossibl.postgres.system.procs.Records,
+    com.impossibl.postgres.system.procs.RefCursors,
+    com.impossibl.postgres.system.procs.Strings,
+    com.impossibl.postgres.system.procs.Tids,
+    com.impossibl.postgres.system.procs.TimeMods,
+    com.impossibl.postgres.system.procs.TimestampMods,
+    com.impossibl.postgres.system.procs.TimestampsWithoutTZ,
+    com.impossibl.postgres.system.procs.TimestampsWithTZ,
+    com.impossibl.postgres.system.procs.TimesWithoutTZ,
+    com.impossibl.postgres.system.procs.TimesWithTZ,
+    com.impossibl.postgres.system.procs.UInt4s,
+    com.impossibl.postgres.system.procs.UUIDs,
+    com.impossibl.postgres.system.procs.XMLs;
+  provides java.sql.Driver with
+    com.impossibl.postgres.jdbc.PGDriver;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.org.gradle.java.compile-classpath-packaging=true

--- a/shared/src/build/compile-java.gradle.kts
+++ b/shared/src/build/compile-java.gradle.kts
@@ -6,10 +6,16 @@ configure<JavaPluginExtension> {
   }
 }
 
-val javaToolchains = extensions.getByName("javaToolchains") as JavaToolchainService
+tasks.named<JavaCompile>("compileJava") {
+  val targetVersion: Int = Integer.parseInt(Versions.javaTarget.majorVersion)
+  options.release.set(targetVersion)
+}
 
-tasks.withType<JavaCompile>().configureEach {
-  javaCompiler.set(javaToolchains.compilerFor {
-    languageVersion.set(JavaLanguageVersion.of(Versions.javaTarget.majorVersion))
-  })
+if (project.extra["moduleDescriptor"] as Boolean) {
+  tasks.named<JavaCompile>("compileJava11Java") {
+    options.release.set(11)
+    options.javaModuleVersion.set(project.version as String)
+  }
+
+  configurations["java11CompileClasspath"].extendsFrom(configurations["compileClasspath"])
 }

--- a/shared/src/build/packaging.gradle.kts
+++ b/shared/src/build/packaging.gradle.kts
@@ -25,6 +25,15 @@ val jar = tasks.named<Jar>("jar") {
        "Created-By" to "${System.getProperty("java.version")} (${System.getProperty("java.vendor")})"
     )
   }
+  if (project.extra["moduleDescriptor"] as Boolean) {
+    manifest {
+      attributes("Multi-Release" to "true")
+    }
+    into("META-INF/versions/11") {
+      from(project.the<SourceSetContainer>()["java11"].output)
+      include("module-info.class")
+    }
+  }
 }
 
 

--- a/spy/build.gradle.kts
+++ b/spy/build.gradle.kts
@@ -13,11 +13,18 @@ dependencies {
 }
 
 val genDir = file("$buildDir/generated")
+val gen11Dir = file("$buildDir/generated-java11")
 
 sourceSets {
   main {
     java.srcDirs(genDir)
+    java.include("com/impossibl/**")
   }
+}
+sourceSets.create("java11") {
+  java.srcDir("src/main/java")
+  java.srcDir(genDir)
+  java.srcDir("src/main/java11")
 }
 
 tasks {
@@ -32,9 +39,23 @@ tasks {
       SpyGen().generateTo(genDir)
     }
   }
+  val gen11Task = register("generator11") {
+    outputs.dir(gen11Dir)
+
+    doLast {
+      gen11Dir.mkdirs()
+      SpyGen().generateTo(gen11Dir)
+    }
+  }
 
   compileJava {
     dependsOn(genTask)
+    options.isDeprecation = true
+  }
+
+  val compileJavaTask = named("compileJava")
+  named<JavaCompile>("compileJava11Java") {
+    dependsOn(compileJavaTask)
     options.isDeprecation = true
   }
 
@@ -43,6 +64,8 @@ tasks {
   }
 
 }
+
+project.extra["moduleDescriptor"] = true
 
 apply {
   from("$rootDir/shared/src/build/compile-java.gradle.kts")

--- a/spy/src/main/java11/module-info.java
+++ b/spy/src/main/java11/module-info.java
@@ -1,0 +1,4 @@
+module com.impossibl.jdbc.spy {
+  requires transitive java.sql;
+  exports com.impossibl.jdbc.spy;
+}


### PR DESCRIPTION
Fixes #464 . Per my comment on that issue, I've proceeded with my assumption that the driver's public API consists of the `api` and `jdbc` packages and sub-packages. If that's not the case, let me know and I will modify the module metadata accordingly.

As this PR raises the build-time JDK requirement to Java 11, I've added the `--release` flag to ensure compatibility. The release flag is like Animal-Sniffer, but better. It prevents you from calling Java 11 methods allowing you to remain Java 8-compatible – it even handles covariant return types.

Because of the JDK 11 build-time requirement, I've updated the Github workflow as well.