### PR TITLE
Suggested fix for #551

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGType.java
+++ b/driver/src/main/java/com/impossibl/postgres/api/jdbc/PGType.java
@@ -67,6 +67,7 @@ public enum PGType implements PGAnyType {
   CHAR                    (  18,  "char",         String.class,         JDBCType.CHAR),
   NAME                    (  19,  "name",         String.class,         JDBCType.VARCHAR),
   TEXT                    (  25,  "text",         String.class,         JDBCType.VARCHAR),
+  TEXT_ARRAY              (1009,  "text[]",       String[].class,       JDBCType.OTHER),
   BPCHAR                  (1042,  "bpchar",       String.class,         JDBCType.VARCHAR),
   VARCHAR                 (1043,  "varchar",      String.class,         JDBCType.VARCHAR),
   CSTRING                 (2275,  "cstring",      String.class,         JDBCType.VARCHAR),

--- a/udt-gen/src/main/kotlin/UDTGenerator.kt
+++ b/udt-gen/src/main/kotlin/UDTGenerator.kt
@@ -354,7 +354,10 @@ class UDTGenerator(
       writeSQLBldr.addCode(
          when {
            attrTypeName is ArrayTypeName ->
-             CodeBlock.of("out.writeObject(this.\$L, \$T.\$L);\n", attrPropName, JDBCType::class.java, "ARRAY")
+             if (attrSqlType.name == "_text")
+               CodeBlock.of("out.writeObject(this.\$L, \$T.\$L);\n", attrPropName, PGType::class.java, "TEXT_ARRAY")
+             else
+               CodeBlock.of("out.writeObject(this.\$L, \$T.\$L);\n", attrPropName, JDBCType::class.java, "ARRAY")
 
            typesInfo[attr.typeName] == TypeCategory.Composite ->
              CodeBlock.of("out.writeObject(this.\$L, \$T.\$L);\n", attrPropName, attrTypeName, "TYPE")


### PR DESCRIPTION
This is a suggested fix for #551. I created a new type to handle the text array, and modified the generator to use this new type when the DB has a TEXT[] in the UDT. 

Please let me know what you think of this change, and test it thoroughly. I tested it on my dev system, but it would be good to make sure that this change does not have wider impacts. My dev work was done in Windows, which this repo's build script does not support. I had to test on an internal fork with a build script that does work in windows, then copy the changes over into this branch. Please run tests and ensure everything works as expected, and verify that this indeed does fix the issue for you as well. I tested with my test repo for this issue: https://github.com/tlf30/pgjdbc-ng-test5. 

It may be beneficial to add the datatypes for other arrays as well, as this issue may arise with more than just the TEXT datatype. 

If this change is not to your liking, please close this PR.