### PR TITLE
Fixes issue #562, multiple calls to PGBuffersArray.free() produces NullPointerException

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGBuffersArray.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGBuffersArray.java
@@ -291,8 +291,10 @@ public class PGBuffersArray extends PGArray {
 
   @Override
   public void free() {
-    for (ByteBuf elementBuf : elementBuffers) {
-      ReferenceCountUtil.release(elementBuf);
+    if (elementBuffers != null) {
+      for (ByteBuf elementBuf : elementBuffers) {
+        ReferenceCountUtil.release(elementBuf);
+      }
     }
     this.context = null;
     this.type = null;


### PR DESCRIPTION
API doc for java.sql.Array says that when multiple calls are made to free(), successive calls should be a no-op. This change makes the PGBuffersArray class adhere to that spec. 