### PR TITLE
fix for NPE in JDBCTypeMetaData

### DIFF
--- a/driver/src/main/java/com/impossibl/postgres/jdbc/JDBCTypeMetaData.java
+++ b/driver/src/main/java/com/impossibl/postgres/jdbc/JDBCTypeMetaData.java
@@ -109,8 +109,11 @@ class JDBCTypeMetaData {
   }
 
   static int getPrecisionRadix(Type type) {
-
-    switch (type.unwrap().getCategory()) {
+   Type.Category c = type.unwrap().getCategory();
+   if (c==null) {
+            return 0;
+   }
+   switch (c) {
       case Numeric:
         return 10;
 


### PR DESCRIPTION
Hi, 
got this NPE after [H2](https://github.com/h2database/h2database) upgrade to 2.2.222 (latest) version:
![pgjdbc-ng-bug](https://github.com/impossibl/pgjdbc-ng/assets/3603492/0b7b78b4-90e8-4b1c-9eb5-9a377b9f4015)

This was taken from "H2 Console" subproject, which I use in combination with your driver.  So I observed driver sources and found a place that looks like very simple bug. For sure, there must be more complicated reason for such NPE, but  function 'getMaxPrecision()' below has the same check as in PR:
`
type = type.unwrap();
    PGType pgType = PGType.valueOf(type);
    if (pgType == null) {
      return 0;
    }
`
So hope this is just small and annoying bug, nothing more.
After patch:
![pgjdbc-ng-patched](https://github.com/impossibl/pgjdbc-ng/assets/3603492/6a5cd160-0c60-4643-9321-9d3dcbc15aaa)
 