### PR TITLE
add where property to PGSQLExceptionInfo

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGSQLExceptionInfo.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGSQLExceptionInfo.java
@@ -31,9 +31,9 @@ package com.impossibl.postgres.api.jdbc;
 /**
  * Driver specific interface for exceptions that carry extended error
  * information reported by the server.
- * 
+ *
  * @author kdubb
- * 
+ *
  */
 public interface PGSQLExceptionInfo {
 
@@ -61,4 +61,7 @@ public interface PGSQLExceptionInfo {
 
   void setDetail(String details);
 
+  String getWhere();
+
+  void setWhere(String where);
 }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/ErrorUtils.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/ErrorUtils.java
@@ -205,6 +205,7 @@ public class ErrorUtils {
     e.setDatatype(notice.getDatatype());
     e.setConstraint(notice.getConstraint());
     e.setDetail(notice.getDetail());
+    e.setWhere(notice.getWhere());
 
     return (SQLException) e;
   }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGSQLIntegrityConstraintViolationException.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGSQLIntegrityConstraintViolationException.java
@@ -42,6 +42,7 @@ public class PGSQLIntegrityConstraintViolationException extends SQLIntegrityCons
   private String datatype;
   private String constraint;
   private String detail;
+  private String where;
 
   public PGSQLIntegrityConstraintViolationException() {
     super();
@@ -135,4 +136,13 @@ public class PGSQLIntegrityConstraintViolationException extends SQLIntegrityCons
     this.detail = details;
   }
 
+  @Override
+  public String getWhere() {
+    return where;
+  }
+
+  @Override
+  public void setWhere(String where) {
+    this.where = where;
+  }
 }

--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGSQLSimpleException.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGSQLSimpleException.java
@@ -44,6 +44,7 @@ public class PGSQLSimpleException extends SQLException implements PGSQLException
   private String datatype;
   private String constraint;
   private String detail;
+  private String where;
 
   public PGSQLSimpleException() {
     super();
@@ -137,4 +138,13 @@ public class PGSQLSimpleException extends SQLException implements PGSQLException
     this.detail = details;
   }
 
+  @Override
+  public String getWhere() {
+    return where;
+  }
+
+  @Override
+  public void setWhere(String where) {
+    this.where = where;
+  }
 }


### PR DESCRIPTION
This pull request adds "where" info to the PGSQLExceptionInfo class. This is useful for logging backtrace of a database error.