### PR TITLE
Add missing quotes around column names

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/PGResultSet.java
@@ -2444,7 +2444,7 @@ class CursorScroller extends Scroller {
     sb.append(" SET ");
 
     for (int pid = 0; pid < resultFields.length; ++pid) {
-      sb.append(resultFields[pid].getName());
+      sb.append('"').append(resultFields[pid].getName()).append('"');
       sb.append(" = $");
       sb.append(pid + 1);
       if (pid < resultFields.length - 1) {


### PR DESCRIPTION
This portion of the code is executed when PGResultSet.updateRow() is called. The omission of double-quotes around the column names seems to be a typo.